### PR TITLE
hotfix(auth): 로그아웃 API 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,9 +1,19 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
 import {
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
+  ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -12,12 +22,14 @@ import {
 import { RegisterCommand } from '@src/auth/command/register.command';
 import { LoginCommand } from '@src/auth/command/login.command';
 import { RefreshTokenCommand } from '@src/auth/command/refresh-token.command';
+import { LogoutCommand } from '@src/auth/command/logout.command';
 import { RegisterRequestDto } from '@src/auth/dto/request/register.request.dto';
 import { LoginRequestDto } from '@src/auth/dto/request/login.request.dto';
 import { RefreshTokenRequestDto } from '@src/auth/dto/request/refresh-token.request.dto';
 import { RegisterResponseDto } from '@src/auth/dto/response/register.response.dto';
 import { AuthTokensResponseDto } from '@src/auth/dto/response/auth-tokens.response.dto';
 import { AuthTokens } from '@src/auth/auth.types';
+import { JwtAuthGuard } from '@src/auth/guard/jwt-auth.guard';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -65,5 +77,17 @@ export class AuthController {
       AuthTokens
     >(new RefreshTokenCommand(dto.refreshToken));
     return AuthTokensResponseDto.of(tokens);
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '로그아웃' })
+  @ApiNoContentResponse({ description: '로그아웃 성공' })
+  @ApiUnauthorizedResponse({ description: '인증 실패' })
+  async logout(@Req() req: { user: { id: number } }): Promise<void> {
+    const user = req.user;
+    await this.commandBus.execute(new LogoutCommand(user.id));
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,11 +6,17 @@ import { AuthController } from '@src/auth/auth.controller';
 import { RegisterHandler } from '@src/auth/command/register.handler';
 import { LoginHandler } from '@src/auth/command/login.handler';
 import { RefreshTokenHandler } from '@src/auth/command/refresh-token.handler';
+import { LogoutHandler } from '@src/auth/command/logout.handler';
 import { userRepositoryProviders } from '@src/auth/user-repository.provider';
 import { JwtStrategy } from '@src/auth/strategy/jwt.strategy';
 import { JwtAuthGuard } from '@src/auth/guard/jwt-auth.guard';
 
-const commandHandlers = [RegisterHandler, LoginHandler, RefreshTokenHandler];
+const commandHandlers = [
+  RegisterHandler,
+  LoginHandler,
+  RefreshTokenHandler,
+  LogoutHandler,
+];
 
 @Module({
   imports: [CqrsModule, PassportModule, JwtModule.register({})],

--- a/src/auth/command/logout.command.ts
+++ b/src/auth/command/logout.command.ts
@@ -1,0 +1,3 @@
+export class LogoutCommand {
+  constructor(public readonly userId: number) {}
+}

--- a/src/auth/command/logout.handler.spec.ts
+++ b/src/auth/command/logout.handler.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { LogoutHandler } from '@src/auth/command/logout.handler';
+import { LogoutCommand } from '@src/auth/command/logout.command';
+import { IUserWriteRepository } from '@src/auth/interface/user-write-repository.interface';
+
+describe('LogoutHandler', () => {
+  let handler: LogoutHandler;
+  let mockWriteRepository: jest.Mocked<IUserWriteRepository>;
+
+  beforeEach(async () => {
+    mockWriteRepository = {
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LogoutHandler,
+        { provide: IUserWriteRepository, useValue: mockWriteRepository },
+      ],
+    }).compile();
+
+    handler = module.get(LogoutHandler);
+
+    jest.clearAllMocks();
+  });
+
+  it('정상 로그아웃 시 update가 올바른 인자로 호출된다', async () => {
+    mockWriteRepository.update.mockResolvedValue(1);
+
+    const command = new LogoutCommand(1);
+    await handler.execute(command);
+
+    expect(mockWriteRepository.update).toHaveBeenCalledWith(1, {
+      hashedRefreshToken: null,
+    });
+  });
+
+  it('존재하지 않는 사용자 ID (affected=0) → NotFoundException', async () => {
+    mockWriteRepository.update.mockResolvedValue(0);
+
+    const command = new LogoutCommand(999);
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+    expect(mockWriteRepository.update).toHaveBeenCalledWith(999, {
+      hashedRefreshToken: null,
+    });
+  });
+});

--- a/src/auth/command/logout.handler.ts
+++ b/src/auth/command/logout.handler.ts
@@ -1,0 +1,19 @@
+import { NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { LogoutCommand } from '@src/auth/command/logout.command';
+import { IUserWriteRepository } from '@src/auth/interface/user-write-repository.interface';
+
+@CommandHandler(LogoutCommand)
+export class LogoutHandler implements ICommandHandler<LogoutCommand> {
+  constructor(private readonly userWriteRepository: IUserWriteRepository) {}
+
+  async execute(command: LogoutCommand): Promise<void> {
+    const affected = await this.userWriteRepository.update(command.userId, {
+      hashedRefreshToken: null,
+    });
+
+    if (affected === 0) {
+      throw new NotFoundException(`User with id ${command.userId} not found`);
+    }
+  }
+}

--- a/test/auth.integration-spec.ts
+++ b/test/auth.integration-spec.ts
@@ -239,4 +239,43 @@ describe('Auth (integration)', () => {
         .expect(400);
     });
   });
+
+  // ============================================================
+  // POST /auth/logout
+  // ============================================================
+  describe('POST /auth/logout', () => {
+    it('should return 204 on successful logout', async () => {
+      const { accessToken } = await registerAndLogin();
+
+      await request(app.getHttpServer())
+        .post('/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+    });
+
+    it('should invalidate refresh token after logout', async () => {
+      const { accessToken, refreshToken } = await registerAndLogin();
+
+      await request(app.getHttpServer())
+        .post('/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+
+      await request(app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(401);
+    });
+
+    it('should return 401 when no Authorization header is provided', async () => {
+      await request(app.getHttpServer()).post('/auth/logout').expect(401);
+    });
+
+    it('should return 401 when an invalid token is provided', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/logout')
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(401);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- JWT 인증된 사용자의 refresh token을 무효화하는 `POST /auth/logout` 엔드포인트 추가
- CQRS 패턴에 따라 `LogoutCommand` / `LogoutHandler` 구현
- `JwtAuthGuard`를 적용하여 인증된 요청만 허용, 204 No Content 응답

## Test plan
- [x] `LogoutHandler` 단위 테스트 2건 통과 (정상 로그아웃, 존재하지 않는 사용자)
- [x] 통합 테스트 4건 통과 (204 응답, refresh token 무효화 검증, 미인증 401, 잘못된 토큰 401)
- [x] 기존 테스트 전체 통과 (unit 40, integration 64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added logout functionality that securely invalidates user sessions and refresh tokens.
  * Logout endpoint requires authentication and returns appropriate error responses for unauthorized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->