### PR TITLE
feat: 프로필 조회 API 추가 및 게시글 조회 사용자 필터링

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,28 +1,57 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
-import { CommandBus } from '@nestjs/cqrs';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import {
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { JwtAuthGuard } from '@src/auth/guard/jwt-auth.guard';
+import { CurrentUser } from '@src/common/decorator/current-user.decorator';
+import { AuthUser } from '@src/common/decorator/auth-user.type';
 import { RegisterCommand } from '@src/auth/command/register.command';
 import { LoginCommand } from '@src/auth/command/login.command';
 import { RefreshTokenCommand } from '@src/auth/command/refresh-token.command';
+import { GetProfileQuery } from '@src/auth/query/get-profile.query';
 import { RegisterRequestDto } from '@src/auth/dto/request/register.request.dto';
 import { LoginRequestDto } from '@src/auth/dto/request/login.request.dto';
 import { RefreshTokenRequestDto } from '@src/auth/dto/request/refresh-token.request.dto';
 import { RegisterResponseDto } from '@src/auth/dto/response/register.response.dto';
 import { AuthTokensResponseDto } from '@src/auth/dto/response/auth-tokens.response.dto';
+import { ProfileResponseDto } from '@src/auth/dto/response/profile.response.dto';
 import { AuthTokens } from '@src/auth/auth.types';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly commandBus: CommandBus) {}
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) {}
+
+  @Get('profile')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '내 프로필 조회' })
+  @ApiOkResponse({ type: ProfileResponseDto })
+  @ApiUnauthorizedResponse({ description: '인증되지 않은 요청' })
+  @ApiNotFoundResponse({ description: '사용자를 찾을 수 없음' })
+  async getProfile(@CurrentUser() user: AuthUser): Promise<ProfileResponseDto> {
+    return this.queryBus.execute(new GetProfileQuery(user.id));
+  }
 
   @Post('register')
   @ApiOperation({ summary: '회원가입' })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,14 +9,17 @@ import { RefreshTokenHandler } from '@src/auth/command/refresh-token.handler';
 import { userRepositoryProviders } from '@src/auth/user-repository.provider';
 import { JwtStrategy } from '@src/auth/strategy/jwt.strategy';
 import { JwtAuthGuard } from '@src/auth/guard/jwt-auth.guard';
+import { GetProfileHandler } from '@src/auth/query/get-profile.handler';
 
 const commandHandlers = [RegisterHandler, LoginHandler, RefreshTokenHandler];
+const queryHandlers = [GetProfileHandler];
 
 @Module({
   imports: [CqrsModule, PassportModule, JwtModule.register({})],
   controllers: [AuthController],
   providers: [
     ...commandHandlers,
+    ...queryHandlers,
     ...userRepositoryProviders,
     JwtStrategy,
     JwtAuthGuard,

--- a/src/auth/dto/response/profile.response.dto.spec.ts
+++ b/src/auth/dto/response/profile.response.dto.spec.ts
@@ -1,0 +1,57 @@
+import { ProfileResponseDto } from '@src/auth/dto/response/profile.response.dto';
+import { User } from '@src/auth/entities/user.entity';
+
+describe('ProfileResponseDto', () => {
+  const now = new Date();
+
+  const createUser = (overrides: Partial<User> = {}): User => {
+    const user = new User();
+    user.id = 1;
+    user.email = 'test@example.com';
+    user.password = 'hashed-password';
+    user.name = '테스트유저';
+    user.hashedRefreshToken = 'hashed-token';
+    user.createdAt = now;
+    user.updatedAt = now;
+    Object.assign(user, overrides);
+    return user;
+  };
+
+  describe('of', () => {
+    it('User 엔티티의 공개 필드를 DTO로 매핑한다', () => {
+      const user = createUser();
+
+      const dto = ProfileResponseDto.of(user);
+
+      expect(dto.id).toBe(user.id);
+      expect(dto.email).toBe(user.email);
+      expect(dto.name).toBe(user.name);
+      expect(dto.createdAt).toBe(user.createdAt);
+      expect(dto.updatedAt).toBe(user.updatedAt);
+    });
+
+    it('ProfileResponseDto 인스턴스를 반환한다', () => {
+      const user = createUser();
+
+      const dto = ProfileResponseDto.of(user);
+
+      expect(dto).toBeInstanceOf(ProfileResponseDto);
+    });
+
+    it('password를 포함하지 않는다', () => {
+      const user = createUser();
+
+      const dto = ProfileResponseDto.of(user);
+
+      expect(dto).not.toHaveProperty('password');
+    });
+
+    it('hashedRefreshToken을 포함하지 않는다', () => {
+      const user = createUser();
+
+      const dto = ProfileResponseDto.of(user);
+
+      expect(dto).not.toHaveProperty('hashedRefreshToken');
+    });
+  });
+});

--- a/src/auth/dto/response/profile.response.dto.ts
+++ b/src/auth/dto/response/profile.response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@src/auth/entities/user.entity';
+
+export class ProfileResponseDto {
+  @ApiProperty({ description: '사용자 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '이메일', example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ description: '이름', example: '홍길동' })
+  name: string;
+
+  @ApiProperty({ description: '생성일시' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '수정일시' })
+  updatedAt: Date;
+
+  static of(user: User): ProfileResponseDto {
+    const dto = new ProfileResponseDto();
+    dto.id = user.id;
+    dto.email = user.email;
+    dto.name = user.name;
+    dto.createdAt = user.createdAt;
+    dto.updatedAt = user.updatedAt;
+    return dto;
+  }
+}

--- a/src/auth/query/get-profile.handler.spec.ts
+++ b/src/auth/query/get-profile.handler.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { GetProfileHandler } from '@src/auth/query/get-profile.handler';
+import { GetProfileQuery } from '@src/auth/query/get-profile.query';
+import { IUserReadRepository } from '@src/auth/interface/user-read-repository.interface';
+import { User } from '@src/auth/entities/user.entity';
+import { ProfileResponseDto } from '@src/auth/dto/response/profile.response.dto';
+
+describe('GetProfileHandler', () => {
+  let handler: GetProfileHandler;
+  let mockReadRepository: jest.Mocked<IUserReadRepository>;
+
+  const now = new Date();
+  const mockUser: User = {
+    id: 1,
+    email: 'test@example.com',
+    password: 'hashed-password',
+    name: '테스트유저',
+    hashedRefreshToken: 'hashed-token',
+    createdAt: now,
+    updatedAt: now,
+  } as User;
+
+  beforeEach(async () => {
+    mockReadRepository = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetProfileHandler,
+        { provide: IUserReadRepository, useValue: mockReadRepository },
+      ],
+    }).compile();
+
+    handler = module.get(GetProfileHandler);
+  });
+
+  it('존재하는 사용자의 프로필을 조회하면 ProfileResponseDto를 반환한다', async () => {
+    mockReadRepository.findById.mockResolvedValue(mockUser);
+
+    const query = new GetProfileQuery(1);
+    const result = await handler.execute(query);
+
+    expect(result).toBeInstanceOf(ProfileResponseDto);
+    expect(result.id).toBe(1);
+    expect(result.email).toBe('test@example.com');
+    expect(result.name).toBe('테스트유저');
+  });
+
+  it('존재하지 않는 사용자를 조회하면 NotFoundException을 발생시킨다', async () => {
+    mockReadRepository.findById.mockResolvedValue(null);
+
+    const query = new GetProfileQuery(999);
+
+    await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+  });
+});

--- a/src/auth/query/get-profile.handler.ts
+++ b/src/auth/query/get-profile.handler.ts
@@ -1,0 +1,19 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { NotFoundException } from '@nestjs/common';
+import { GetProfileQuery } from '@src/auth/query/get-profile.query';
+import { IUserReadRepository } from '@src/auth/interface/user-read-repository.interface';
+import { ProfileResponseDto } from '@src/auth/dto/response/profile.response.dto';
+
+@QueryHandler(GetProfileQuery)
+export class GetProfileHandler implements IQueryHandler<GetProfileQuery> {
+  constructor(private readonly userReadRepository: IUserReadRepository) {}
+
+  async execute(query: GetProfileQuery): Promise<ProfileResponseDto> {
+    const user = await this.userReadRepository.findById(query.userId);
+    if (!user) {
+      throw new NotFoundException(`User with ID ${query.userId} not found`);
+    }
+
+    return ProfileResponseDto.of(user);
+  }
+}

--- a/src/auth/query/get-profile.query.ts
+++ b/src/auth/query/get-profile.query.ts
@@ -1,0 +1,3 @@
+export class GetProfileQuery {
+  constructor(public readonly userId: number) {}
+}

--- a/src/posts/interface/post-read-repository.interface.ts
+++ b/src/posts/interface/post-read-repository.interface.ts
@@ -1,6 +1,7 @@
 import { Post } from '@src/posts/entities/post.entity';
 
 export type PostFilter = {
+  userId?: number;
   isPublished?: boolean;
 };
 

--- a/src/posts/post.repository.ts
+++ b/src/posts/post.repository.ts
@@ -43,6 +43,10 @@ export class PostRepository
   ): Promise<[Post[], number]> {
     const where: FindOptionsWhere<Post> = {};
 
+    if (filter.userId !== undefined) {
+      where.userId = filter.userId;
+    }
+
     if (filter.isPublished !== undefined) {
       where.isPublished = filter.isPublished;
     }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -56,10 +56,12 @@ export class PostsController {
   @ApiOperation({ summary: '게시글 페이지네이션 조회' })
   @ApiOkResponse({ type: PaginatedResponseDto })
   async findAllPaginated(
+    @CurrentUser() user: AuthUser,
     @Query() dto: PostsPaginationRequestDto,
   ): Promise<PaginatedResponseDto<PostResponseDto>> {
     return this.queryBus.execute(
       new FindAllPostsPaginatedQuery(dto.page, dto.limit, {
+        userId: user.id,
         isPublished: dto.isPublished,
       }),
     );
@@ -70,9 +72,10 @@ export class PostsController {
   @ApiOkResponse({ type: PostResponseDto })
   @ApiNotFoundResponse({ description: '게시글을 찾을 수 없음' })
   async getPostById(
+    @CurrentUser() user: AuthUser,
     @Param('id', ParseIntPipe) id: number,
   ): Promise<PostResponseDto> {
-    return this.queryBus.execute(new GetPostByIdQuery(id));
+    return this.queryBus.execute(new GetPostByIdQuery(user.id, id));
   }
 
   @Post()

--- a/src/posts/query/find-all-posts-paginated.handler.spec.ts
+++ b/src/posts/query/find-all-posts-paginated.handler.spec.ts
@@ -51,10 +51,12 @@ describe('FindAllPostsPaginatedHandler', () => {
   it('게시글 목록을 페이지네이션하여 PaginatedResponseDto로 반환한다', async () => {
     mockReadRepository.findAllPaginated.mockResolvedValue([mockPosts, 5]);
 
-    const query = new FindAllPostsPaginatedQuery(1, 2);
+    const query = new FindAllPostsPaginatedQuery(1, 2, { userId: 1 });
     const result = await handler.execute(query);
 
-    expect(mockReadRepository.findAllPaginated).toHaveBeenCalledWith(1, 2, {});
+    expect(mockReadRepository.findAllPaginated).toHaveBeenCalledWith(1, 2, {
+      userId: 1,
+    });
     expect(result.items).toHaveLength(2);
     expect(result.items[0]).toBeInstanceOf(PostResponseDto);
     expect(result.items[0].id).toBe(2);
@@ -72,7 +74,7 @@ describe('FindAllPostsPaginatedHandler', () => {
   it('빈 목록이면 빈 items와 올바른 메타 정보를 반환한다', async () => {
     mockReadRepository.findAllPaginated.mockResolvedValue([[], 0]);
 
-    const query = new FindAllPostsPaginatedQuery(1, 10);
+    const query = new FindAllPostsPaginatedQuery(1, 10, { userId: 1 });
     const result = await handler.execute(query);
 
     expect(result.items).toHaveLength(0);

--- a/src/posts/query/get-post-by-id.handler.spec.ts
+++ b/src/posts/query/get-post-by-id.handler.spec.ts
@@ -38,10 +38,10 @@ describe('GetPostByIdHandler', () => {
     handler = module.get(GetPostByIdHandler);
   });
 
-  it('존재하는 게시글을 조회하면 PostResponseDto를 반환한다', async () => {
+  it('존재하는 본인의 게시글을 조회하면 PostResponseDto를 반환한다', async () => {
     mockReadRepository.findById.mockResolvedValue(mockPost);
 
-    const query = new GetPostByIdQuery(1);
+    const query = new GetPostByIdQuery(1, 1);
     const result = await handler.execute(query);
 
     expect(result).toBeInstanceOf(PostResponseDto);
@@ -54,7 +54,15 @@ describe('GetPostByIdHandler', () => {
   it('존재하지 않는 게시글을 조회하면 NotFoundException을 발생시킨다', async () => {
     mockReadRepository.findById.mockResolvedValue(null);
 
-    const query = new GetPostByIdQuery(999);
+    const query = new GetPostByIdQuery(1, 999);
+
+    await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+  });
+
+  it('다른 사용자의 게시글을 조회하면 NotFoundException을 발생시킨다', async () => {
+    mockReadRepository.findById.mockResolvedValue(mockPost);
+
+    const query = new GetPostByIdQuery(2, 1);
 
     await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
   });

--- a/src/posts/query/get-post-by-id.handler.ts
+++ b/src/posts/query/get-post-by-id.handler.ts
@@ -10,7 +10,7 @@ export class GetPostByIdHandler implements IQueryHandler<GetPostByIdQuery> {
 
   async execute(query: GetPostByIdQuery): Promise<PostResponseDto> {
     const post = await this.postReadRepository.findById(query.id);
-    if (!post) {
+    if (!post || post.userId !== query.userId) {
       throw new NotFoundException(`Post with ID ${query.id} not found`);
     }
 

--- a/src/posts/query/get-post-by-id.query.ts
+++ b/src/posts/query/get-post-by-id.query.ts
@@ -1,3 +1,6 @@
 export class GetPostByIdQuery {
-  constructor(public readonly id: number) {}
+  constructor(
+    public readonly userId: number,
+    public readonly id: number,
+  ) {}
 }

--- a/test/auth.integration-spec.ts
+++ b/test/auth.integration-spec.ts
@@ -239,4 +239,55 @@ describe('Auth (integration)', () => {
         .expect(400);
     });
   });
+
+  // ============================================================
+  // GET /auth/profile
+  // ============================================================
+  describe('GET /auth/profile', () => {
+    it('should return profile with { id, email, name, createdAt, updatedAt } and 200', async () => {
+      const tokens = await registerAndLogin();
+
+      const res = await request(app.getHttpServer())
+        .get('/auth/profile')
+        .set('Authorization', `Bearer ${tokens.accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBeDefined();
+      expect(typeof res.body.id).toBe('number');
+      expect(res.body.email).toBe(defaultUser.email);
+      expect(res.body.name).toBe(defaultUser.name);
+      expect(res.body.createdAt).toBeDefined();
+      expect(res.body.updatedAt).toBeDefined();
+      expect(Object.keys(res.body).sort()).toEqual([
+        'createdAt',
+        'email',
+        'id',
+        'name',
+        'updatedAt',
+      ]);
+    });
+
+    it('should not include password or hashedRefreshToken in response', async () => {
+      const tokens = await registerAndLogin();
+
+      const res = await request(app.getHttpServer())
+        .get('/auth/profile')
+        .set('Authorization', `Bearer ${tokens.accessToken}`)
+        .expect(200);
+
+      expect(res.body).not.toHaveProperty('password');
+      expect(res.body).not.toHaveProperty('hashedRefreshToken');
+    });
+
+    it('should return 401 without token', () => {
+      return request(app.getHttpServer()).get('/auth/profile').expect(401);
+    });
+
+    it('should return 401 with invalid token', () => {
+      return request(app.getHttpServer())
+        .get('/auth/profile')
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(401);
+    });
+  });
 });

--- a/test/posts.integration-spec.ts
+++ b/test/posts.integration-spec.ts
@@ -433,6 +433,44 @@ describe('Posts (integration)', () => {
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
+
+    it('should only return posts created by the authenticated user', async () => {
+      await createPost(token, { title: 'My Post' }).expect(201);
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+      await createPost(tokens2.accessToken, { title: 'Other Post' }).expect(
+        201,
+      );
+
+      const res = await request(app.getHttpServer())
+        .get('/posts')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].title).toBe('My Post');
+      expect(res.body.meta.totalElements).toBe(1);
+    });
+
+    it('should return empty when user has no posts even if other users do', async () => {
+      await createPost(token, { title: 'User 1 Post' }).expect(201);
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/posts')
+        .set('Authorization', `Bearer ${tokens2.accessToken}`)
+        .expect(200);
+
+      expect(res.body.items).toHaveLength(0);
+      expect(res.body.meta.totalElements).toBe(0);
+    });
   });
 
   // ============================================================
@@ -492,6 +530,24 @@ describe('Posts (integration)', () => {
         .expect((res) => {
           expect(res.body.message).toBe('Post with ID 99999 not found');
         });
+    });
+
+    it("should return 404 when accessing another user's post", async () => {
+      const createRes = await createPost(token, {
+        title: 'Private Post',
+        content: 'Owner Only',
+      }).expect(201);
+      const id = createRes.body.id as number;
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+
+      await request(app.getHttpServer())
+        .get(`/posts/${id}`)
+        .set('Authorization', `Bearer ${tokens2.accessToken}`)
+        .expect(404);
     });
 
     it('should return 400 for non-numeric id', () => {


### PR DESCRIPTION
## Summary
- `GET /auth/profile` 엔드포인트 추가 (CQRS Query 패턴, JWT 인증 필요)
- 게시글 목록(`GET /posts`) 및 단건 조회(`GET /posts/:id`) 시 인증된 사용자 본인의 게시글만 반환
- 다른 사용자의 게시글 단건 조회 시 NotFoundException 반환으로 존재 여부 비노출

## Test plan
- [x] ProfileResponseDto 단위 테스트 (민감 필드 미포함 검증)
- [x] GetProfileHandler 단위 테스트 (정상 조회, NotFoundException)
- [x] GetPostByIdHandler 단위 테스트 (소유권 검증 추가)
- [x] FindAllPostsPaginatedHandler 단위 테스트 (userId 필터 전달 검증)
- [x] 통합 테스트: GET /auth/profile (200, 401)
- [x] 통합 테스트: GET /posts 사용자 격리 검증
- [x] 통합 테스트: GET /posts/:id 타 사용자 접근 시 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)