### PR TITLE
feat(idempotency): Idempotency-Key 기반 POST 중복 요청 방지

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ JWT_REFRESH_EXPIRATION=7d
 LOG_LEVEL=debug
 
 SLACK_BOT_TOKEN=xoxb-your-slack-bot-token
+
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,19 @@ jobs:
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/idempotency-guide.md
+++ b/docs/idempotency-guide.md
@@ -1,0 +1,926 @@
+# Idempotency(멱등성) 가이드: 중복 요청 방지
+
+> 이 문서는 API에서 중복 요청이 발생하는 원인을 설명하고, Idempotency-Key 패턴으로 해결하는 방법을 입문자도 이해할 수 있도록 안내한다.
+> [참고 블로그: Implementing Idempotency in NestJS with an Interceptor](https://michaelguay.dev/implementing-idempotency-in-nestjs-with-an-interceptor/)
+
+---
+
+## 목차
+
+### Part I: 개념 이해
+- [1. 문제 상황: 왜 중복 요청이 발생하는가?](#1-문제-상황-왜-중복-요청이-발생하는가)
+- [2. 멱등성(Idempotency)이란?](#2-멱등성idempotency이란)
+- [3. Idempotency-Key 패턴이란?](#3-idempotency-key-패턴이란)
+
+### Part II: 대안 비교
+- [4. 해결 대안 비교](#4-해결-대안-비교)
+- [5. 왜 Idempotency-Key를 선택했는가?](#5-왜-idempotency-key를-선택했는가)
+
+### Part III: 설계
+- [6. 전체 흐름 한눈에 보기](#6-전체-흐름-한눈에-보기)
+- [7. 핵심 컴포넌트 설명](#7-핵심-컴포넌트-설명)
+- [8. 동시 요청 처리 (Race Condition)](#8-동시-요청-처리-race-condition)
+
+### Part IV: 구현 상세
+- [9. 파일 구조](#9-파일-구조)
+- [10. Step-by-Step 구현](#10-step-by-step-구현)
+
+### Part V: 사용법
+- [11. API 사용 예시](#11-api-사용-예시)
+- [12. 에러 케이스 정리](#12-에러-케이스-정리)
+- [13. 검증 방법](#13-검증-방법)
+
+---
+
+## Part I: 개념 이해
+
+---
+
+## 1. 문제 상황: 왜 중복 요청이 발생하는가?
+
+사용자가 "게시글 작성" 버튼을 클릭하면 브라우저가 서버에 POST 요청을 보낸다. 이 과정에서 중복 요청이 발생하는 시나리오는 여러 가지가 있다.
+
+### 1.1 시나리오별 분류
+
+| 시나리오 | 원인 | 결과 |
+|----------|------|------|
+| **더블 클릭** | 사용자가 버튼을 빠르게 2번 클릭 | 동일한 POST 요청 2회 전송 |
+| **네트워크 타임아웃** | 첫 요청의 응답이 늦어 사용자가 다시 클릭 | 서버에서는 2건 모두 처리 |
+| **브라우저 새로고침** | 결과 페이지에서 F5를 누름 | POST 재전송 (브라우저 경고가 뜨지만 무시 가능) |
+| **자동 재시도** | Axios 등 HTTP 클라이언트가 실패 시 자동 재시도 | 서버가 이미 처리한 요청을 다시 받음 |
+
+### 1.2 결제 시나리오에서의 위험
+
+```
+1. 사용자가 "결제하기" 버튼 클릭
+2. 요청이 서버로 전송됨 (네트워크 느림)
+3. 사용자가 응답이 없다고 생각하여 다시 클릭
+4. 서버는 2건의 결제 요청을 각각 처리
+5. → 이중 결제 발생!
+```
+
+이것이 이 프로젝트에서 해결하려는 핵심 문제다.
+
+---
+
+## 2. 멱등성(Idempotency)이란?
+
+> **멱등성**: 동일한 요청을 여러 번 실행해도 결과가 한 번 실행한 것과 동일한 성질
+
+### 2.1 HTTP 메서드별 멱등성
+
+| HTTP 메서드 | 멱등한가? | 설명 |
+|-------------|-----------|------|
+| GET | O | 같은 URL을 몇 번 조회해도 결과 동일 |
+| PUT | O | 같은 데이터로 몇 번 업데이트해도 결과 동일 |
+| DELETE | O | 이미 삭제된 리소스를 다시 삭제해도 결과 동일 |
+| **POST** | **X** | 같은 데이터로 2번 호출하면 **2건이 생성됨** |
+
+POST가 원래 멱등하지 않기 때문에, **별도의 메커니즘**이 필요하다. 그것이 Idempotency-Key 패턴이다.
+
+### 2.2 비유로 이해하기
+
+- **멱등하지 않은 것**: ATM에서 "출금" 버튼을 2번 누르면 2번 출금됨
+- **멱등한 것**: 엘리베이터 버튼을 여러 번 눌러도 한 번만 호출됨
+
+우리가 원하는 것은 API를 **엘리베이터 버튼처럼** 만드는 것이다.
+
+---
+
+## 3. Idempotency-Key 패턴이란?
+
+Stripe, PayPal 같은 결제 API에서 널리 사용하는 업계 표준 패턴이다.
+
+### 3.1 기본 원리
+
+```
+[클라이언트]                          [서버]
+    |                                  |
+    |  POST /posts                     |
+    |  Idempotency-Key: abc-123        |
+    |  Body: {title, content}          |
+    |--------------------------------->|
+    |                                  |  1. "abc-123" 키가 캐시에 있는지 확인
+    |                                  |  2. 없음 → 요청 처리 + 응답을 캐시에 저장
+    |  201 Created {id: 1}             |
+    |<---------------------------------|
+    |                                  |
+    |  POST /posts (재시도)             |
+    |  Idempotency-Key: abc-123        |  ← 동일한 키
+    |  Body: {title, content}          |
+    |--------------------------------->|
+    |                                  |  1. "abc-123" 키가 캐시에 있는지 확인
+    |                                  |  2. 있음 → 캐시된 응답을 그대로 반환
+    |  201 Created {id: 1}             |  ← 동일한 응답 (처리 안 함)
+    |<---------------------------------|
+```
+
+핵심: 서버가 **키를 기준으로 이미 처리한 요청인지 판단**하고, 처리된 요청이면 **저장해둔 응답을 그대로 반환**한다.
+
+### 3.2 구성 요소
+
+| 구성 요소 | 역할 | 비유 |
+|-----------|------|------|
+| **Idempotency-Key** | 클라이언트가 보내는 고유 식별자 (UUID) | 택배 송장번호 |
+| **Redis** | 키 + 응답을 저장하는 인메모리 캐시 | 택배 추적 시스템 |
+| **Interceptor** | 요청을 가로채서 캐시를 확인하는 미들웨어 | 택배 분류 센터 |
+| **TTL** | 캐시 만료 시간 (예: 24시간) | 송장번호 유효기간 |
+
+### 3.3 블로그의 핵심 코드
+
+[참고 블로그](https://michaelguay.dev/implementing-idempotency-in-nestjs-with-an-interceptor/)에서 제시하는 구현의 핵심이다:
+
+```typescript
+// 블로그의 Interceptor (핵심 로직만 발췌)
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<any>> {
+    const request = context.switchToHttp().getRequest();
+    const idempotencyKey = request.headers['idempotency-key'];
+
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+
+    // 캐시 조회
+    const cachedResponse = await this.cacheManager.get(idempotencyKey);
+    if (cachedResponse) {
+      return from([cachedResponse]);  // 캐시된 응답 반환
+    }
+
+    // 캐시 없음 → 요청 처리 + 결과 저장
+    return next.handle().pipe(
+      tap(async (response) => {
+        await this.cacheManager.set(idempotencyKey, response, { ttl: 60 * 5 });
+      }),
+    );
+  }
+}
+```
+
+우리 프로젝트에서는 이 블로그 패턴을 그대로 따르면서 **사용자별 키 격리**와 **상태코드 보존**을 추가한다.
+
+---
+
+## Part II: 대안 비교
+
+---
+
+## 4. 해결 대안 비교
+
+중복 요청을 방지하는 방법은 여러 가지가 있다. 각각의 장단점을 비교한다.
+
+### 대안 1: 프론트엔드 방어 (버튼 비활성화)
+
+```typescript
+// 프론트엔드 코드 예시
+const handleClick = async () => {
+  setLoading(true);          // 버튼 비활성화
+  try {
+    await api.createPost(data);
+  } finally {
+    setLoading(false);        // 버튼 재활성화
+  }
+};
+```
+
+| 장점 | 단점 |
+|------|------|
+| 구현이 가장 간단 | 서버 측 방어가 아님 — API 직접 호출 시 무방비 |
+| UX 개선 효과 (로딩 표시) | 네트워크 타임아웃, 자동 재시도는 방지 불가 |
+| 서버 변경 불필요 | 결제 같은 크리티컬 작업에는 단독으로 부족 |
+
+### 대안 2: 서버 측 요청 중복 차단 (Deduplication Guard)
+
+서버가 `hash(userId + path + body)`로 요청의 "지문"을 만들어, 짧은 시간(예: 5초) 내 동일 지문 요청을 차단한다.
+
+| 장점 | 단점 |
+|------|------|
+| 클라이언트 변경 불필요 | 멱등하지 않음 — 중복 시 에러(409) 반환 |
+| 구현이 비교적 단순 | 의도적으로 2번 호출하는 정당한 케이스도 차단할 수 있음 |
+
+### 대안 3: Idempotency-Key 헤더 + Redis (선택)
+
+클라이언트가 UUID를 보내고, 서버가 응답을 Redis에 캐시하여 동일 키 재요청 시 캐시된 응답을 반환한다.
+
+| 장점 | 단점 |
+|------|------|
+| 완전한 멱등성 보장 | 클라이언트 협력 필요 (UUID 헤더 전송) |
+| 업계 표준 (Stripe, PayPal) | Redis 인프라 필요 |
+| 재시도 시 동일 성공 응답 반환 | 구현 복잡도 중간 |
+| TTL 자동 만료 (Redis 내장) | |
+| 다중 인스턴스 환경에서도 동작 | |
+
+### 대안 4: DB Advisory Lock
+
+PostgreSQL의 Advisory Lock으로 동일 리소스에 대한 동시 쓰기를 직렬화한다.
+
+| 장점 | 단점 |
+|------|------|
+| 추가 인프라 불필요 | 멱등하지 않음 — 두 번째 요청은 에러 반환 |
+| Race condition 완벽 방지 | PostgreSQL 종속적 |
+
+---
+
+## 5. 왜 Idempotency-Key + Redis를 선택했는가?
+
+### 5.1 핵심 차별점: "에러 반환" vs "성공 응답 재생"
+
+```
+[Deduplication Guard]
+  첫 번째 요청 → 201 Created {id: 1}
+  두 번째 요청 → 409 Conflict ❌  ← 클라이언트는 에러 처리 필요
+
+[Idempotency-Key]
+  첫 번째 요청 → 201 Created {id: 1}
+  두 번째 요청 → 201 Created {id: 1} ✅  ← 동일한 성공 응답
+```
+
+Idempotency-Key는 중복 요청 시에도 **성공 응답을 그대로 반환**한다. 클라이언트 입장에서는 재시도가 항상 안전하다. 이것이 결제 API에서 이 패턴을 표준으로 사용하는 이유다.
+
+### 5.2 왜 Redis인가?
+
+블로그와 동일하게 Redis를 캐시 저장소로 사용한다.
+
+| 비교 항목 | Redis | PostgreSQL 테이블 |
+|-----------|-------|-------------------|
+| **속도** | 인메모리 — 매우 빠름 (< 1ms) | 디스크 I/O — 상대적으로 느림 |
+| **TTL** | `SET key value EX 86400` — 내장 지원 | 별도 cleanup cron 필요 |
+| **동시성** | 단일 스레드 — 원자적 처리 | Advisory Lock 등 별도 제어 필요 |
+| **다중 인스턴스** | 중앙 집중식 캐시 — 자연스럽게 공유 | DB 공유하면 가능하나 무거움 |
+| **인프라** | Redis 서버 필요 | 추가 인프라 불필요 |
+| **데이터 영속성** | 휘발성 (재시작 시 소실 가능) | 영구 저장 |
+
+Redis를 선택한 이유:
+- **블로그에서 권장하는 프로덕션 방식**이며, 분산 환경(Kubernetes, 로드밸런싱)에서도 동작
+- TTL이 내장되어 있어 **만료 키 정리 서비스가 불필요** — 코드가 간결해짐
+- 단일 스레드 특성으로 **Advisory Lock 없이도 동시성 문제가 완화**됨
+- DB 마이그레이션, Entity, Repository 등 **보일러플레이트 코드가 대폭 줄어듦**
+
+### 5.3 블로그 대비 우리 프로젝트의 개선점
+
+블로그의 기본 구현에 다음을 추가한다:
+
+| 항목 | 블로그 | 우리 프로젝트 |
+|------|--------|--------------|
+| 키 스코핑 | `idempotencyKey`만 사용 | `userId:idempotencyKey` 복합키 (사용자별 격리) |
+| 상태코드 보존 | X (응답 본문만 캐시) | O (statusCode + responseBody를 함께 캐시) |
+| UUID 검증 | X | O (UUID v4 형식 검증) |
+| 인증 검증 | X | O (userId 누락 시 401 반환) |
+| 동시성 제어 | `get`/`set` 분리 (비원자적) | `ioredis` `SET NX` (원자적 선점) |
+| 적용 방식 | `@UseInterceptors()` 직접 사용 | `@Idempotent()` 커스텀 데코레이터로 래핑 |
+| TTL | 5분 | 24시간 (Stripe 기본값과 동일) |
+| TTL 단위 | 미명시 | 밀리초 명시 (`_MS` 접미사, cache-manager v5+ 기준) |
+
+---
+
+## Part III: 설계
+
+---
+
+## 6. 전체 흐름 한눈에 보기
+
+### 6.1 정상 흐름 (첫 번째 요청)
+
+```text
+클라이언트
+  │  POST /posts
+  │  Headers: { Idempotency-Key: "550e8400-..." }
+  │  Body: { title: "제목", content: "내용" }
+  ▼
+IdempotencyInterceptor
+  │  1. 헤더에서 Idempotency-Key 추출
+  │  2. UUID 형식 검증
+  │  3. Redis 조회: cacheManager.get("idempotency:1:550e8400-...") → null
+  │  4. "처리 중" 마커 설정 → next.handle() → Handler 실행
+  ▼
+CreatePostHandler
+  │  게시글 생성 로직 실행
+  │  return post.id
+  ▼
+IdempotencyInterceptor (응답 후처리 — tap)
+  │  5. Redis 저장: cacheManager.set("idempotency:1:550e8400-...", { statusCode: 201, body: {id: 1} }, TTL)
+  ▼
+클라이언트 ← 201 Created { id: 1 }
+```
+
+### 6.2 캐시 히트 (동일 키로 재요청)
+
+```text
+클라이언트
+  │  POST /posts
+  │  Headers: { Idempotency-Key: "550e8400-..." }  ← 동일한 키
+  ▼
+IdempotencyInterceptor
+  │  1. 헤더에서 Idempotency-Key 추출
+  │  2. UUID 형식 검증
+  │  3. Redis 조회: cacheManager.get("idempotency:1:550e8400-...") → { statusCode: 201, body: {id: 1} }
+  │  4. 저장된 응답 그대로 반환 (Handler 실행 안 함)
+  ▼
+클라이언트 ← 201 Created { id: 1 }  ← 동일한 응답
+```
+
+### 6.3 모듈 구조
+
+```text
+AppModule
+├── CacheModule (Redis)             ← 신규 — 글로벌 캐시
+├── IdempotencyModule               ← 신규
+│   └── IdempotencyInterceptor      ← 요청 가로채기 + Redis 캐시 확인
+├── PostsModule
+│   └── PostsController
+│       └── @Idempotent()           ← createPost, updatePost에 적용
+└── ...
+```
+
+PostgreSQL 방식 대비 구조가 훨씬 간결하다. Entity, Repository, Provider, Cleanup Service가 모두 불필요하다.
+
+---
+
+## 7. 핵심 컴포넌트 설명
+
+### 7.1 용어 해설
+
+| 용어 | 설명 |
+|------|------|
+| **Redis** | 인메모리 데이터 저장소. 키-값 쌍을 매우 빠르게 읽고 쓸 수 있다. TTL(Time-To-Live)을 지원하여 설정한 시간이 지나면 자동으로 데이터가 삭제된다. |
+| **cache-manager** | Node.js의 캐시 추상화 라이브러리. Redis, Memcached, 인메모리 등 다양한 백엔드를 동일한 `get`/`set` API로 사용할 수 있게 해준다. |
+| **CACHE_MANAGER** | NestJS가 `CacheModule`을 통해 제공하는 DI 토큰. `@Inject(CACHE_MANAGER)`로 주입받아 `cache.get(key)`, `cache.set(key, value, ttl)` 메서드를 사용한다. |
+| **cache-manager-redis-store** | `cache-manager`의 Redis 어댑터. `cache-manager`의 `get`/`set` 호출을 Redis 명령어로 변환한다. |
+| **NestJS Interceptor** | Controller 메서드 실행 전후를 감싸는 미들웨어. `intercept(context, next)` 메서드에서 요청을 가로채고, `next.handle()`로 Controller를 실행하며, `pipe(tap(...))`으로 응답을 후처리한다. |
+| **TTL (Time-To-Live)** | 캐시 항목의 유효 시간. TTL이 지나면 Redis가 자동으로 해당 키를 삭제한다. 별도 cleanup 로직이 불필요하다. |
+
+### 7.2 `@Idempotent()` 데코레이터
+
+```typescript
+// 사용 예시
+@Post()
+@Idempotent()
+async createPost(@Body() dto: CreatePostRequestDto) { ... }
+```
+
+`@Idempotent()`는 두 가지 일을 한꺼번에 한다:
+
+1. **메타데이터 설정**: 이 메서드가 멱등성 처리 대상임을 표시
+2. **인터셉터 연결**: `IdempotencyInterceptor`를 이 메서드에만 적용
+
+내부적으로 NestJS의 `applyDecorators`를 사용한다:
+
+```typescript
+export function Idempotent(): MethodDecorator {
+  return applyDecorators(
+    SetMetadata(IDEMPOTENT_KEY, true),            // 메타데이터 설정
+    UseInterceptors(IdempotencyInterceptor),       // 인터셉터 연결
+  );
+}
+```
+
+**왜 글로벌 인터셉터가 아닌가?**
+GET 요청은 이미 멱등하므로 불필요하다. `@Idempotent()`를 메서드 단위로 적용하면 필요한 엔드포인트에만 선택적으로 멱등성을 부여할 수 있다.
+
+### 7.3 `IdempotencyInterceptor`
+
+블로그 코드를 기반으로, 사용자별 키 격리와 상태코드 보존을 추가한 인터셉터다.
+
+NestJS의 Interceptor는 Controller 메서드 실행 **전후**를 감싸는 미들웨어다:
+
+```
+요청 → [Interceptor 전처리] → [Controller] → [Interceptor 후처리] → 응답
+```
+
+블로그 대비 주요 변경점:
+
+| 영역 | 블로그 | 우리 프로젝트 |
+|------|--------|--------------|
+| 캐시 키 | `idempotencyKey` | `idempotency:${userId}:${idempotencyKey}` |
+| 캐시 값 | `response` (본문만) | `{ statusCode, body }` (객체) |
+| 선점 방식 | `get` → `set` (비원자적) | `ioredis` `SET NX` (원자적) |
+| 에러 처리 | 없음 | `catchError`에서 마커 삭제 + Observable 반환 |
+| 인증 검증 | 없음 | `userId` 누락 시 `401 Unauthorized` |
+
+전체 코드는 [Step 5: Interceptor 생성](#step-5-interceptor-생성-핵심)을 참고한다.
+
+### 7.4 Redis 캐시에 저장되는 데이터 구조
+
+```typescript
+// Redis에 저장되는 값의 타입
+interface CachedResponse {
+  statusCode: number;         // HTTP 상태코드 (201, 204 등)
+  body: Record<string, unknown> | null;  // 응답 본문 (void면 null)
+}
+```
+
+Redis 키 형식: `idempotency:{userId}:{uuid}`
+
+예시:
+```
+키:   "idempotency:1:550e8400-e29b-41d4-a716-446655440000"
+값:   { "statusCode": 201, "body": { "id": 1 } }
+TTL:  86400000ms (24시간)
+```
+
+---
+
+## 8. 동시 요청 처리 (Race Condition)
+
+### 8.1 문제: `get`/`set` 분리의 비원자성
+
+Redis는 단일 스레드로 **개별 명령**을 순서대로 처리하지만, NestJS 서버에서 `GET` → `SET` 두 명령을 **분리하여** 실행하면 그 사이에 다른 요청이 끼어들 수 있다.
+
+```
+시간 →
+요청 A: GET(없음) ─────────────────── SET("PROCESSING") → Handler 실행
+요청 B:           GET(없음) ────────── SET("PROCESSING") → Handler 실행  ← 중복!
+                  ↑ 이 시점에 A의 SET이 아직 완료되지 않음
+```
+
+`cache-manager`의 `get`/`set`은 별도의 Redis 명령이므로 원자적이지 않다. 블로그 원본의 댓글에서도 정확히 이 문제가 지적되었다.
+
+### 8.2 해결: Redis `SET NX` 원자적 선점
+
+Redis의 `SET key value NX EX ttl` 명령은 **키가 없을 때만 설정**하는 것을 **하나의 원자적 연산**으로 보장한다. `NX` = "Not eXists".
+
+```
+시간 →
+요청 A: SET NX(성공, "PROCESSING") → Handler 실행 → SET(응답) → 반환
+요청 B: SET NX(실패) → GET → 마커 발견 → 409 반환
+```
+
+`cache-manager`의 `set` 메서드는 `NX` 옵션을 지원하지 않으므로, `ioredis` 클라이언트를 직접 사용한다:
+
+```typescript
+// ioredis를 직접 사용하여 원자적 선점
+const acquired = await this.redis.set(
+  cacheKey,
+  PROCESSING_MARKER,
+  'EX', PROCESSING_TTL_SEC,
+  'NX',                         // 키가 없을 때만 설정
+);
+
+if (!acquired) {
+  // 이미 키가 존재 → 캐시 히트이거나 다른 요청이 처리 중
+  const existing = await this.cacheManager.get<string | CachedResponse>(cacheKey);
+  if (existing === PROCESSING_MARKER) {
+    throw new ConflictException(
+      'A request with this Idempotency-Key is currently being processed',
+    );
+  }
+  if (existing && typeof existing === 'object') {
+    response.status(existing.statusCode);
+    return of(existing.body);
+  }
+}
+```
+
+`ioredis` 인스턴스는 별도 DI 토큰(`REDIS_CLIENT`)으로 주입한다. 자세한 코드는 [Step 5](#step-5-interceptor-생성-핵심)를 참고한다.
+
+---
+
+## Part IV: 구현 상세
+
+---
+
+## 9. 파일 구조
+
+### 9.1 신규 파일
+
+```
+src/common/idempotency/
+├── decorator/
+│   └── idempotent.decorator.ts        # @Idempotent() 메서드 데코레이터
+├── idempotency.interceptor.ts         # 핵심 Interceptor (Redis 캐시 사용)
+└── idempotency.module.ts              # NestJS 모듈
+```
+
+PostgreSQL 방식과 비교하면 **Entity, Repository, Provider, Cleanup Service, Migration이 모두 불필요**하다. Redis의 TTL이 만료 처리를 대신하고, `cache-manager`가 데이터 접근을 대신한다.
+
+### 9.2 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `package.json` | `cache-manager`, `@nestjs/cache-manager`, `cache-manager-redis-store` 의존성 추가 |
+| `src/app.module.ts` | `CacheModule.registerAsync()` + `IdempotencyModule` import 추가 |
+| `src/posts/posts.controller.ts` | `createPost`와 `updatePost`에 `@Idempotent()` + `@ApiHeader` 추가 |
+| `.env.example` | `REDIS_HOST`, `REDIS_PORT` 추가 |
+
+---
+
+## 10. Step-by-Step 구현
+
+### Step 1: 의존성 설치
+
+```bash
+pnpm add cache-manager @nestjs/cache-manager cache-manager-redis-store@^3 ioredis
+```
+
+| 패키지 | 설치 버전 | 역할 |
+|--------|-----------|------|
+| `cache-manager` | `^7.2.8` | 캐시 추상화 라이브러리 — `get`/`set`/`del` API 제공. **v5+는 TTL 단위가 밀리초(ms)** |
+| `@nestjs/cache-manager` | `^3.1.0` | NestJS의 `CacheModule` 제공 — DI를 통해 `CACHE_MANAGER` 토큰 주입. cache-manager v5+와 호환 |
+| `cache-manager-redis-store` | `^3.0.1` | `cache-manager`의 Redis 어댑터 — 실제 Redis와 통신 |
+| `ioredis` | `^5.10.1` | Node.js Redis 클라이언트 — `cache-manager-redis-store`가 내부적으로 사용하며, `SET NX` 원자적 선점에도 직접 사용 |
+
+> **주의:** `cache-manager` v5+는 TTL 단위가 **밀리초(ms)**다. 블로그 원본(v4)의 코드에서 초 단위로 작성된 TTL을 그대로 복사하면 의도보다 1000배 짧게 만료된다. 이 프로젝트에서는 모든 TTL 상수에 `_MS` 접미사를 붙여 혼동을 방지한다.
+
+### Step 2: 환경 변수 추가
+
+**파일:** `.env.example`
+
+```env
+# Redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
+```
+
+`.env.local`, `.env.development`, `.env.production`에도 동일하게 추가한다.
+
+### Step 3: AppModule에 CacheModule 등록
+
+**파일:** `src/app.module.ts`
+
+블로그에서 제시한 것과 동일한 `CacheModule.registerAsync()` 패턴을 사용한다.
+
+```typescript
+import { CacheModule } from '@nestjs/cache-manager';
+import * as redisStore from 'cache-manager-redis-store';
+
+@Module({
+  imports: [
+    // ...기존 imports
+    CacheModule.registerAsync({
+      isGlobal: true,
+      useFactory: () => ({
+        store: redisStore,
+        host: process.env.REDIS_HOST || 'localhost',
+        port: parseInt(process.env.REDIS_PORT || '6379', 10),
+        ttl: 1000 * 60 * 60,  // 기본 TTL 1시간 (밀리초, cache-manager v5+) — 안전망
+      }),
+    }),
+    IdempotencyModule,    // ← 추가
+  ],
+})
+export class AppModule {}
+```
+
+**`isGlobal: true`**: `CacheModule`을 글로벌로 등록하면 다른 모듈에서 별도 import 없이 `CACHE_MANAGER`를 주입받을 수 있다.
+
+### Step 4: `@Idempotent()` 데코레이터 생성
+
+**파일:** `src/common/idempotency/decorator/idempotent.decorator.ts`
+
+```typescript
+import { applyDecorators, SetMetadata, UseInterceptors } from '@nestjs/common';
+import { IdempotencyInterceptor } from '../idempotency.interceptor';
+
+export const IDEMPOTENT_KEY = 'isIdempotent';
+
+export function Idempotent(): MethodDecorator {
+  return applyDecorators(
+    SetMetadata(IDEMPOTENT_KEY, true),
+    UseInterceptors(IdempotencyInterceptor),
+  );
+}
+```
+
+### Step 5: Interceptor 생성 (핵심)
+
+**파일:** `src/common/idempotency/idempotency.interceptor.ts`
+
+블로그의 `@Inject(CACHE_MANAGER)` 패턴을 그대로 따르되, userId 스코핑과 상태코드 보존을 추가한다.
+
+```typescript
+import {
+  BadRequestException,
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { from, Observable, of, throwError } from 'rxjs';
+import { catchError, switchMap, tap } from 'rxjs/operators';
+import { isUUID } from 'class-validator';
+import Redis from 'ioredis';
+import { PinoLogger } from 'nestjs-pino';
+
+interface CachedResponse {
+  statusCode: number;
+  body: Record<string, unknown> | null;
+}
+
+const PROCESSING_MARKER = '__PROCESSING__';
+const IDEMPOTENCY_TTL_MS = 1000 * 60 * 60 * 24;  // 24시간 (밀리초, cache-manager v5+ 기준)
+const PROCESSING_TTL_SEC = 60;                     // ioredis SET NX의 EX 옵션은 초 단위
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    @Inject('REDIS_CLIENT') private readonly redis: Redis,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(IdempotencyInterceptor.name);
+  }
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<unknown>> {
+    const httpContext = context.switchToHttp();
+    const request = httpContext.getRequest();
+    const response = httpContext.getResponse();
+    const idempotencyKey = request.headers['idempotency-key'] as string;
+
+    // 1. 헤더 검증
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    if (!isUUID(idempotencyKey, '4')) {
+      throw new BadRequestException('Idempotency-Key must be a valid UUID');
+    }
+
+    const userId = request.user?.id;
+    if (!userId) {
+      throw new UnauthorizedException(
+        'Idempotent endpoints require authentication',
+      );
+    }
+    const cacheKey = `idempotency:${userId}:${idempotencyKey}`;
+
+    // 2. Redis 캐시 조회 (블로그: cacheManager.get)
+    const cached = await this.cacheManager.get<string | CachedResponse>(cacheKey);
+
+    // 2-a. "처리 중" 마커 → 동시 요청 차단
+    if (cached === PROCESSING_MARKER) {
+      throw new ConflictException(
+        'A request with this Idempotency-Key is currently being processed',
+      );
+    }
+
+    // 2-b. 캐시 히트 → 저장된 응답 반환
+    if (cached && typeof cached === 'object') {
+      this.logger.info({ cacheKey }, 'Idempotency cache hit — returning cached response');
+      response.status(cached.statusCode);
+      return of(cached.body);
+    }
+
+    // 3. 원자적 선점: SET NX (ioredis 직접 사용)
+    const acquired = await this.redis.set(
+      cacheKey,
+      PROCESSING_MARKER,
+      'EX', PROCESSING_TTL_SEC,
+      'NX',                         // 키가 없을 때만 설정 — 원자적
+    );
+
+    if (!acquired) {
+      // 이미 키가 존재 → 캐시 히트이거나 다른 요청이 처리 중
+      const existing = await this.cacheManager.get<string | CachedResponse>(cacheKey);
+      if (existing === PROCESSING_MARKER) {
+        throw new ConflictException(
+          'A request with this Idempotency-Key is currently being processed',
+        );
+      }
+      if (existing && typeof existing === 'object') {
+        this.logger.info({ cacheKey }, 'Idempotency cache hit — returning cached response');
+        response.status(existing.statusCode);
+        return of(existing.body);
+      }
+    }
+
+    // 4. Handler 실행 + 응답 저장 (블로그: next.handle().pipe(tap(...)))
+    return next.handle().pipe(
+      tap(async (responseBody) => {
+        const cachedValue: CachedResponse = {
+          statusCode: response.statusCode,
+          body: responseBody ?? null,
+        };
+        await this.cacheManager.set(cacheKey, cachedValue, IDEMPOTENCY_TTL_MS);
+        this.logger.info({ cacheKey, statusCode: response.statusCode }, 'Idempotency response cached');
+      }),
+      catchError((error) => {
+        // 에러 시 마커 제거 → 동일 키로 재시도 가능
+        // from()으로 Promise를 Observable로 변환 후 switchMap으로 에러 재전파
+        return from(this.cacheManager.del(cacheKey)).pipe(
+          switchMap(() => throwError(() => error)),
+        );
+      }),
+    );
+  }
+}
+```
+
+**블로그 코드와의 차이점 해설:**
+
+| 영역 | 블로그 | 우리 프로젝트 | 이유 |
+|------|--------|--------------|------|
+| 캐시 키 | `idempotencyKey` | `idempotency:${userId}:${idempotencyKey}` | 사용자 A와 B가 같은 UUID를 쓸 경우 충돌 방지 |
+| 캐시 값 | `response` (본문만) | `{ statusCode, body }` (객체) | 201, 204 등 원래 상태코드를 정확히 재현 |
+| TTL | `60 * 5` (5분, 초) | `IDEMPOTENCY_TTL_MS = 86400000` (24시간, 밀리초) | Stripe 기본값과 동일. 상수명에 단위(`_MS`) 명시 |
+| 선점 | `get` → `set` (비원자적) | `ioredis` `SET NX` (원자적) | `get`/`set` 사이 race condition 방지 |
+| 인증 | 없음 | `userId` 누락 시 `401` | 캐시 키에 `undefined` 삽입 방지 |
+| 에러 처리 | 없음 | `catchError` → `from()` + `throwError()` | RxJS에서 올바르게 Observable 반환 |
+
+### Step 6: Module 생성
+
+**파일:** `src/common/idempotency/idempotency.module.ts`
+
+```typescript
+import { Module } from '@nestjs/common';
+import Redis from 'ioredis';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+@Module({
+  providers: [
+    {
+      provide: 'REDIS_CLIENT',
+      useFactory: () =>
+        new Redis({
+          host: process.env.REDIS_HOST || 'localhost',
+          port: parseInt(process.env.REDIS_PORT || '6379', 10),
+        }),
+    },
+    IdempotencyInterceptor,
+  ],
+  exports: [IdempotencyInterceptor],
+})
+export class IdempotencyModule {}
+```
+
+`REDIS_CLIENT`는 `SET NX` 원자적 선점에 사용하는 `ioredis` 인스턴스다. `CACHE_MANAGER`는 글로벌 `CacheModule`에서 주입되므로 별도 import가 불필요하다.
+
+### Step 7: Controller에 적용
+
+**파일:** `src/posts/posts.controller.ts`
+
+```typescript
+import { Idempotent } from '@src/common/idempotency/decorator/idempotent.decorator';
+import { ApiHeader } from '@nestjs/swagger';
+
+// createPost에 적용
+@Post()
+@Idempotent()
+@ApiHeader({ name: 'Idempotency-Key', required: true, description: 'UUID v4 형식의 멱등성 키' })
+@ApiOperation({ summary: '게시글 생성' })
+async createPost(...) { ... }
+
+// updatePost에 적용
+@Patch(':id')
+@Idempotent()
+@ApiHeader({ name: 'Idempotency-Key', required: true, description: 'UUID v4 형식의 멱등성 키' })
+@HttpCode(HttpStatus.NO_CONTENT)
+@ApiOperation({ summary: '게시글 수정 (전체 업데이트)' })
+async updatePost(...) { ... }
+```
+
+**PATCH 적용 판단 기준:**
+PATCH는 같은 데이터로 같은 리소스를 수정하면 결과가 동일하므로, 단순 필드 업데이트라면 `@Idempotent()`가 불필요하다. 다만 PATCH 내부에 비멱등 부수 효과(예: 조회수 +1, 포인트 차감, 외부 결제 API 호출)가 있는 경우에는 적용해야 한다. 현재 `updatePost`는 단순 필드 업데이트이므로 **선택적 적용**이다.
+
+> **주의:** `@Idempotent()`를 사용하는 Controller가 속한 Module에서 `IdempotencyModule`을 import하거나, `AppModule`에서 `IdempotencyModule`을 import해야 한다. 이 프로젝트에서는 `AppModule`에서 import하므로 별도 작업이 불필요하다.
+
+**적용하지 않는 엔드포인트:**
+- `GET /posts`, `GET /posts/:id` — 조회는 이미 멱등
+- `DELETE /posts/:id` — soft delete는 이미 멱등 (같은 ID를 2번 삭제해도 결과 동일)
+
+---
+
+## Part V: 사용법
+
+---
+
+## 11. API 사용 예시
+
+### 11.1 프론트엔드에서 사용하는 방법
+
+```typescript
+import { v4 as uuidv4 } from 'uuid';
+
+// 게시글 생성 요청
+const createPost = async (title: string, content: string) => {
+  const idempotencyKey = uuidv4();  // 요청마다 새 UUID 생성
+
+  const response = await fetch('/posts', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+      'Idempotency-Key': idempotencyKey,    // ← 핵심
+    },
+    body: JSON.stringify({ title, content }),
+  });
+
+  return response.json();
+};
+```
+
+**주의사항:**
+- 새로운 요청마다 **새 UUID**를 생성해야 한다
+- **재시도** 시에는 **동일한 UUID**를 사용해야 한다
+- UUID는 프론트엔드의 `crypto.randomUUID()` 또는 `uuid` 라이브러리로 생성
+
+### 11.2 cURL로 테스트
+
+```bash
+# UUID 생성
+KEY=$(uuidgen)
+
+# 첫 번째 요청
+curl -X POST http://localhost:3000/posts \
+  -H "Authorization: Bearer <token>" \
+  -H "Idempotency-Key: $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"테스트 게시글","content":"내용"}'
+# → 201 Created { "id": 1 }
+
+# 동일 키로 재요청 (재시도 시뮬레이션)
+curl -X POST http://localhost:3000/posts \
+  -H "Authorization: Bearer <token>" \
+  -H "Idempotency-Key: $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"테스트 게시글","content":"내용"}'
+# → 201 Created { "id": 1 }  ← 동일한 응답, 게시글은 1건만 생성됨
+```
+
+### 11.3 Swagger에서 테스트
+
+Swagger UI(`/api`)에서 `@Idempotent()`가 적용된 엔드포인트에는 `Idempotency-Key` 헤더 입력란이 표시된다. UUID v4 형식의 값을 입력하면 된다.
+
+---
+
+## 12. 에러 케이스 정리
+
+| 상황 | 응답 | 설명 |
+|------|------|------|
+| `Idempotency-Key` 헤더 누락 | `400 Bad Request` | "Idempotency-Key header is required" |
+| 잘못된 UUID 형식 | `400 Bad Request` | "Idempotency-Key must be a valid UUID" |
+| 인증 없이 멱등 엔드포인트 호출 | `401 Unauthorized` | "Idempotent endpoints require authentication" |
+| 동일 키로 동시 요청 (`SET NX` 선점 실패) | `409 Conflict` | "A request with this Idempotency-Key is currently being processed" |
+| 동일 키로 재요청 (캐시 히트) | 원본과 동일한 상태코드 + 본문 | Handler를 실행하지 않고 캐시된 응답 반환 |
+| Handler에서 에러 발생 | 원본 에러 그대로 전달 | 에러 응답은 캐시하지 않음 → 동일 키로 재시도 가능 |
+| TTL 만료 후 동일 키 | 새 요청으로 처리 | 24시간 경과 시 Redis가 자동 삭제하여 새로 실행 |
+| Redis 연결 실패 | `500 Internal Server Error` | Redis가 다운되면 캐시 조회가 실패하며, 이 경우 요청이 통과하지 않음 |
+
+---
+
+## 13. 검증 방법
+
+### 13.1 사전 준비: Redis 실행
+
+```bash
+# Docker로 Redis 실행
+docker run -d --name redis -p 6379:6379 redis:7-alpine
+
+# 또는 Homebrew (macOS)
+brew install redis && brew services start redis
+
+# 연결 확인
+redis-cli ping
+# → PONG
+```
+
+### 13.2 자동화 검증
+
+```bash
+# 1. 빌드 확인
+pnpm build:local
+
+# 2. 단위 테스트
+pnpm test
+
+# 3. 통합 테스트 (Docker 필수)
+pnpm test:e2e
+```
+
+마이그레이션은 불필요하다 — Redis는 스키마 없이 키-값을 즉시 저장한다.
+
+### 13.3 수동 검증 시나리오
+
+| # | 시나리오 | 기대 결과 |
+|---|----------|-----------|
+| 1 | 새 UUID로 POST /posts | 201 Created, 게시글 1건 생성 |
+| 2 | 동일 UUID로 POST /posts 재요청 | 201 Created, 동일 응답, 게시글 여전히 1건 |
+| 3 | Idempotency-Key 헤더 없이 POST /posts | 400 Bad Request |
+| 4 | 잘못된 형식의 키로 POST /posts | 400 Bad Request |
+| 5 | 새 UUID로 PATCH /posts/:id | 204 No Content |
+| 6 | 동일 UUID로 PATCH /posts/:id 재요청 | 204 No Content (Handler 실행 안 함) |
+| 7 | GET /posts (Idempotent 미적용) | Idempotency-Key 헤더 무관하게 정상 동작 |
+
+### 13.4 Redis에서 캐시 확인
+
+```bash
+# Redis CLI로 저장된 캐시 확인
+redis-cli
+> KEYS idempotency:*
+# → "idempotency:1:550e8400-e29b-41d4-a716-446655440000"
+
+> GET "idempotency:1:550e8400-e29b-41d4-a716-446655440000"
+# → {"statusCode":201,"body":{"id":1}}
+
+> TTL "idempotency:1:550e8400-e29b-41d4-a716-446655440000"
+# → 86350  (남은 초)
+```

--- a/docs/idempotency-guide.md
+++ b/docs/idempotency-guide.md
@@ -160,7 +160,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
 }
 ```
 
-우리 프로젝트에서는 이 블로그 패턴을 그대로 따르면서 **사용자별 키 격리**와 **상태코드 보존**을 추가한다.
+우리 프로젝트에서는 블로그의 `cache-manager` 대신 **`ioredis`를 직접 사용**하여 `SET NX` 원자적 선점을 구현하고, **사용자별 키 격리**와 **상태코드 보존**을 추가한다.
 
 ---
 
@@ -272,7 +272,7 @@ Redis를 선택한 이유:
 | 동시성 제어 | `get`/`set` 분리 (비원자적) | `ioredis` `SET NX` (원자적 선점) |
 | 적용 방식 | `@UseInterceptors()` 직접 사용 | `@Idempotent()` 커스텀 데코레이터로 래핑 |
 | TTL | 5분 | 24시간 (Stripe 기본값과 동일) |
-| TTL 단위 | 미명시 | 밀리초 명시 (`_MS` 접미사, cache-manager v5+ 기준) |
+| TTL 단위 | 미명시 | 밀리초 명시 (`_MS` 접미사, ioredis `PX` 옵션 기준) |
 
 ---
 
@@ -293,15 +293,15 @@ Redis를 선택한 이유:
 IdempotencyInterceptor
   │  1. 헤더에서 Idempotency-Key 추출
   │  2. UUID 형식 검증
-  │  3. Redis 조회: cacheManager.get("idempotency:1:550e8400-...") → null
-  │  4. "처리 중" 마커 설정 → next.handle() → Handler 실행
+  │  3. Redis SET NX: redis.set("idempotency:1:550e8400-...", "PROCESSING", NX) → 성공
+  │  4. next.handle() → Handler 실행
   ▼
 CreatePostHandler
   │  게시글 생성 로직 실행
   │  return post.id
   ▼
 IdempotencyInterceptor (응답 후처리 — tap)
-  │  5. Redis 저장: cacheManager.set("idempotency:1:550e8400-...", { statusCode: 201, body: {id: 1} }, TTL)
+  │  5. Redis 저장: redis.set("idempotency:1:550e8400-...", JSON.stringify({statusCode:201, body:{id:1}}), PX, TTL)
   ▼
 클라이언트 ← 201 Created { id: 1 }
 ```
@@ -316,7 +316,7 @@ IdempotencyInterceptor (응답 후처리 — tap)
 IdempotencyInterceptor
   │  1. 헤더에서 Idempotency-Key 추출
   │  2. UUID 형식 검증
-  │  3. Redis 조회: cacheManager.get("idempotency:1:550e8400-...") → { statusCode: 201, body: {id: 1} }
+  │  3. Redis SET NX: redis.set(... NX) → 실패 → redis.get → JSON 파싱 → 캐시 히트
   │  4. 저장된 응답 그대로 반환 (Handler 실행 안 함)
   ▼
 클라이언트 ← 201 Created { id: 1 }  ← 동일한 응답
@@ -326,16 +326,14 @@ IdempotencyInterceptor
 
 ```text
 AppModule
-├── CacheModule (Redis)             ← 신규 — 글로벌 캐시
-├── IdempotencyModule               ← 신규
-│   └── IdempotencyInterceptor      ← 요청 가로채기 + Redis 캐시 확인
+├── IdempotencyModule (@Global)     ← 신규 — REDIS_CLIENT + IdempotencyInterceptor 제공
 ├── PostsModule
 │   └── PostsController
 │       └── @Idempotent()           ← createPost에 적용
 └── ...
 ```
 
-PostgreSQL 방식 대비 구조가 훨씬 간결하다. Entity, Repository, Provider, Cleanup Service가 모두 불필요하다.
+`IdempotencyModule`이 `@Global()`로 등록되어 `REDIS_CLIENT`와 `IdempotencyInterceptor`를 모든 모듈에서 사용할 수 있다. `cache-manager`/`CacheModule`은 사용하지 않는다.
 
 ---
 
@@ -346,9 +344,8 @@ PostgreSQL 방식 대비 구조가 훨씬 간결하다. Entity, Repository, Prov
 | 용어 | 설명 |
 |------|------|
 | **Redis** | 인메모리 데이터 저장소. 키-값 쌍을 매우 빠르게 읽고 쓸 수 있다. TTL(Time-To-Live)을 지원하여 설정한 시간이 지나면 자동으로 데이터가 삭제된다. |
-| **cache-manager** | Node.js의 캐시 추상화 라이브러리. Redis, Memcached, 인메모리 등 다양한 백엔드를 동일한 `get`/`set` API로 사용할 수 있게 해준다. |
-| **CACHE_MANAGER** | NestJS가 `CacheModule`을 통해 제공하는 DI 토큰. `@Inject(CACHE_MANAGER)`로 주입받아 `cache.get(key)`, `cache.set(key, value, ttl)` 메서드를 사용한다. |
-| **cache-manager-redis-store** | `cache-manager`의 Redis 어댑터. `cache-manager`의 `get`/`set` 호출을 Redis 명령어로 변환한다. |
+| **ioredis** | Node.js에서 가장 널리 사용되는 Redis 클라이언트. `SET`, `GET`, `DEL` 등 Redis 명령을 직접 실행할 수 있으며, `SET NX` 같은 원자적 연산도 지원한다. 이 프로젝트에서 Redis와의 모든 통신에 사용한다. |
+| **SET NX** | Redis의 `SET key value NX EX ttl` 명령. `NX` = "Not eXists" — 키가 없을 때만 설정하는 것을 하나의 원자적 연산으로 보장한다. 동시 요청에서 하나만 선점하도록 할 때 사용한다. |
 | **NestJS Interceptor** | Controller 메서드 실행 전후를 감싸는 미들웨어. `intercept(context, next)` 메서드에서 요청을 가로채고, `next.handle()`로 Controller를 실행하며, `pipe(tap(...))`으로 응답을 후처리한다. |
 | **TTL (Time-To-Live)** | 캐시 항목의 유효 시간. TTL이 지나면 Redis가 자동으로 해당 키를 삭제한다. 별도 cleanup 로직이 불필요하다. |
 
@@ -436,7 +433,7 @@ Redis는 단일 스레드로 **개별 명령**을 순서대로 처리하지만, 
                   ↑ 이 시점에 A의 SET이 아직 완료되지 않음
 ```
 
-`cache-manager`의 `get`/`set`은 별도의 Redis 명령이므로 원자적이지 않다. 블로그 원본의 댓글에서도 정확히 이 문제가 지적되었다.
+블로그에서 사용하는 `cache-manager`의 `get`/`set`은 별도의 Redis 명령이므로 원자적이지 않다. 블로그 원본의 댓글에서도 정확히 이 문제가 지적되었다. 이 프로젝트에서는 `ioredis`의 `SET NX`로 해결한다.
 
 ### 8.2 해결: Redis `SET NX` 원자적 선점
 
@@ -448,10 +445,10 @@ Redis의 `SET key value NX EX ttl` 명령은 **키가 없을 때만 설정**하�
 요청 B: SET NX(실패) → GET → 마커 발견 → 409 반환
 ```
 
-`cache-manager`의 `set` 메서드는 `NX` 옵션을 지원하지 않으므로, `ioredis` 클라이언트를 직접 사용한다:
+`ioredis` 클라이언트를 직접 사용한다:
 
 ```typescript
-// ioredis를 직접 사용하여 원자적 선점
+// ioredis의 SET NX로 원자적 선점
 const acquired = await this.redis.set(
   cacheKey,
   PROCESSING_MARKER,
@@ -461,13 +458,14 @@ const acquired = await this.redis.set(
 
 if (!acquired) {
   // 이미 키가 존재 → 캐시 히트이거나 다른 요청이 처리 중
-  const existing = await this.cacheManager.get<string | CachedResponse>(cacheKey);
-  if (existing === PROCESSING_MARKER) {
+  const raw = await this.redis.get(cacheKey);
+  if (raw === PROCESSING_MARKER) {
     throw new ConflictException(
       'A request with this Idempotency-Key is currently being processed',
     );
   }
-  if (existing && typeof existing === 'object') {
+  if (raw) {
+    const existing = JSON.parse(raw) as CachedResponse;
     response.status(existing.statusCode);
     return of(existing.body);
   }
@@ -494,15 +492,15 @@ src/common/idempotency/
 └── idempotency.module.ts              # NestJS 모듈
 ```
 
-PostgreSQL 방식과 비교하면 **Entity, Repository, Provider, Cleanup Service, Migration이 모두 불필요**하다. Redis의 TTL이 만료 처리를 대신하고, `cache-manager`가 데이터 접근을 대신한다.
+PostgreSQL 방식과 비교하면 **Entity, Repository, Provider, Cleanup Service, Migration이 모두 불필요**하다. `ioredis`로 Redis에 직접 접근하며, Redis의 TTL이 만료 처리를 자동으로 수행한다.
 
 ### 9.2 수정 파일
 
 | 파일 | 변경 내용 |
 |------|-----------|
-| `package.json` | `cache-manager`, `@nestjs/cache-manager`, `cache-manager-redis-store` 의존성 추가 |
-| `src/app.module.ts` | `CacheModule.registerAsync()` + `IdempotencyModule` import 추가 |
-| `src/posts/posts.controller.ts` | `createPost`와 `updatePost`에 `@Idempotent()` + `@ApiHeader` 추가 |
+| `package.json` | `ioredis` 의존성 추가 |
+| `src/app.module.ts` | `IdempotencyModule` import 추가 |
+| `src/posts/posts.controller.ts` | `createPost`에 `@Idempotent()` + `@ApiHeader` 추가 |
 | `.env.example` | `REDIS_HOST`, `REDIS_PORT` 추가 |
 
 ---
@@ -512,17 +510,14 @@ PostgreSQL 방식과 비교하면 **Entity, Repository, Provider, Cleanup Servic
 ### Step 1: 의존성 설치
 
 ```bash
-pnpm add cache-manager @nestjs/cache-manager cache-manager-redis-store@^3 ioredis
+pnpm add ioredis
 ```
 
 | 패키지 | 설치 버전 | 역할 |
 |--------|-----------|------|
-| `cache-manager` | `^7.2.8` | 캐시 추상화 라이브러리 — `get`/`set`/`del` API 제공. **v5+는 TTL 단위가 밀리초(ms)** |
-| `@nestjs/cache-manager` | `^3.1.0` | NestJS의 `CacheModule` 제공 — DI를 통해 `CACHE_MANAGER` 토큰 주입. cache-manager v5+와 호환 |
-| `cache-manager-redis-store` | `^3.0.1` | `cache-manager`의 Redis 어댑터 — 실제 Redis와 통신 |
-| `ioredis` | `^5.10.1` | Node.js Redis 클라이언트 — `cache-manager-redis-store`가 내부적으로 사용하며, `SET NX` 원자적 선점에도 직접 사용 |
+| `ioredis` | `^5.10.1` | Node.js Redis 클라이언트. `SET NX` 원자적 선점, `GET`, `DEL` 등 모든 Redis 통신에 직접 사용 |
 
-> **주의:** `cache-manager` v5+는 TTL 단위가 **밀리초(ms)**다. 블로그 원본(v4)의 코드에서 초 단위로 작성된 TTL을 그대로 복사하면 의도보다 1000배 짧게 만료된다. 이 프로젝트에서는 모든 TTL 상수에 `_MS` 접미사를 붙여 혼동을 방지한다.
+> **블로그와의 차이:** 블로그는 `cache-manager` + `@nestjs/cache-manager` + `cache-manager-redis-store`를 사용하지만, 이 프로젝트에서는 `ioredis`만 사용한다. `cache-manager`의 `get`/`set`이 `SET NX` 원자적 선점을 지원하지 않고, `ioredis`와 키 직렬화 방식이 달라 데이터 불일치가 발생할 수 있기 때문이다.
 
 ### Step 2: 환경 변수 추가
 
@@ -536,35 +531,23 @@ REDIS_PORT=6379
 
 `.env.local`, `.env.development`, `.env.production`에도 동일하게 추가한다.
 
-### Step 3: AppModule에 CacheModule 등록
+### Step 3: AppModule에 IdempotencyModule 등록
 
 **파일:** `src/app.module.ts`
 
-블로그에서 제시한 것과 동일한 `CacheModule.registerAsync()` 패턴을 사용한다.
-
 ```typescript
-import { CacheModule } from '@nestjs/cache-manager';
-import * as redisStore from 'cache-manager-redis-store';
+import { IdempotencyModule } from '@src/common/idempotency/idempotency.module';
 
 @Module({
   imports: [
     // ...기존 imports
-    CacheModule.registerAsync({
-      isGlobal: true,
-      useFactory: () => ({
-        store: redisStore,
-        host: process.env.REDIS_HOST || 'localhost',
-        port: parseInt(process.env.REDIS_PORT || '6379', 10),
-        ttl: 1000 * 60 * 60,  // 기본 TTL 1시간 (밀리초, cache-manager v5+) — 안전망
-      }),
-    }),
     IdempotencyModule,    // ← 추가
   ],
 })
 export class AppModule {}
 ```
 
-**`isGlobal: true`**: `CacheModule`을 글로벌로 등록하면 다른 모듈에서 별도 import 없이 `CACHE_MANAGER`를 주입받을 수 있다.
+`IdempotencyModule`은 `@Global()`로 선언되어 있으므로, `AppModule`에 한 번만 import하면 모든 모듈에서 `@Idempotent()` 데코레이터를 사용할 수 있다. Redis 연결(`REDIS_CLIENT`)은 `IdempotencyModule` 내부에서 관리한다.
 
 ### Step 4: `@Idempotent()` 데코레이터 생성
 
@@ -588,7 +571,7 @@ export function Idempotent(): MethodDecorator {
 
 **파일:** `src/common/idempotency/idempotency.interceptor.ts`
 
-블로그의 `@Inject(CACHE_MANAGER)` 패턴을 그대로 따르되, userId 스코핑과 상태코드 보존을 추가한다.
+`ioredis`를 직접 사용하여 모든 Redis 통신을 통일한다. 블로그의 `cache-manager` 패턴 대신 `ioredis`의 `SET NX`로 원자적 선점을 구현하고, `GET`/`SET`/`DEL`도 모두 `ioredis`로 처리한다.
 
 ```typescript
 import {
@@ -601,8 +584,6 @@ import {
   NestInterceptor,
   UnauthorizedException,
 } from '@nestjs/common';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import type { Cache } from 'cache-manager';       // type import — emitDecoratorMetadata 호환
 import { Request, Response } from 'express';
 import { from, Observable, of, throwError } from 'rxjs';
 import { catchError, switchMap, tap } from 'rxjs/operators';
@@ -616,13 +597,12 @@ interface CachedResponse {
 }
 
 const PROCESSING_MARKER = '__PROCESSING__';
-const IDEMPOTENCY_TTL_MS = 1000 * 60 * 60 * 24;  // 24시간 (밀리초, cache-manager v5+ 기준)
+const IDEMPOTENCY_TTL_MS = 1000 * 60 * 60 * 24;  // 24시간 (밀리초, ioredis PX 옵션 기준)
 const PROCESSING_TTL_SEC = 60;                     // ioredis SET NX의 EX 옵션은 초 단위
 
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
   constructor(
-    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     @Inject('REDIS_CLIENT') private readonly redis: Redis,
     private readonly logger: PinoLogger,
   ) {
@@ -664,31 +644,36 @@ export class IdempotencyInterceptor implements NestInterceptor {
 
     if (!acquired) {
       // 이미 키가 존재 → 캐시 히트이거나 다른 요청이 처리 중
-      const existing = await this.cacheManager.get<string | CachedResponse>(cacheKey);
-      if (existing === PROCESSING_MARKER) {
+      const raw = await this.redis.get(cacheKey);
+      if (raw === PROCESSING_MARKER) {
         throw new ConflictException(
           'A request with this Idempotency-Key is currently being processed',
         );
       }
-      if (existing && typeof existing === 'object') {
+      if (raw) {
+        const existing = JSON.parse(raw) as CachedResponse;
         this.logger.info({ cacheKey }, 'Idempotency cache hit — returning cached response');
         response.status(existing.statusCode);
         return of(existing.body);
       }
     }
 
-    // 3. Handler 실행 + 응답 저장
+    // 3. Handler 실행 + 응답 저장 (ioredis로 통일)
     return next.handle().pipe(
       tap((responseBody: unknown) => {
         const cachedValue: CachedResponse = {
           statusCode: response.statusCode,
           body: (responseBody as Record<string, unknown>) ?? null,
         };
-        void this.cacheManager.set(cacheKey, cachedValue, IDEMPOTENCY_TTL_MS);
+        void this.redis.set(
+          cacheKey,
+          JSON.stringify(cachedValue),
+          'PX', IDEMPOTENCY_TTL_MS,
+        );
         this.logger.info({ cacheKey, statusCode: response.statusCode }, 'Idempotency response cached');
       }),
       catchError((error: Error) => {
-        return from(this.cacheManager.del(cacheKey)).pipe(
+        return from(this.redis.del(cacheKey)).pipe(
           switchMap(() => throwError(() => error)),
         );
       }),
@@ -704,6 +689,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
 | 캐시 키 | `idempotencyKey` | `idempotency:${userId}:${idempotencyKey}` | 사용자 A와 B가 같은 UUID를 쓸 경우 충돌 방지 |
 | 캐시 값 | `response` (본문만) | `{ statusCode, body }` (객체) | 201, 204 등 원래 상태코드를 정확히 재현 |
 | TTL | `60 * 5` (5분, 초) | `IDEMPOTENCY_TTL_MS = 86400000` (24시간, 밀리초) | Stripe 기본값과 동일. 상수명에 단위(`_MS`) 명시 |
+| Redis 클라이언트 | `cache-manager` (추상화) | `ioredis` (직접 사용) | `SET NX` 원자적 선점 + 키 직렬화 일관성 |
 | 선점 | `get` → `set` (비원자적) | `ioredis` `SET NX` (원자적) | `get`/`set` 사이 race condition 방지 |
 | 인증 | 없음 | `userId` 누락 시 `401` | 캐시 키에 `undefined` 삽입 방지 |
 | 에러 처리 | 없음 | `catchError` → `from()` + `throwError()` | RxJS에서 올바르게 Observable 반환 |
@@ -737,7 +723,7 @@ export class IdempotencyModule {}
 
 - `@Global()` — 다른 모듈에서 별도 import 없이 `REDIS_CLIENT`와 `IdempotencyInterceptor`를 주입받을 수 있다. `@UseInterceptors()`는 Controller가 속한 모듈의 DI 컨텍스트에서 의존성을 해결하므로, 글로벌 등록이 필수다.
 - `exports: ['REDIS_CLIENT', ...]` — `REDIS_CLIENT`를 export해야 `IdempotencyInterceptor`가 다른 모듈에서 인스턴스화될 때 주입받을 수 있다.
-- `CACHE_MANAGER`는 `AppModule`의 글로벌 `CacheModule`에서 주입되므로 별도 import가 불필요하다.
+- `REDIS_CLIENT`는 `IdempotencyModule` 내부에서 `ioredis` 인스턴스로 생성되며, `@Global()`로 모든 모듈에서 접근 가능하다.
 
 ### Step 7: Controller에 적용
 

--- a/docs/idempotency-guide.md
+++ b/docs/idempotency-guide.md
@@ -616,7 +616,8 @@ export class IdempotencyInterceptor implements NestInterceptor {
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest<Request>();
     const response = httpContext.getResponse<Response>();
-    const idempotencyKey = request.headers['idempotency-key'] as string;
+    const rawHeader = request.headers['idempotency-key'];
+    const idempotencyKey = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
 
     // 1. 헤더 검증
     if (!idempotencyKey) {
@@ -651,11 +652,20 @@ export class IdempotencyInterceptor implements NestInterceptor {
         );
       }
       if (raw) {
-        const existing = JSON.parse(raw) as CachedResponse;
-        this.logger.info({ cacheKey }, 'Idempotency cache hit — returning cached response');
-        response.status(existing.statusCode);
-        return of(existing.body);
+        try {
+          const existing = JSON.parse(raw) as CachedResponse;
+          this.logger.info({ cacheKey }, 'Idempotency cache hit — returning cached response');
+          response.status(existing.statusCode);
+          return of(existing.body);
+        } catch {
+          this.logger.warn({ cacheKey }, 'Corrupted cache entry, reprocessing');
+          await this.redis.del(cacheKey);
+        }
       }
+      // SET NX 실패 후 GET이 null (키가 두 명령 사이에 만료됨) → 409로 안전하게 차단
+      throw new ConflictException(
+        'A request with this Idempotency-Key is currently being processed',
+      );
     }
 
     // 3. Handler 실행 + 응답 저장 (ioredis로 통일)

--- a/docs/idempotency-guide.md
+++ b/docs/idempotency-guide.md
@@ -51,7 +51,7 @@
 
 ### 1.2 결제 시나리오에서의 위험
 
-```
+```text
 1. 사용자가 "결제하기" 버튼 클릭
 2. 요청이 서버로 전송됨 (네트워크 느림)
 3. 사용자가 응답이 없다고 생각하여 다시 클릭
@@ -93,7 +93,7 @@ Stripe, PayPal 같은 결제 API에서 널리 사용하는 업계 표준 패턴�
 
 ### 3.1 기본 원리
 
-```
+```text
 [클라이언트]                          [서버]
     |                                  |
     |  POST /posts                     |
@@ -228,7 +228,7 @@ PostgreSQL의 Advisory Lock으로 동일 리소스에 대한 동시 쓰기를 �
 
 ### 5.1 핵심 차별점: "에러 반환" vs "성공 응답 재생"
 
-```
+```text
 [Deduplication Guard]
   첫 번째 요청 → 201 Created {id: 1}
   두 번째 요청 → 409 Conflict ❌  ← 클라이언트는 에러 처리 필요
@@ -383,7 +383,7 @@ GET 요청은 이미 멱등하므로 불필요하다. `@Idempotent()`를 메서�
 
 NestJS의 Interceptor는 Controller 메서드 실행 **전후**를 감싸는 미들웨어다:
 
-```
+```text
 요청 → [Interceptor 전처리] → [Controller] → [Interceptor 후처리] → 응답
 ```
 
@@ -412,7 +412,7 @@ interface CachedResponse {
 Redis 키 형식: `idempotency:{userId}:{uuid}`
 
 예시:
-```
+```text
 키:   "idempotency:1:550e8400-e29b-41d4-a716-446655440000"
 값:   { "statusCode": 201, "body": { "id": 1 } }
 TTL:  86400000ms (24시간)
@@ -426,7 +426,7 @@ TTL:  86400000ms (24시간)
 
 Redis는 단일 스레드로 **개별 명령**을 순서대로 처리하지만, NestJS 서버에서 `GET` → `SET` 두 명령을 **분리하여** 실행하면 그 사이에 다른 요청이 끼어들 수 있다.
 
-```
+```text
 시간 →
 요청 A: GET(없음) ─────────────────── SET("PROCESSING") → Handler 실행
 요청 B:           GET(없음) ────────── SET("PROCESSING") → Handler 실행  ← 중복!
@@ -439,7 +439,7 @@ Redis는 단일 스레드로 **개별 명령**을 순서대로 처리하지만, 
 
 Redis의 `SET key value NX EX ttl` 명령은 **키가 없을 때만 설정**하는 것을 **하나의 원자적 연산**으로 보장한다. `NX` = "Not eXists".
 
-```
+```text
 시간 →
 요청 A: SET NX(성공, "PROCESSING") → Handler 실행 → SET(응답) → 반환
 요청 B: SET NX(실패) → GET → 마커 발견 → 409 반환
@@ -484,7 +484,7 @@ if (!acquired) {
 
 ### 9.1 신규 파일
 
-```
+```text
 src/common/idempotency/
 ├── decorator/
 │   └── idempotent.decorator.ts        # @Idempotent() 메서드 데코레이터

--- a/docs/idempotency-guide.md
+++ b/docs/idempotency-guide.md
@@ -331,7 +331,7 @@ AppModule
 │   └── IdempotencyInterceptor      ← 요청 가로채기 + Redis 캐시 확인
 ├── PostsModule
 │   └── PostsController
-│       └── @Idempotent()           ← createPost, updatePost에 적용
+│       └── @Idempotent()           ← createPost에 적용
 └── ...
 ```
 
@@ -602,11 +602,12 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Cache } from 'cache-manager';
+import type { Cache } from 'cache-manager';       // type import — emitDecoratorMetadata 호환
+import { Request, Response } from 'express';
 import { from, Observable, of, throwError } from 'rxjs';
 import { catchError, switchMap, tap } from 'rxjs/operators';
 import { isUUID } from 'class-validator';
-import Redis from 'ioredis';
+import type Redis from 'ioredis';                  // type import — emitDecoratorMetadata 호환
 import { PinoLogger } from 'nestjs-pino';
 
 interface CachedResponse {
@@ -633,8 +634,8 @@ export class IdempotencyInterceptor implements NestInterceptor {
     next: CallHandler,
   ): Promise<Observable<unknown>> {
     const httpContext = context.switchToHttp();
-    const request = httpContext.getRequest();
-    const response = httpContext.getResponse();
+    const request = httpContext.getRequest<Request>();
+    const response = httpContext.getResponse<Response>();
     const idempotencyKey = request.headers['idempotency-key'] as string;
 
     // 1. 헤더 검증
@@ -645,7 +646,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
       throw new BadRequestException('Idempotency-Key must be a valid UUID');
     }
 
-    const userId = request.user?.id;
+    const userId = (request as Request & { user?: { id?: number } }).user?.id;
     if (!userId) {
       throw new UnauthorizedException(
         'Idempotent endpoints require authentication',
@@ -653,24 +654,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
     }
     const cacheKey = `idempotency:${userId}:${idempotencyKey}`;
 
-    // 2. Redis 캐시 조회 (블로그: cacheManager.get)
-    const cached = await this.cacheManager.get<string | CachedResponse>(cacheKey);
-
-    // 2-a. "처리 중" 마커 → 동시 요청 차단
-    if (cached === PROCESSING_MARKER) {
-      throw new ConflictException(
-        'A request with this Idempotency-Key is currently being processed',
-      );
-    }
-
-    // 2-b. 캐시 히트 → 저장된 응답 반환
-    if (cached && typeof cached === 'object') {
-      this.logger.info({ cacheKey }, 'Idempotency cache hit — returning cached response');
-      response.status(cached.statusCode);
-      return of(cached.body);
-    }
-
-    // 3. 원자적 선점: SET NX (ioredis 직접 사용)
+    // 2. 원자적 선점: SET NX (ioredis 직접 사용)
     const acquired = await this.redis.set(
       cacheKey,
       PROCESSING_MARKER,
@@ -693,19 +677,17 @@ export class IdempotencyInterceptor implements NestInterceptor {
       }
     }
 
-    // 4. Handler 실행 + 응답 저장 (블로그: next.handle().pipe(tap(...)))
+    // 3. Handler 실행 + 응답 저장
     return next.handle().pipe(
-      tap(async (responseBody) => {
+      tap((responseBody: unknown) => {
         const cachedValue: CachedResponse = {
           statusCode: response.statusCode,
-          body: responseBody ?? null,
+          body: (responseBody as Record<string, unknown>) ?? null,
         };
-        await this.cacheManager.set(cacheKey, cachedValue, IDEMPOTENCY_TTL_MS);
+        void this.cacheManager.set(cacheKey, cachedValue, IDEMPOTENCY_TTL_MS);
         this.logger.info({ cacheKey, statusCode: response.statusCode }, 'Idempotency response cached');
       }),
-      catchError((error) => {
-        // 에러 시 마커 제거 → 동일 키로 재시도 가능
-        // from()으로 Promise를 Observable로 변환 후 switchMap으로 에러 재전파
+      catchError((error: Error) => {
         return from(this.cacheManager.del(cacheKey)).pipe(
           switchMap(() => throwError(() => error)),
         );
@@ -731,10 +713,11 @@ export class IdempotencyInterceptor implements NestInterceptor {
 **파일:** `src/common/idempotency/idempotency.module.ts`
 
 ```typescript
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import Redis from 'ioredis';
 import { IdempotencyInterceptor } from './idempotency.interceptor';
 
+@Global()
 @Module({
   providers: [
     {
@@ -747,12 +730,14 @@ import { IdempotencyInterceptor } from './idempotency.interceptor';
     },
     IdempotencyInterceptor,
   ],
-  exports: [IdempotencyInterceptor],
+  exports: ['REDIS_CLIENT', IdempotencyInterceptor],
 })
 export class IdempotencyModule {}
 ```
 
-`REDIS_CLIENT`는 `SET NX` 원자적 선점에 사용하는 `ioredis` 인스턴스다. `CACHE_MANAGER`는 글로벌 `CacheModule`에서 주입되므로 별도 import가 불필요하다.
+- `@Global()` — 다른 모듈에서 별도 import 없이 `REDIS_CLIENT`와 `IdempotencyInterceptor`를 주입받을 수 있다. `@UseInterceptors()`는 Controller가 속한 모듈의 DI 컨텍스트에서 의존성을 해결하므로, 글로벌 등록이 필수다.
+- `exports: ['REDIS_CLIENT', ...]` — `REDIS_CLIENT`를 export해야 `IdempotencyInterceptor`가 다른 모듈에서 인스턴스화될 때 주입받을 수 있다.
+- `CACHE_MANAGER`는 `AppModule`의 글로벌 `CacheModule`에서 주입되므로 별도 import가 불필요하다.
 
 ### Step 7: Controller에 적용
 
@@ -768,14 +753,6 @@ import { ApiHeader } from '@nestjs/swagger';
 @ApiHeader({ name: 'Idempotency-Key', required: true, description: 'UUID v4 형식의 멱등성 키' })
 @ApiOperation({ summary: '게시글 생성' })
 async createPost(...) { ... }
-
-// updatePost에 적용
-@Patch(':id')
-@Idempotent()
-@ApiHeader({ name: 'Idempotency-Key', required: true, description: 'UUID v4 형식의 멱등성 키' })
-@HttpCode(HttpStatus.NO_CONTENT)
-@ApiOperation({ summary: '게시글 수정 (전체 업데이트)' })
-async updatePost(...) { ... }
 ```
 
 **PATCH 적용 판단 기준:**
@@ -906,9 +883,8 @@ pnpm test:e2e
 | 2 | 동일 UUID로 POST /posts 재요청 | 201 Created, 동일 응답, 게시글 여전히 1건 |
 | 3 | Idempotency-Key 헤더 없이 POST /posts | 400 Bad Request |
 | 4 | 잘못된 형식의 키로 POST /posts | 400 Bad Request |
-| 5 | 새 UUID로 PATCH /posts/:id | 204 No Content |
-| 6 | 동일 UUID로 PATCH /posts/:id 재요청 | 204 No Content (Handler 실행 안 함) |
-| 7 | GET /posts (Idempotent 미적용) | Idempotency-Key 헤더 무관하게 정상 동작 |
+| 5 | GET /posts (Idempotent 미적용) | Idempotency-Key 헤더 무관하게 정상 동작 |
+| 6 | PATCH /posts/:id (Idempotent 미적용) | Idempotency-Key 헤더 무관하게 정상 동작 |
 
 ### 13.4 Redis에서 캐시 확인
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "migration:create": "typeorm migration:create"
   },
   "dependencies": {
-    "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.1.17",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.1.17",
@@ -47,8 +46,6 @@
     "@nestjs/typeorm": "^11.0.0",
     "@slack/web-api": "^7.15.0",
     "bcrypt": "^6.0.0",
-    "cache-manager": "^7.2.8",
-    "cache-manager-redis-store": "^3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.4",
     "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "migration:create": "typeorm migration:create"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.1.17",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.1.17",
@@ -46,9 +47,12 @@
     "@nestjs/typeorm": "^11.0.0",
     "@slack/web-api": "^7.15.0",
     "bcrypt": "^6.0.0",
+    "cache-manager": "^7.2.8",
+    "cache-manager-redis-store": "^3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.4",
     "dotenv": "^17.3.1",
+    "ioredis": "^5.10.1",
     "nestjs-pino": "^4.6.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@nestjs/cache-manager':
-        specifier: ^3.1.0
-        version: 3.1.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.1.17
         version: 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -47,12 +44,6 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
-      cache-manager:
-        specifier: ^7.2.8
-        version: 7.2.8
-      cache-manager-redis-store:
-        specifier: ^3
-        version: 3.0.1
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -384,9 +375,6 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
-
-  '@cacheable/utils@2.4.1':
-    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -746,9 +734,6 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@keyv/serialize@1.1.1':
-    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
-
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -761,15 +746,6 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
-
-  '@nestjs/cache-manager@3.1.0':
-    resolution: {integrity: sha512-pEIqYZrBcE8UdkJmZRduurvoUfdU+3kRPeO1R2muiMbZnRuqlki5klFFNllO9LyYWzrx98bd1j0PSPKSJk1Wbw==}
-    peerDependencies:
-      '@nestjs/common': ^9.0.0 || ^10.0.0 || ^11.0.0
-      '@nestjs/core': ^9.0.0 || ^10.0.0 || ^11.0.0
-      cache-manager: '>=6'
-      keyv: '>=5'
-      rxjs: ^7.8.1
 
   '@nestjs/cli@11.0.16':
     resolution: {integrity: sha512-P0H+Vcjki6P5160E5QnMt3Q0X5FTg4PZkP99Ig4lm/4JWqfw32j3EXv3YBTJ2DmxLwOQ/IS9F7dzKpMAgzKTGg==}
@@ -1713,13 +1689,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  cache-manager-redis-store@3.0.1:
-    resolution: {integrity: sha512-o560kw+dFqusC9lQJhcm6L2F2fMKobJ5af+FoR2PdnMVdpQ3f3Bz6qzvObTGyvoazQJxjQNWgMQeChP4vRTuXQ==}
-    engines: {node: '>= 16.18.0'}
-
-  cache-manager@7.2.8:
-    resolution: {integrity: sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2453,19 +2422,12 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hashery@1.5.1:
-    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
-    engines: {node: '>=20'}
-
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
-
-  hookified@1.15.1:
-    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2800,9 +2762,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  keyv@5.6.0:
-    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -4367,11 +4326,6 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@cacheable/utils@2.4.1':
-    dependencies:
-      hashery: 1.5.1
-      keyv: 5.6.0
-
   '@colors/colors@1.5.0':
     optional: true
 
@@ -4844,8 +4798,6 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@keyv/serialize@1.1.1': {}
-
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -4862,14 +4814,6 @@ snapshots:
       '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
     optional: true
-
-  '@nestjs/cache-manager@3.1.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)':
-    dependencies:
-      '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      cache-manager: 7.2.8
-      keyv: 5.6.0
-      rxjs: 7.8.2
 
   '@nestjs/cli@11.0.16(@types/node@25.5.0)':
     dependencies:
@@ -5075,28 +5019,34 @@ snapshots:
   '@redis/bloom@1.2.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
+    optional: true
 
   '@redis/client@1.6.1':
     dependencies:
       cluster-key-slot: 1.1.2
       generic-pool: 3.9.0
       yallist: 4.0.0
+    optional: true
 
   '@redis/graph@1.1.1(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
+    optional: true
 
   '@redis/json@1.0.7(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
+    optional: true
 
   '@redis/search@1.2.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
+    optional: true
 
   '@redis/time-series@1.1.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
+    optional: true
 
   '@scarf/scarf@1.4.0': {}
 
@@ -5910,15 +5860,6 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  cache-manager-redis-store@3.0.1:
-    dependencies:
-      redis: 4.7.1
-
-  cache-manager@7.2.8:
-    dependencies:
-      '@cacheable/utils': 2.4.1
-      keyv: 5.6.0
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6565,7 +6506,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  generic-pool@3.9.0: {}
+  generic-pool@3.9.0:
+    optional: true
 
   gensync@1.0.0-beta.2: {}
 
@@ -6671,17 +6613,11 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hashery@1.5.1:
-    dependencies:
-      hookified: 1.15.1
-
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
   help-me@5.0.0: {}
-
-  hookified@1.15.1: {}
 
   html-escaper@2.0.2: {}
 
@@ -7198,10 +7134,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  keyv@5.6.0:
-    dependencies:
-      '@keyv/serialize': 1.1.1
 
   lazystream@1.0.1:
     dependencies:
@@ -7765,6 +7697,7 @@ snapshots:
       '@redis/json': 1.0.7(@redis/client@1.6.1)
       '@redis/search': 1.2.0(@redis/client@1.6.1)
       '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+    optional: true
 
   reflect-metadata@0.2.2: {}
 
@@ -8517,7 +8450,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@4.0.0: {}
+  yallist@4.0.0:
+    optional: true
 
   yaml@2.8.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@nestjs/cache-manager':
+        specifier: ^3.1.0
+        version: 3.1.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.1.17
         version: 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -37,13 +40,19 @@ importers:
         version: 11.2.6(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))
+        version: 11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))
       '@slack/web-api':
         specifier: ^7.15.0
         version: 7.15.0
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      cache-manager:
+        specifier: ^7.2.8
+        version: 7.2.8
+      cache-manager-redis-store:
+        specifier: ^3
+        version: 3.0.1
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -53,6 +62,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       nestjs-pino:
         specifier: ^4.6.1
         version: 4.6.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(pino-http@11.0.0)(pino@10.3.1)(rxjs@7.8.2)
@@ -76,7 +88,7 @@ importers:
         version: 7.8.2
       typeorm:
         specifier: ^0.3.28
-        version: 0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.5
@@ -373,6 +385,9 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@cacheable/utils@2.4.1':
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -609,6 +624,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -728,6 +746,9 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -740,6 +761,15 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@nestjs/cache-manager@3.1.0':
+    resolution: {integrity: sha512-pEIqYZrBcE8UdkJmZRduurvoUfdU+3kRPeO1R2muiMbZnRuqlki5klFFNllO9LyYWzrx98bd1j0PSPKSJk1Wbw==}
+    peerDependencies:
+      '@nestjs/common': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^9.0.0 || ^10.0.0 || ^11.0.0
+      cache-manager: '>=6'
+      keyv: '>=5'
+      rxjs: ^7.8.1
 
   '@nestjs/cli@11.0.16':
     resolution: {integrity: sha512-P0H+Vcjki6P5160E5QnMt3Q0X5FTg4PZkP99Ig4lm/4JWqfw32j3EXv3YBTJ2DmxLwOQ/IS9F7dzKpMAgzKTGg==}
@@ -943,6 +973,35 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
@@ -1654,6 +1713,13 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cache-manager-redis-store@3.0.1:
+    resolution: {integrity: sha512-o560kw+dFqusC9lQJhcm6L2F2fMKobJ5af+FoR2PdnMVdpQ3f3Bz6qzvObTGyvoazQJxjQNWgMQeChP4vRTuXQ==}
+    engines: {node: '>= 16.18.0'}
+
+  cache-manager@7.2.8:
+    resolution: {integrity: sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1743,6 +1809,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -1901,6 +1971,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2281,6 +2355,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2375,12 +2453,19 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2427,6 +2512,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2712,6 +2801,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
@@ -2749,8 +2841,14 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -3297,6 +3395,17 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -3485,6 +3594,9 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -3974,6 +4086,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
@@ -4252,6 +4367,11 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@cacheable/utils@2.4.1':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -4495,6 +4615,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
+  '@ioredis/commands@1.5.1': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4722,6 +4844,8 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@keyv/serialize@1.1.1': {}
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -4738,6 +4862,14 @@ snapshots:
       '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nestjs/cache-manager@3.1.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cache-manager: 7.2.8
+      keyv: 5.6.0
+      rxjs: 7.8.2
 
   '@nestjs/cli@11.0.16(@types/node@25.5.0)':
     dependencies:
@@ -4880,13 +5012,13 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
-      typeorm: 0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      typeorm: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
 
   '@noble/hashes@1.8.0': {}
 
@@ -4939,6 +5071,32 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
 
   '@scarf/scarf@1.4.0': {}
 
@@ -5752,6 +5910,15 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cache-manager-redis-store@3.0.1:
+    dependencies:
+      redis: 4.7.1
+
+  cache-manager@7.2.8:
+    dependencies:
+      '@cacheable/utils': 2.4.1
+      keyv: 5.6.0
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -5839,6 +6006,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
+
+  cluster-key-slot@1.1.2: {}
 
   co@4.6.0: {}
 
@@ -5968,6 +6137,8 @@ snapshots:
       gopd: 1.2.0
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -6394,6 +6565,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generic-pool@3.9.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -6498,11 +6671,17 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
   help-me@5.0.0: {}
+
+  hookified@1.15.1: {}
 
   html-escaper@2.0.2: {}
 
@@ -6544,6 +6723,20 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ipaddr.js@1.9.1: {}
 
@@ -7006,6 +7199,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
@@ -7035,7 +7232,11 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -7550,6 +7751,21 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
   reflect-metadata@0.2.2: {}
 
   require-directory@2.1.1: {}
@@ -7752,6 +7968,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 
@@ -8089,7 +8307,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typeorm@0.3.28(pg@8.20.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
+  typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0
@@ -8107,7 +8325,9 @@ snapshots:
       uuid: 11.1.0
       yargs: 17.7.2
     optionalDependencies:
+      ioredis: 5.10.1
       pg: 8.20.0
+      redis: 4.7.1
       ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -8296,6 +8516,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.8.2: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,7 @@
 import { Module } from '@nestjs/common';
-import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import * as redisStore from 'cache-manager-redis-store';
 import { createDataSourceOptions } from '@src/database/typeorm.config';
 import { LoggingModule } from '@src/common/logging/logging.module';
 import { IdempotencyModule } from '@src/common/idempotency/idempotency.module';
@@ -17,15 +15,6 @@ const nodeEnv = process.env.NODE_ENV || 'local';
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: `.env.${nodeEnv}`,
-    }),
-    CacheModule.registerAsync({
-      isGlobal: true,
-      useFactory: () => ({
-        store: redisStore,
-        host: process.env.REDIS_HOST || 'localhost',
-        port: parseInt(process.env.REDIS_PORT || '6379', 10),
-        ttl: 1000 * 60 * 60,
-      }),
     }),
     EventEmitterModule.forRoot(),
     LoggingModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import * as redisStore from 'cache-manager-redis-store';
 import { createDataSourceOptions } from '@src/database/typeorm.config';
 import { LoggingModule } from '@src/common/logging/logging.module';
+import { IdempotencyModule } from '@src/common/idempotency/idempotency.module';
 import { PostsModule } from '@src/posts/posts.module';
 import { AuthModule } from '@src/auth/auth.module';
 
@@ -15,8 +18,18 @@ const nodeEnv = process.env.NODE_ENV || 'local';
       isGlobal: true,
       envFilePath: `.env.${nodeEnv}`,
     }),
+    CacheModule.registerAsync({
+      isGlobal: true,
+      useFactory: () => ({
+        store: redisStore,
+        host: process.env.REDIS_HOST || 'localhost',
+        port: parseInt(process.env.REDIS_PORT || '6379', 10),
+        ttl: 1000 * 60 * 60,
+      }),
+    }),
     EventEmitterModule.forRoot(),
     LoggingModule,
+    IdempotencyModule,
     TypeOrmModule.forRootAsync({
       useFactory: () => ({
         ...createDataSourceOptions(process.env),

--- a/src/common/idempotency/decorator/idempotent.decorator.ts
+++ b/src/common/idempotency/decorator/idempotent.decorator.ts
@@ -1,11 +1,6 @@
-import { applyDecorators, SetMetadata, UseInterceptors } from '@nestjs/common';
+import { UseInterceptors } from '@nestjs/common';
 import { IdempotencyInterceptor } from '../idempotency.interceptor';
 
-export const IDEMPOTENT_KEY = 'isIdempotent';
-
 export function Idempotent(): MethodDecorator {
-  return applyDecorators(
-    SetMetadata(IDEMPOTENT_KEY, true),
-    UseInterceptors(IdempotencyInterceptor),
-  );
+  return UseInterceptors(IdempotencyInterceptor);
 }

--- a/src/common/idempotency/decorator/idempotent.decorator.ts
+++ b/src/common/idempotency/decorator/idempotent.decorator.ts
@@ -1,0 +1,11 @@
+import { applyDecorators, SetMetadata, UseInterceptors } from '@nestjs/common';
+import { IdempotencyInterceptor } from '../idempotency.interceptor';
+
+export const IDEMPOTENT_KEY = 'isIdempotent';
+
+export function Idempotent(): MethodDecorator {
+  return applyDecorators(
+    SetMetadata(IDEMPOTENT_KEY, true),
+    UseInterceptors(IdempotencyInterceptor),
+  );
+}

--- a/src/common/idempotency/idempotency.interceptor.ts
+++ b/src/common/idempotency/idempotency.interceptor.ts
@@ -40,7 +40,8 @@ export class IdempotencyInterceptor implements NestInterceptor {
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest<Request>();
     const response = httpContext.getResponse<Response>();
-    const idempotencyKey = request.headers['idempotency-key'] as string;
+    const rawHeader = request.headers['idempotency-key'];
+    const idempotencyKey = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
 
     // 1. 헤더 검증
     if (!idempotencyKey) {
@@ -76,13 +77,18 @@ export class IdempotencyInterceptor implements NestInterceptor {
         );
       }
       if (raw) {
-        const existing = JSON.parse(raw) as CachedResponse;
-        this.logger.info(
-          { cacheKey },
-          'Idempotency cache hit — returning cached response',
-        );
-        response.status(existing.statusCode);
-        return of(existing.body);
+        try {
+          const existing = JSON.parse(raw) as CachedResponse;
+          this.logger.info(
+            { cacheKey },
+            'Idempotency cache hit — returning cached response',
+          );
+          response.status(existing.statusCode);
+          return of(existing.body);
+        } catch {
+          this.logger.warn({ cacheKey }, 'Corrupted cache entry, reprocessing');
+          await this.redis.del(cacheKey);
+        }
       }
       // SET NX 실패 후 GET이 null (키가 두 명령 사이에 만료됨) → 409로 안전하게 차단
       throw new ConflictException(

--- a/src/common/idempotency/idempotency.interceptor.ts
+++ b/src/common/idempotency/idempotency.interceptor.ts
@@ -8,8 +8,6 @@ import {
   NestInterceptor,
   UnauthorizedException,
 } from '@nestjs/common';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import type { Cache } from 'cache-manager';
 import { Request, Response } from 'express';
 import { from, Observable, of, throwError } from 'rxjs';
 import { catchError, switchMap, tap } from 'rxjs/operators';
@@ -29,7 +27,6 @@ const PROCESSING_TTL_SEC = 60; // ioredis SET NX의 EX 옵션은 초 단위
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
   constructor(
-    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     @Inject('REDIS_CLIENT') private readonly redis: Redis,
     private readonly logger: PinoLogger,
   ) {
@@ -72,15 +69,14 @@ export class IdempotencyInterceptor implements NestInterceptor {
 
     if (!acquired) {
       // 이미 키가 존재 → 캐시 히트이거나 다른 요청이 처리 중
-      const existing = await this.cacheManager.get<string | CachedResponse>(
-        cacheKey,
-      );
-      if (existing === PROCESSING_MARKER) {
+      const raw = await this.redis.get(cacheKey);
+      if (raw === PROCESSING_MARKER) {
         throw new ConflictException(
           'A request with this Idempotency-Key is currently being processed',
         );
       }
-      if (existing && typeof existing === 'object') {
+      if (raw) {
+        const existing = JSON.parse(raw) as CachedResponse;
         this.logger.info(
           { cacheKey },
           'Idempotency cache hit — returning cached response',
@@ -90,21 +86,26 @@ export class IdempotencyInterceptor implements NestInterceptor {
       }
     }
 
-    // 3. Handler 실행 + 응답 저장
+    // 3. Handler 실행 + 응답 저장 (ioredis로 통일 — cache-manager와 키 직렬화 불일치 방지)
     return next.handle().pipe(
       tap((responseBody: unknown) => {
         const cachedValue: CachedResponse = {
           statusCode: response.statusCode,
           body: (responseBody as Record<string, unknown>) ?? null,
         };
-        void this.cacheManager.set(cacheKey, cachedValue, IDEMPOTENCY_TTL_MS);
+        void this.redis.set(
+          cacheKey,
+          JSON.stringify(cachedValue),
+          'PX',
+          IDEMPOTENCY_TTL_MS,
+        );
         this.logger.info(
           { cacheKey, statusCode: response.statusCode },
           'Idempotency response cached',
         );
       }),
       catchError((error: Error) => {
-        return from(this.cacheManager.del(cacheKey)).pipe(
+        return from(this.redis.del(cacheKey)).pipe(
           switchMap(() => throwError(() => error)),
         );
       }),

--- a/src/common/idempotency/idempotency.interceptor.ts
+++ b/src/common/idempotency/idempotency.interceptor.ts
@@ -21,7 +21,7 @@ interface CachedResponse {
 }
 
 const PROCESSING_MARKER = '__PROCESSING__';
-const IDEMPOTENCY_TTL_MS = 1000 * 60 * 60 * 24; // 24시간 (밀리초, cache-manager v5+ 기준)
+const IDEMPOTENCY_TTL_MS = 1000 * 60 * 60 * 24; // 24시간 (밀리초, ioredis PX 옵션 기준)
 const PROCESSING_TTL_SEC = 60; // ioredis SET NX의 EX 옵션은 초 단위
 
 @Injectable()
@@ -84,21 +84,27 @@ export class IdempotencyInterceptor implements NestInterceptor {
         response.status(existing.statusCode);
         return of(existing.body);
       }
+      // SET NX 실패 후 GET이 null (키가 두 명령 사이에 만료됨) → 409로 안전하게 차단
+      throw new ConflictException(
+        'A request with this Idempotency-Key is currently being processed',
+      );
     }
 
-    // 3. Handler 실행 + 응답 저장 (ioredis로 통일 — cache-manager와 키 직렬화 불일치 방지)
+    // 3. Handler 실행 + 응답 저장
     return next.handle().pipe(
       tap((responseBody: unknown) => {
         const cachedValue: CachedResponse = {
           statusCode: response.statusCode,
           body: (responseBody as Record<string, unknown>) ?? null,
         };
-        void this.redis.set(
-          cacheKey,
-          JSON.stringify(cachedValue),
-          'PX',
-          IDEMPOTENCY_TTL_MS,
-        );
+        this.redis
+          .set(cacheKey, JSON.stringify(cachedValue), 'PX', IDEMPOTENCY_TTL_MS)
+          .catch((err: Error) => {
+            this.logger.error(
+              { cacheKey, err },
+              'Failed to cache idempotency response — subsequent retries may create duplicates',
+            );
+          });
         this.logger.info(
           { cacheKey, statusCode: response.statusCode },
           'Idempotency response cached',

--- a/src/common/idempotency/idempotency.interceptor.ts
+++ b/src/common/idempotency/idempotency.interceptor.ts
@@ -1,0 +1,113 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
+import { Request, Response } from 'express';
+import { from, Observable, of, throwError } from 'rxjs';
+import { catchError, switchMap, tap } from 'rxjs/operators';
+import { isUUID } from 'class-validator';
+import type Redis from 'ioredis';
+import { PinoLogger } from 'nestjs-pino';
+
+interface CachedResponse {
+  statusCode: number;
+  body: Record<string, unknown> | null;
+}
+
+const PROCESSING_MARKER = '__PROCESSING__';
+const IDEMPOTENCY_TTL_MS = 1000 * 60 * 60 * 24; // 24시간 (밀리초, cache-manager v5+ 기준)
+const PROCESSING_TTL_SEC = 60; // ioredis SET NX의 EX 옵션은 초 단위
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    @Inject('REDIS_CLIENT') private readonly redis: Redis,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(IdempotencyInterceptor.name);
+  }
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<unknown>> {
+    const httpContext = context.switchToHttp();
+    const request = httpContext.getRequest<Request>();
+    const response = httpContext.getResponse<Response>();
+    const idempotencyKey = request.headers['idempotency-key'] as string;
+
+    // 1. 헤더 검증
+    if (!idempotencyKey) {
+      throw new BadRequestException('Idempotency-Key header is required');
+    }
+    if (!isUUID(idempotencyKey, '4')) {
+      throw new BadRequestException('Idempotency-Key must be a valid UUID');
+    }
+
+    const userId = (request as Request & { user?: { id?: number } }).user?.id;
+    if (!userId) {
+      throw new UnauthorizedException(
+        'Idempotent endpoints require authentication',
+      );
+    }
+    const cacheKey = `idempotency:${userId}:${idempotencyKey}`;
+
+    // 2. 원자적 선점: SET NX (ioredis 직접 사용)
+    const acquired = await this.redis.set(
+      cacheKey,
+      PROCESSING_MARKER,
+      'EX',
+      PROCESSING_TTL_SEC,
+      'NX',
+    );
+
+    if (!acquired) {
+      // 이미 키가 존재 → 캐시 히트이거나 다른 요청이 처리 중
+      const existing = await this.cacheManager.get<string | CachedResponse>(
+        cacheKey,
+      );
+      if (existing === PROCESSING_MARKER) {
+        throw new ConflictException(
+          'A request with this Idempotency-Key is currently being processed',
+        );
+      }
+      if (existing && typeof existing === 'object') {
+        this.logger.info(
+          { cacheKey },
+          'Idempotency cache hit — returning cached response',
+        );
+        response.status(existing.statusCode);
+        return of(existing.body);
+      }
+    }
+
+    // 3. Handler 실행 + 응답 저장
+    return next.handle().pipe(
+      tap((responseBody: unknown) => {
+        const cachedValue: CachedResponse = {
+          statusCode: response.statusCode,
+          body: (responseBody as Record<string, unknown>) ?? null,
+        };
+        void this.cacheManager.set(cacheKey, cachedValue, IDEMPOTENCY_TTL_MS);
+        this.logger.info(
+          { cacheKey, statusCode: response.statusCode },
+          'Idempotency response cached',
+        );
+      }),
+      catchError((error: Error) => {
+        return from(this.cacheManager.del(cacheKey)).pipe(
+          switchMap(() => throwError(() => error)),
+        );
+      }),
+    );
+  }
+}

--- a/src/common/idempotency/idempotency.module.ts
+++ b/src/common/idempotency/idempotency.module.ts
@@ -12,6 +12,9 @@ import { IdempotencyInterceptor } from './idempotency.interceptor';
         new Redis({
           host: config.get<string>('REDIS_HOST', 'localhost'),
           port: config.get<number>('REDIS_PORT', 6379),
+          enableOfflineQueue: false,
+          maxRetriesPerRequest: 1,
+          connectTimeout: 1000,
         }),
       inject: [ConfigService],
     },

--- a/src/common/idempotency/idempotency.module.ts
+++ b/src/common/idempotency/idempotency.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
 import { IdempotencyInterceptor } from './idempotency.interceptor';
 
@@ -7,11 +8,12 @@ import { IdempotencyInterceptor } from './idempotency.interceptor';
   providers: [
     {
       provide: 'REDIS_CLIENT',
-      useFactory: () =>
+      useFactory: (config: ConfigService) =>
         new Redis({
-          host: process.env.REDIS_HOST || 'localhost',
-          port: parseInt(process.env.REDIS_PORT || '6379', 10),
+          host: config.get<string>('REDIS_HOST', 'localhost'),
+          port: config.get<number>('REDIS_PORT', 6379),
         }),
+      inject: [ConfigService],
     },
     IdempotencyInterceptor,
   ],

--- a/src/common/idempotency/idempotency.module.ts
+++ b/src/common/idempotency/idempotency.module.ts
@@ -1,4 +1,4 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, Inject, Module, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
 import { IdempotencyInterceptor } from './idempotency.interceptor';
@@ -19,4 +19,10 @@ import { IdempotencyInterceptor } from './idempotency.interceptor';
   ],
   exports: ['REDIS_CLIENT', IdempotencyInterceptor],
 })
-export class IdempotencyModule {}
+export class IdempotencyModule implements OnModuleDestroy {
+  constructor(@Inject('REDIS_CLIENT') private readonly redis: Redis) {}
+
+  async onModuleDestroy() {
+    await this.redis.quit();
+  }
+}

--- a/src/common/idempotency/idempotency.module.ts
+++ b/src/common/idempotency/idempotency.module.ts
@@ -1,0 +1,20 @@
+import { Global, Module } from '@nestjs/common';
+import Redis from 'ioredis';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: 'REDIS_CLIENT',
+      useFactory: () =>
+        new Redis({
+          host: process.env.REDIS_HOST || 'localhost',
+          port: parseInt(process.env.REDIS_PORT || '6379', 10),
+        }),
+    },
+    IdempotencyInterceptor,
+  ],
+  exports: ['REDIS_CLIENT', IdempotencyInterceptor],
+})
+export class IdempotencyModule {}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiConflictResponse,
   ApiCreatedResponse,
   ApiForbiddenResponse,
+  ApiHeader,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -26,6 +27,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { Idempotent } from '@src/common/idempotency/decorator/idempotent.decorator';
 import { JwtAuthGuard } from '@src/auth/guard/jwt-auth.guard';
 import { CurrentUser } from '@src/common/decorator/current-user.decorator';
 import { AuthUser } from '@src/common/decorator/auth-user.type';
@@ -79,6 +81,12 @@ export class PostsController {
   }
 
   @Post()
+  @Idempotent()
+  @ApiHeader({
+    name: 'Idempotency-Key',
+    required: true,
+    description: 'UUID v4 형식의 멱등성 키',
+  })
   @ApiOperation({ summary: '게시글 생성' })
   @ApiCreatedResponse({ type: CreatePostResponseDto })
   @ApiBadRequestResponse({ description: '잘못된 요청' })

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -90,7 +90,9 @@ export class PostsController {
   @ApiOperation({ summary: '게시글 생성' })
   @ApiCreatedResponse({ type: CreatePostResponseDto })
   @ApiBadRequestResponse({ description: '잘못된 요청' })
-  @ApiConflictResponse({ description: '중복된 제목' })
+  @ApiConflictResponse({
+    description: '중복된 제목 또는 동일 Idempotency-Key로 동시 요청 처리 중',
+  })
   async createPost(
     @CurrentUser() user: AuthUser,
     @Body() dto: CreatePostRequestDto,

--- a/test/posts.integration-spec.ts
+++ b/test/posts.integration-spec.ts
@@ -48,6 +48,7 @@ describe('Posts (integration)', () => {
     return request(app.getHttpServer())
       .post('/posts')
       .set('Authorization', `Bearer ${token}`)
+      .set('Idempotency-Key', crypto.randomUUID())
       .send({ title: 'Default Title', content: 'Default Content', ...body });
   }
 

--- a/test/setup/global-setup.ts
+++ b/test/setup/global-setup.ts
@@ -1,3 +1,4 @@
+import { createConnection } from 'net';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import {
@@ -15,10 +16,35 @@ declare global {
 
 const TEST_ENV_PATH = join(__dirname, '..', '.test-env.json');
 
+function isRedisAvailable(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host, port });
+    socket.setTimeout(500);
+    socket.on('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on('error', () => resolve(false));
+    socket.on('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+}
+
 export default async function globalSetup() {
+  // Redis: CI 서비스 컨테이너가 있으면 재사용, 없으면 Testcontainer 기동
+  const redisHost = process.env.REDIS_HOST || 'localhost';
+  const redisPort = parseInt(process.env.REDIS_PORT || '6379', 10);
+  const redisAlreadyRunning = await isRedisAvailable(redisHost, redisPort);
+
+  const startRedisContainer = redisAlreadyRunning
+    ? Promise.resolve(null)
+    : new GenericContainer('redis:7-alpine').withExposedPorts(6379).start();
+
   const [pgContainer, redisContainer] = await Promise.all([
     new PostgreSqlContainer('postgres:17-alpine').start(),
-    new GenericContainer('redis:7-alpine').withExposedPorts(6379).start(),
+    startRedisContainer,
   ]);
 
   const env = {
@@ -27,8 +53,10 @@ export default async function globalSetup() {
     DB_USERNAME: pgContainer.getUsername(),
     DB_PASSWORD: pgContainer.getPassword(),
     DB_DATABASE: pgContainer.getDatabase(),
-    REDIS_HOST: redisContainer.getHost(),
-    REDIS_PORT: redisContainer.getMappedPort(6379).toString(),
+    REDIS_HOST: redisContainer ? redisContainer.getHost() : redisHost,
+    REDIS_PORT: redisContainer
+      ? redisContainer.getMappedPort(6379).toString()
+      : redisPort.toString(),
     JWT_ACCESS_SECRET: 'test-access-secret',
     JWT_REFRESH_SECRET: 'test-refresh-secret',
     JWT_ACCESS_EXPIRATION: '15m',
@@ -47,5 +75,5 @@ export default async function globalSetup() {
   await dataSource.destroy();
 
   globalThis.__TEST_CONTAINER__ = pgContainer;
-  globalThis.__REDIS_CONTAINER__ = redisContainer;
+  globalThis.__REDIS_CONTAINER__ = redisContainer ?? undefined;
 }

--- a/test/setup/global-setup.ts
+++ b/test/setup/global-setup.ts
@@ -4,24 +4,31 @@ import {
   PostgreSqlContainer,
   StartedPostgreSqlContainer,
 } from '@testcontainers/postgresql';
+import { GenericContainer, StartedTestContainer } from 'testcontainers';
 import { DataSource } from 'typeorm';
 import { createDataSourceOptions } from '@src/database/typeorm.config';
 
 declare global {
   var __TEST_CONTAINER__: StartedPostgreSqlContainer | undefined;
+  var __REDIS_CONTAINER__: StartedTestContainer | undefined;
 }
 
 const TEST_ENV_PATH = join(__dirname, '..', '.test-env.json');
 
 export default async function globalSetup() {
-  const container = await new PostgreSqlContainer('postgres:17-alpine').start();
+  const [pgContainer, redisContainer] = await Promise.all([
+    new PostgreSqlContainer('postgres:17-alpine').start(),
+    new GenericContainer('redis:7-alpine').withExposedPorts(6379).start(),
+  ]);
 
   const env = {
-    DB_HOST: container.getHost(),
-    DB_PORT: container.getPort().toString(),
-    DB_USERNAME: container.getUsername(),
-    DB_PASSWORD: container.getPassword(),
-    DB_DATABASE: container.getDatabase(),
+    DB_HOST: pgContainer.getHost(),
+    DB_PORT: pgContainer.getPort().toString(),
+    DB_USERNAME: pgContainer.getUsername(),
+    DB_PASSWORD: pgContainer.getPassword(),
+    DB_DATABASE: pgContainer.getDatabase(),
+    REDIS_HOST: redisContainer.getHost(),
+    REDIS_PORT: redisContainer.getMappedPort(6379).toString(),
     JWT_ACCESS_SECRET: 'test-access-secret',
     JWT_REFRESH_SECRET: 'test-refresh-secret',
     JWT_ACCESS_EXPIRATION: '15m',
@@ -39,5 +46,6 @@ export default async function globalSetup() {
   await dataSource.runMigrations();
   await dataSource.destroy();
 
-  globalThis.__TEST_CONTAINER__ = container;
+  globalThis.__TEST_CONTAINER__ = pgContainer;
+  globalThis.__REDIS_CONTAINER__ = redisContainer;
 }

--- a/test/setup/global-setup.ts
+++ b/test/setup/global-setup.ts
@@ -42,38 +42,47 @@ export default async function globalSetup() {
     ? Promise.resolve(null)
     : new GenericContainer('redis:7-alpine').withExposedPorts(6379).start();
 
-  const [pgContainer, redisContainer] = await Promise.all([
-    new PostgreSqlContainer('postgres:17-alpine').start(),
-    startRedisContainer,
-  ]);
+  let pgContainer: StartedPostgreSqlContainer | undefined;
+  let redisContainer: StartedTestContainer | null = null;
 
-  const env = {
-    DB_HOST: pgContainer.getHost(),
-    DB_PORT: pgContainer.getPort().toString(),
-    DB_USERNAME: pgContainer.getUsername(),
-    DB_PASSWORD: pgContainer.getPassword(),
-    DB_DATABASE: pgContainer.getDatabase(),
-    REDIS_HOST: redisContainer ? redisContainer.getHost() : redisHost,
-    REDIS_PORT: redisContainer
-      ? redisContainer.getMappedPort(6379).toString()
-      : redisPort.toString(),
-    JWT_ACCESS_SECRET: 'test-access-secret',
-    JWT_REFRESH_SECRET: 'test-refresh-secret',
-    JWT_ACCESS_EXPIRATION: '15m',
-    JWT_REFRESH_EXPIRATION: '7d',
-  };
+  try {
+    [pgContainer, redisContainer] = await Promise.all([
+      new PostgreSqlContainer('postgres:17-alpine').start(),
+      startRedisContainer,
+    ]);
 
-  writeFileSync(TEST_ENV_PATH, JSON.stringify(env, null, 2));
+    // 컨테이너 핸들을 즉시 등록 — 이후 실패 시 teardown에서 정리 가능
+    globalThis.__TEST_CONTAINER__ = pgContainer;
+    globalThis.__REDIS_CONTAINER__ = redisContainer ?? undefined;
 
-  const dataSource = new DataSource({
-    ...createDataSourceOptions(env),
-    synchronize: false,
-  });
+    const env = {
+      DB_HOST: pgContainer.getHost(),
+      DB_PORT: pgContainer.getPort().toString(),
+      DB_USERNAME: pgContainer.getUsername(),
+      DB_PASSWORD: pgContainer.getPassword(),
+      DB_DATABASE: pgContainer.getDatabase(),
+      REDIS_HOST: redisContainer ? redisContainer.getHost() : redisHost,
+      REDIS_PORT: redisContainer
+        ? redisContainer.getMappedPort(6379).toString()
+        : redisPort.toString(),
+      JWT_ACCESS_SECRET: 'test-access-secret',
+      JWT_REFRESH_SECRET: 'test-refresh-secret',
+      JWT_ACCESS_EXPIRATION: '15m',
+      JWT_REFRESH_EXPIRATION: '7d',
+    };
 
-  await dataSource.initialize();
-  await dataSource.runMigrations();
-  await dataSource.destroy();
+    writeFileSync(TEST_ENV_PATH, JSON.stringify(env, null, 2));
 
-  globalThis.__TEST_CONTAINER__ = pgContainer;
-  globalThis.__REDIS_CONTAINER__ = redisContainer ?? undefined;
+    const dataSource = new DataSource({
+      ...createDataSourceOptions(env),
+      synchronize: false,
+    });
+
+    await dataSource.initialize();
+    await dataSource.runMigrations();
+    await dataSource.destroy();
+  } catch (error) {
+    await Promise.all([pgContainer?.stop(), redisContainer?.stop()]);
+    throw error;
+  }
 }

--- a/test/setup/global-teardown.ts
+++ b/test/setup/global-teardown.ts
@@ -4,10 +4,10 @@ import { join } from 'path';
 const TEST_ENV_PATH = join(__dirname, '..', '.test-env.json');
 
 export default async function globalTeardown() {
-  const container = globalThis.__TEST_CONTAINER__;
-  if (container) {
-    await container.stop();
-  }
+  const pgContainer = globalThis.__TEST_CONTAINER__;
+  const redisContainer = globalThis.__REDIS_CONTAINER__;
+
+  await Promise.all([pgContainer?.stop(), redisContainer?.stop()]);
 
   try {
     unlinkSync(TEST_ENV_PATH);


### PR DESCRIPTION
## Summary

- `Idempotency-Key` 헤더 기반 멱등성 Interceptor 추가 (`ioredis` + `SET NX` 원자적 선점)
- `@Idempotent()` 데코레이터로 `POST /posts` 엔드포인트에 선택적 적용
- 동일 키 재요청 시 캐시된 응답을 반환하여 중복 게시글 생성 방지

## Changes

| 파일 | 변경 |
|------|------|
| `src/common/idempotency/` | Interceptor, Module, Decorator 신규 생성 |
| `src/app.module.ts` | `IdempotencyModule` import 추가 |
| `src/posts/posts.controller.ts` | `createPost`에 `@Idempotent()` + `@ApiHeader` 적용 |
| `test/posts.integration-spec.ts` | `Idempotency-Key` 헤더 추가 |
| `docs/idempotency-guide.md` | 멱등성 가이드 문서 |

## Test plan

- [x] `pnpm build:local` 빌드 통과
- [x] `pnpm test` 단위 테스트 48개 통과
- [x] `pnpm test:e2e` 통합 테스트 81개 통과
- [x] Swagger UI에서 `Idempotency-Key` 헤더로 POST 요청 검증
- [x] 동일 UUID 재요청 시 캐시된 응답 반환 확인 (Redis CLI)

> **Merge Strategy**: Create a merge commit을 사용해주세요.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * POST 요청에 대한 멱등성(Idempotency) 지원 추가 — Idempotency-Key 헤더로 중복·동시 요청 처리 및 409 충돌 대응 개선

* **문서**
  * 한국어 멱등성 구현 가이드 추가 — 패턴, 헤더 요구사항, 동시성 처리, 검증 및 테스트 절차 포함

* **테스트·CI / 기타**
  * Redis 환경변수 예시와 Redis 클라이언트 의존성 추가
  * 테스트 설정 및 CI 워크플로우에 Redis 지원 추가 (테스트 컨테이너 및 종료 처리 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->