### PR TITLE
feat(throttle): @nestjs/throttler 기반 Rate Limiting 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@nestjs/platform-express": "^11.1.17",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/terminus": "^11.1.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@slack/web-api": "^7.15.0",
     "bcrypt": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@nestjs/terminus':
         specifier: ^11.1.1
         version: 11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))
@@ -926,6 +929,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@nestjs/typeorm@11.0.0':
     resolution: {integrity: sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==}
@@ -5043,6 +5053,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
 
   '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))':
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { createDataSourceOptions } from '@src/database/typeorm.config';
 import { LoggingModule } from '@src/common/logging/logging.module';
@@ -17,6 +19,13 @@ const nodeEnv = process.env.NODE_ENV || 'local';
       isGlobal: true,
       envFilePath: `.env.${nodeEnv}`,
     }),
+    ThrottlerModule.forRoot({
+      skipIf: () => process.env.THROTTLE_SKIP === 'true',
+      throttlers: [
+        { name: 'short', ttl: 1000, limit: 3 },
+        { name: 'long', ttl: 60000, limit: 60 },
+      ],
+    }),
     EventEmitterModule.forRoot(),
     LoggingModule,
     IdempotencyModule,
@@ -31,5 +40,6 @@ const nodeEnv = process.env.NODE_ENV || 'local';
     AuthModule,
     HealthModule,
   ],
+  providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,8 +18,10 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiTags,
+  ApiTooManyRequestsResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { JwtAuthGuard } from '@src/auth/guard/jwt-auth.guard';
 import { CurrentUser } from '@src/common/decorator/current-user.decorator';
 import { AuthUser } from '@src/common/decorator/auth-user.type';
@@ -56,10 +58,12 @@ export class AuthController {
   }
 
   @Post('register')
+  @Throttle({ short: { ttl: 1000, limit: 2 }, long: { ttl: 60000, limit: 5 } })
   @ApiOperation({ summary: '회원가입' })
   @ApiCreatedResponse({ type: RegisterResponseDto })
   @ApiBadRequestResponse({ description: '잘못된 요청' })
   @ApiConflictResponse({ description: '중복된 이메일' })
+  @ApiTooManyRequestsResponse({ description: '요청 횟수 초과' })
   async register(
     @Body() dto: RegisterRequestDto,
   ): Promise<RegisterResponseDto> {
@@ -70,11 +74,13 @@ export class AuthController {
   }
 
   @Post('login')
+  @Throttle({ short: { ttl: 1000, limit: 2 }, long: { ttl: 60000, limit: 5 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '로그인' })
   @ApiOkResponse({ type: AuthTokensResponseDto })
   @ApiBadRequestResponse({ description: '잘못된 요청' })
   @ApiUnauthorizedResponse({ description: '인증 실패' })
+  @ApiTooManyRequestsResponse({ description: '요청 횟수 초과' })
   async login(@Body() dto: LoginRequestDto): Promise<AuthTokensResponseDto> {
     const tokens = await this.commandBus.execute<LoginCommand, AuthTokens>(
       new LoginCommand(dto.email, dto.password),

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -10,7 +10,7 @@ import {
 import { RedisHealthIndicator } from './redis-health.indicator';
 
 @ApiTags('Health')
-@SkipThrottle()
+@SkipThrottle({ short: true, long: true })
 @Controller('health')
 export class HealthController {
   constructor(

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
 import {
   HealthCheck,
   HealthCheckService,
@@ -9,6 +10,7 @@ import {
 import { RedisHealthIndicator } from './redis-health.indicator';
 
 @ApiTags('Health')
+@SkipThrottle()
 @Controller('health')
 export class HealthController {
   constructor(

--- a/test/setup/global-setup.ts
+++ b/test/setup/global-setup.ts
@@ -69,6 +69,7 @@ export default async function globalSetup() {
       JWT_REFRESH_SECRET: 'test-refresh-secret',
       JWT_ACCESS_EXPIRATION: '15m',
       JWT_REFRESH_EXPIRATION: '7d',
+      THROTTLE_SKIP: 'true',
     };
 
     writeFileSync(TEST_ENV_PATH, JSON.stringify(env, null, 2));


### PR DESCRIPTION
## Summary

- `@nestjs/throttler` 기반 글로벌 Rate Limiting 적용 (Named Throttlers: short/long)
- login/register 엔드포인트에 엄격한 제한 적용 (brute-force 방어)
- Health Check 엔드포인트 `@SkipThrottle()` 적용 (K8s probe 보호)
- 통합 테스트 환경에서 `THROTTLE_SKIP=true`로 Rate Limiting 비활성화

## Changes

| 파일 | 변경 |
|------|------|
| `src/app.module.ts` | `ThrottlerModule.forRoot` + `APP_GUARD` 글로벌 등록 |
| `src/auth/auth.controller.ts` | login/register에 `@Throttle()` (1초 2회, 분당 5회) |
| `src/health/health.controller.ts` | `@SkipThrottle()` 적용 |
| `test/setup/global-setup.ts` | 테스트 환경에 `THROTTLE_SKIP=true` 추가 |

## Rate Limiting 설정

| 이름 | TTL | Limit | 용도 |
|------|-----|-------|------|
| `short` | 1초 | 3회 | burst 방지 (전체 엔드포인트 기본) |
| `long` | 60초 | 60회 | 분당 제한 (전체 엔드포인트 기본) |
| login/register | 1초 2회, 60초 5회 | brute-force 방어 |

## Test plan

- [x] `pnpm format` — 포맷 확인
- [x] `pnpm lint:check` — 린트 통과
- [x] `pnpm build:local` — 빌드 성공
- [x] `pnpm test` — 단위 테스트 48개 통과
- [x] `pnpm test:e2e` — 통합 테스트 81개 통과

> **Merge Strategy**: Create a merge commit을 사용해주세요.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 전체에 요청 스로틀링을 적용하여 과도한 요청을 제한합니다.
  * 인증 엔드포인트(회원가입·로그인)에 보다 엄격한 요청 제한을 추가했습니다.
  * API 문서에 요청 한도 초과 시 반환되는 HTTP 429 응답을 명시했습니다.
  * 헬스 체크 엔드포인트는 스로틀링 대상에서 제외됩니다.
  * 환경변수로 스로틀링을 비활성화할 수 있습니다.

* **테스트**
  * 테스트 환경 설정에 스로틀링 비활성화 플래그를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->