### PR TITLE
ci: 브랜치별 머지 전략 안내 워크플로우 추가

### DIFF
--- a/.github/workflows/merge-strategy-guide.yml
+++ b/.github/workflows/merge-strategy-guide.yml
@@ -1,0 +1,35 @@
+name: Merge Strategy Guide
+
+on:
+  pull_request:
+    types: [opened]
+    branches: [dev, main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guide merge strategy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const base = context.payload.pull_request.base.ref;
+            let message;
+
+            if (base === 'dev') {
+              message = '> **Merge Strategy**: 이 PR은 `dev` 브랜치 대상입니다. **Squash and merge**를 사용해주세요.';
+            } else if (base === 'main') {
+              message = '> **Merge Strategy**: 이 PR은 `main` 브랜치 대상입니다. **Create a merge commit**을 사용해주세요.';
+            }
+
+            if (message) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: message
+              });
+            }


### PR DESCRIPTION
## Summary
- PR이 `dev` 또는 `main` 브랜치에 열릴 때 올바른 머지 방법을 코멘트로 안내하는 워크플로우 추가
- `dev` 대상 PR: **Squash and merge** 안내
- `main` 대상 PR: **Create a merge commit** 안내
- 리포지토리 설정에서 rebase merge 비활성화 (`allow_rebase_merge=false`)

## Test plan
- [ ] `dev` 대상 PR 생성 시 "Squash and merge를 사용해주세요" 코멘트 확인
- [ ] `main` 대상 PR 생성 시 "Create a merge commit을 사용해주세요" 코멘트 확인
- [ ] GitHub PR 머지 UI에서 rebase 옵션이 사라졌는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)