### PR TITLE
feat(cache): Redis 기반 Cache Layer 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,31 @@ Controller → CommandBus / QueryBus → Handler (검증 + 로직) → IPostRead
 - Post 엔티티에 `@DeleteDateColumn()` 적용 — 삭제 시 `deletedAt` 타임스탬프 기록, 실제 행은 유지
 - TypeORM의 `softDelete()`/`restore()` 메서드 사용
 
+### Health Check & Graceful Shutdown
+
+- `@nestjs/terminus` 기반 `GET /health` 엔드포인트 — DB(TypeORM) + Redis 연결 상태 확인
+- `RedisHealthIndicator` — `HealthIndicatorService`를 사용한 커스텀 헬스 인디케이터 (`src/health/redis-health.indicator.ts`)
+- `@SkipThrottle({ short: true, long: true })` — Health Check는 Rate Limiting 제외 (K8s probe 보호)
+- `app.enableShutdownHooks()` — SIGTERM/SIGINT 시 `OnModuleDestroy` 훅 트리거 (Redis 연결 정리 등)
+
+### Rate Limiting
+
+- `@nestjs/throttler` 기반 글로벌 Rate Limiting (`APP_GUARD`로 `ThrottlerGuard` 등록)
+- Named Throttlers: `short` (1초 3회), `long` (분당 60회)
+- `@Throttle()` — login/register에 엄격한 제한 (1초 2회, 분당 5회)
+- `@SkipThrottle({ short: true, long: true })` — named throttlers 사용 시 스킵 대상을 명시해야 함
+- `skipIf: () => process.env.THROTTLE_SKIP === 'true'` — 통합 테스트 환경에서 비활성화
+- 429 Too Many Requests 자동 반환. Swagger에 `@ApiTooManyRequestsResponse` 적용
+
+### Cache Layer
+
+- `CacheService` (`src/common/cache/`) — 기존 `REDIS_CLIENT`(ioredis)를 재사용한 캐시 유틸리티. 추가 패키지 없음
+- **CQRS 정합**: Query Handler에서 캐시 읽기/저장, Command Handler에서 캐시 무효화
+- **Fail-Open 패턴**: 모든 Redis 연산을 try/catch로 감싸 Redis 장애 시 DB fallback. 캐시 장애가 서비스 가용성에 영향을 미치지 않음
+- **사용자 격리**: 모든 캐시 키에 `userId` 포함 (예: `post:{userId}:{postId}`)
+- 캐시 히트/미스/SET/DEL을 `debug` 레벨로 로깅, 장애 시 `warn` 레벨 로깅
+- 상세 가이드: `docs/cache-layer-guide.md`
+
 ### Logging
 
 - `pino-http` 기반 구조화 로깅 (`src/common/logging/`)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 NestJS + TypeORM + PostgreSQL 기반 Posts CRUD API.
 **Repository Pattern**으로 데이터 액세스를 추상화하고, **CQRS Pattern**으로 읽기/쓰기 관심사를 분리한다.
 
+### 주요 기능
+
+| 기능 | 설명 |
+|------|------|
+| **Posts CRUD** | 게시물 생성/조회/수정/삭제 (Soft Delete) |
+| **Auth** | JWT 기반 회원가입, 로그인, 로그아웃, 토큰 갱신, 프로필 조회 |
+| **Health Check** | `GET /health` — DB + Redis 연결 상태 확인 + Graceful Shutdown |
+| **Rate Limiting** | `@nestjs/throttler` 기반 글로벌 Rate Limiting (login/register 엄격 제한) |
+| **Cache Layer** | Redis 기반 Cache-Aside 패턴 (CQRS Handler 레벨, Fail-Open) |
+| **Idempotency** | Redis 기반 POST 요청 멱등성 보장 |
+| **Logging** | pino-http 기반 구조화 로깅 (correlation ID, redaction) |
+| **Slack 알림** | 게시물 생성 시 이벤트 기반 Slack 알림 |
+
 ## 목차
 
 - [아키텍처](#아키텍처)
@@ -12,6 +25,10 @@ NestJS + TypeORM + PostgreSQL 기반 Posts CRUD API.
 - [디자인 패턴](#디자인-패턴)
   - [CQRS Pattern](#cqrs-pattern)
   - [Repository Pattern (ISP 적용)](#repository-pattern-isp-적용)
+- [인프라 기능](#인프라-기능)
+  - [Health Check & Graceful Shutdown](#health-check--graceful-shutdown)
+  - [Rate Limiting](#rate-limiting)
+  - [Cache Layer](#cache-layer)
 - [시작하기](#시작하기)
   - [환경 설정](#환경-설정)
   - [실행](#실행)
@@ -24,6 +41,7 @@ NestJS + TypeORM + PostgreSQL 기반 Posts CRUD API.
   - [통합 테스트](#통합-테스트)
   - [커버리지](#커버리지)
 - [CI/CD](#cicd)
+- [문서](#문서)
 
 ---
 
@@ -42,14 +60,16 @@ Controller              ← 라우팅, Command/Query 객체 생성
   │      ▼
   │    Command Handler             ← 쓰기 로직. void 또는 ID 반환
   │      │
-  │      └──→ IPostWriteRepository ← 상태 변경 (create, update, delete). affected count로 존재 검증
+  │      ├──→ IPostWriteRepository ← 상태 변경 (create, update, delete)
+  │      └──→ CacheService         ← 캐시 무효화 (del, delByPattern)
   │
   └──→ QueryBus.execute()          ← 상태 조회 (GetById, FindAllPaginated)
          │
          ▼
        Query Handler               ← 읽기 로직 + PostResponseDto.of() 변환
          │
-         └──→ IPostReadRepository  ← 데이터 조회
+         ├──→ CacheService.get()   ← 캐시 HIT → 즉시 반환
+         └──→ IPostReadRepository  ← 캐시 MISS → DB 조회 → CacheService.set()
                    │
                    ▼
               PostRepository → BaseRepository → TypeORM → PostgreSQL
@@ -71,57 +91,47 @@ Controller              ← 라우팅, Command/Query 객체 생성
 
 ```
 src/
-├── main.ts                                   # 앱 부트스트랩 (ValidationPipe, Swagger)
-├── app.module.ts                             # 루트 모듈 (ConfigModule, TypeOrmModule)
-├── data-source.ts                            # TypeORM CLI용 DataSource
+├── main.ts                        # 앱 부트스트랩 (ValidationPipe, Swagger, Shutdown Hooks)
+├── app.module.ts                  # 루트 모듈 (Config, TypeORM, Throttler, EventEmitter)
+├── data-source.ts                 # TypeORM CLI용 DataSource
+├── posts/                         # 게시물 도메인 (CQRS + Repository Pattern)
+│   ├── command/                   # Command + Handler (생성/수정/삭제 + 캐시 무효화)
+│   ├── query/                     # Query + Handler (조회/목록 + 캐시 적용)
+│   ├── interface/                 # Repository 인터페이스 (Read/Write 분리)
+│   ├── entities/                  # Post 엔티티 (Soft Delete)
+│   ├── dto/                       # Request/Response DTO
+│   ├── event/                     # PostCreatedEvent + Slack 알림 Handler
+│   ├── post.repository.ts        # PostRepository 구현체
+│   └── post-repository.provider.ts
+├── auth/                          # 인증 도메인 (동일 CQRS 구조)
+│   ├── command/                   # register, login, logout, refresh-token
+│   ├── query/                     # get-profile (캐시 적용)
+│   ├── interface/                 # IUserReadRepository / IUserWriteRepository
+│   ├── guard/                     # JwtAuthGuard
+│   └── strategy/                  # JwtStrategy
+├── health/                        # Health Check (@nestjs/terminus)
+│   ├── health.controller.ts       # GET /health (DB + Redis)
+│   └── redis-health.indicator.ts  # 커스텀 Redis 헬스 인디케이터
+├── slack/                         # Slack 알림 모듈
 ├── common/
-│   ├── base.repository.ts                    # BaseRepository (DataSource 추상화)
-│   └── dto/
-│       ├── request/
-│       │   └── pagination.request.dto.ts     # 페이지네이션 요청 DTO
-│       └── response/
-│           └── paginated.response.dto.ts     # 페이지네이션 응답 DTO (static of)
+│   ├── cache/                     # CacheService (Redis 기반, Fail-Open)
+│   ├── idempotency/               # 멱등성 처리 (Redis)
+│   ├── logging/                   # 구조화 로깅 (pino-http)
+│   ├── decorator/                 # @CurrentUser() 등 커스텀 데코레이터
+│   ├── dto/                       # 공통 DTO (Pagination)
+│   ├── query/                     # PaginatedQuery 추상 클래스
+│   └── base.repository.ts        # BaseRepository (DataSource 추상화)
 ├── database/
-│   └── typeorm.config.ts                     # DataSource 설정 팩토리
-├── migrations/
-│   └── 1770456974651-CreatePostTable.ts      # TypeORM Table API 기반 migration
-└── posts/
-    ├── entities/
-    │   └── post.entity.ts                    # Post 엔티티
-    ├── interface/
-    │   ├── post-read-repository.interface.ts  # IPostReadRepository (읽기 전용)
-    │   └── post-write-repository.interface.ts # IPostWriteRepository (쓰기 전용) + 도메인 입력 타입
-    ├── command/
-    │   ├── create-post.command.ts            # 생성 Command 값 객체
-    │   ├── create-post.handler.ts            # 생성 Handler → number (ID)
-    │   ├── update-post.command.ts            # 수정 Command 값 객체
-    │   ├── update-post.handler.ts            # 수정 Handler → void
-    │   ├── delete-post.command.ts            # 삭제 Command 값 객체
-    │   └── delete-post.handler.ts            # 삭제 Handler → void
-    ├── query/
-    │   ├── get-post-by-id.query.ts           # 단건 조회 Query 값 객체
-    │   ├── get-post-by-id.handler.ts         # 단건 조회 Handler → PostResponseDto
-    │   ├── find-all-posts-paginated.query.ts # 페이지네이션 Query 값 객체
-    │   └── find-all-posts-paginated.handler.ts # 페이지네이션 Handler → PaginatedResponseDto
-    ├── dto/
-    │   ├── request/
-    │   │   ├── create-post.request.dto.ts
-    │   │   └── update-post.request.dto.ts
-    │   └── response/
-    │       ├── create-post.response.dto.ts   # 생성 응답 DTO ({ id })
-    │       └── post.response.dto.ts          # static of() 팩토리 메서드
-    ├── post.repository.ts                    # PostRepository 구현체
-    ├── post-repository.provider.ts           # useExisting 기반 커스텀 프로바이더
-    ├── posts.controller.ts                   # HTTP 라우팅 + Command/Query 생성
-    └── posts.module.ts                       # Posts 모듈
+│   └── typeorm.config.ts          # DataSource 설정 팩토리
+└── migrations/                    # TypeORM 마이그레이션
 
 test/
-├── posts.integration-spec.ts                 # 통합 테스트 (Testcontainers, Docker 필수)
-├── jest-e2e.json                             # 통합 테스트 Jest 설정
+├── posts.integration-spec.ts      # Posts 통합 테스트
+├── auth.integration-spec.ts       # Auth 통합 테스트
 └── setup/
-    ├── global-setup.ts                       # PostgreSQL 컨테이너 기동 + migration
-    ├── global-teardown.ts                    # 컨테이너 종료 + 임시 파일 삭제
-    └── integration-helper.ts                 # 앱 생성 + per-test 트랜잭션 격리
+    ├── global-setup.ts            # PostgreSQL + Redis 컨테이너 기동
+    ├── global-teardown.ts         # 컨테이너 종료
+    └── integration-helper.ts      # 앱 생성 + per-test 트랜잭션 격리
 ```
 
 ---
@@ -247,6 +257,33 @@ export const postRepositoryProviders: Provider[] = [
 
 ---
 
+## 인프라 기능
+
+### Health Check & Graceful Shutdown
+
+- `@nestjs/terminus` 기반 `GET /health` — DB(TypeORM pingCheck) + Redis(커스텀 `RedisHealthIndicator`) 연결 상태 확인
+- `app.enableShutdownHooks()` — SIGTERM/SIGINT 시 `OnModuleDestroy` 훅으로 Redis 연결 등 리소스 정리
+- Rate Limiting에서 제외 (`@SkipThrottle({ short: true, long: true })`)
+
+### Rate Limiting
+
+- `@nestjs/throttler` 기반, `APP_GUARD`로 `ThrottlerGuard` 글로벌 등록
+- Named Throttlers: `short` (1초 3회), `long` (분당 60회)
+- login/register에 엄격한 제한: `@Throttle({ short: { ttl: 1000, limit: 2 }, long: { ttl: 60000, limit: 5 } })`
+- 통합 테스트에서 `THROTTLE_SKIP=true`로 비활성화
+- 429 Too Many Requests 자동 반환
+
+### Cache Layer
+
+- `CacheService` (`src/common/cache/`) — 기존 `REDIS_CLIENT`(ioredis)를 재사용. 추가 패키지 없음
+- **Cache-Aside 패턴**: Query Handler에서 캐시 읽기/저장, Command Handler에서 캐시 무효화
+- **Fail-Open**: 모든 Redis 연산을 try/catch로 감싸 Redis 장애 시 DB fallback
+- 캐시 키에 `userId` 포함하여 사용자 격리 (예: `post:{userId}:{postId}`)
+- TTL: 게시물 5분, 목록 3분, 프로필 10분
+- 상세 가이드: [docs/cache-layer-guide.md](./docs/cache-layer-guide.md)
+
+---
+
 ## 시작하기
 
 ### 환경 설정
@@ -305,13 +342,19 @@ pnpm migration:create -- src/migrations/AddCategoryToPost
 
 Swagger UI: `http://localhost:3000/api`
 
-| Method | Endpoint | 설명 | 상태 코드 |
-|--------|----------|------|-----------|
-| GET | `/posts` | 게시글 페이지네이션 조회 | 200 |
-| GET | `/posts/:id` | ID로 게시글 조회 | 200 / 404 |
-| POST | `/posts` | 게시글 생성 | 201 |
-| PATCH | `/posts/:id` | 게시글 수정 (전체 업데이트) | 204 / 400 / 404 |
-| DELETE | `/posts/:id` | 게시글 삭제 | 204 / 404 |
+| Method | Endpoint | 설명 | 상태 코드 | 인증 |
+|--------|----------|------|-----------|------|
+| GET | `/health` | Health Check (DB + Redis) | 200 / 503 | X |
+| POST | `/auth/register` | 회원가입 | 201 / 409 | X |
+| POST | `/auth/login` | 로그인 | 200 / 401 | X |
+| POST | `/auth/refresh` | 토큰 갱신 | 200 / 401 | X |
+| POST | `/auth/logout` | 로그아웃 | 204 / 401 | O |
+| GET | `/auth/profile` | 내 프로필 조회 | 200 / 404 | O |
+| GET | `/posts` | 게시글 페이지네이션 조회 | 200 | O |
+| GET | `/posts/:id` | ID로 게시글 조회 | 200 / 404 | O |
+| POST | `/posts` | 게시글 생성 | 201 / 409 | O |
+| PATCH | `/posts/:id` | 게시글 수정 | 204 / 400 / 404 | O |
+| DELETE | `/posts/:id` | 게시글 삭제 | 204 / 404 | O |
 
 ### 요청/응답 DTO
 
@@ -451,3 +494,17 @@ GitHub Actions로 코드 품질을 자동 검증한다. 모든 워크플로우�
 | **PR Auto-label** | PR | 변경 파일 경로 기반 자동 라벨링 (`database`, `cqrs-command`, `test` 등) |
 
 Dependabot이 의존성 업데이트 PR을 주간 자동 생성한다 (NestJS, TypeORM, Testing, ESLint 그룹).
+
+---
+
+## 문서
+
+| 문서 | 설명 |
+|------|------|
+| [CLAUDE.md](./CLAUDE.md) | Claude Code 가이드 (아키텍처, 규칙, 명령어) |
+| [Cache Layer 가이드](./docs/cache-layer-guide.md) | 캐시 적용 방법 및 전략 |
+| [CQRS 가이드](./docs/cqrs-guide.md) | CQRS 패턴 적용 가이드 |
+| [테스트 전략](./docs/testing-strategy.md) | Classical School 테스트 구조 |
+| [멱등성 가이드](./docs/idempotency-guide.md) | Redis 기반 멱등성 처리 |
+| [ISP 적용](./docs/interface-segregation-principle.md) | Repository 인터페이스 분리 원칙 |
+| [GitHub Actions 가이드](./docs/github-actions-guide.md) | CI/CD 파이프라인 설정 |

--- a/docs/cache-layer-guide.md
+++ b/docs/cache-layer-guide.md
@@ -1,0 +1,249 @@
+# Cache Layer 가이드
+
+## 개요
+
+CQRS 패턴에 맞춰 Query Handler에서 캐시를 읽고/저장하며, Command Handler에서 캐시를 무효화하는 Cache-Aside 패턴을 적용한다. 기존 `ioredis` 기반 `REDIS_CLIENT`를 재사용하여 추가 패키지 없이 구현한다.
+
+## 아키텍처
+
+```text
+[Query 요청]
+Controller → QueryBus → Query Handler
+                            ├─ CacheService.get() → Redis (HIT → 즉시 반환)
+                            └─ (MISS) → Repository → DB 조회
+                                          └─ CacheService.set() → Redis 저장
+
+[Command 요청]
+Controller → CommandBus → Command Handler
+                              ├─ Repository → DB 쓰기
+                              └─ CacheService.del() / delByPattern() → 캐시 무효화
+```
+
+## 핵심 설계 원칙
+
+### 1. CQRS 정합
+
+- **Query Handler**: 캐시 읽기/저장 담당
+- **Command Handler**: 캐시 무효화 담당
+- Controller와 Repository는 캐시를 모르는 상태 유지
+
+### 2. Fail-Open 패턴
+
+- 모든 Redis 연산은 `CacheService` 내부에서 try/catch로 감싸짐
+- Redis 장애 시 캐시 미스로 처리하고 DB 조회로 fallback
+- 캐시 무효화 실패 시 warn 로그만 남기고 정상 진행
+- **캐시 장애가 서비스 가용성에 영향을 미치지 않음**
+
+### 3. 사용자 격리
+
+- 모든 캐시 키에 `userId`를 포함하여 교차 접근 방지
+- 예: `post:1:5` (userId=1의 postId=5)
+- 인증된 JWT 토큰에서 추출한 userId로 키를 생성하므로 위조 불가
+
+### 4. 추가 패키지 없음
+
+- `@nestjs/cache-manager` + `cache-manager` v6는 내부적으로 `keyv` + `@keyv/redis`로 별도 Redis 연결을 생성
+- 프로젝트에 이미 `ioredis` 기반 `REDIS_CLIENT`가 글로벌로 제공되므로, 이를 재사용하여 연결 이중화 방지
+
+## 구성 요소
+
+### CacheService
+
+**파일**: `src/common/cache/cache.service.ts`
+
+기존 `REDIS_CLIENT`를 주입받아 캐시 CRUD를 제공하는 인프라 유틸리티.
+
+| 메서드 | 설명 | 실패 시 동작 |
+|--------|------|-------------|
+| `get<T>(key)` | 캐시 조회. 히트 시 `T` 반환, 미스 시 `undefined` | `undefined` 반환 (캐시 미스 처리) |
+| `set(key, value, ttlSeconds)` | 캐시 저장. TTL(초) 지정 | warn 로그 후 무시 |
+| `del(key)` | 단일 키 삭제 | warn 로그 후 무시 |
+| `delByPattern(pattern)` | 패턴 매칭 키 일괄 삭제 (Redis SCAN) | warn 로그 후 무시 |
+
+### AppCacheModule
+
+**파일**: `src/common/cache/cache.module.ts`
+
+```typescript
+@Module({
+  providers: [CacheService],
+  exports: [CacheService],
+})
+export class AppCacheModule {}
+```
+
+`REDIS_CLIENT`는 `IdempotencyModule`이 `@Global()`로 제공하므로 별도 import 불필요.
+
+## 캐시 전략
+
+### 캐시 대상 (Query)
+
+| Handler | 캐시 키 패턴 | TTL | 비고 |
+|---------|-------------|-----|------|
+| `GetPostByIdHandler` | `post:{userId}:{postId}` | 300초 (5분) | 단일 게시물 조회 |
+| `FindAllPostsPaginatedHandler` | `posts:{userId}:{page}:{limit}:{isPublished\|all}` | 180초 (3분) | 페이지네이션 목록 |
+| `GetProfileHandler` | `profile:{userId}` | 600초 (10분) | 사용자 프로필 |
+
+### 캐시 무효화 (Command)
+
+| Handler | 무효화 대상 | 이유 |
+|---------|-----------|------|
+| `CreatePostHandler` | `posts:{userId}:*` | 새 게시물로 목록 캐시가 stale |
+| `UpdatePostHandler` | `post:{userId}:{postId}` + `posts:{userId}:*` | 수정된 게시물 + 목록 갱신 |
+| `DeletePostHandler` | `post:{userId}:{postId}` + `posts:{userId}:*` | 삭제된 게시물 + 목록 갱신 |
+
+## 구현 패턴
+
+### Query Handler에서 캐시 적용
+
+```typescript
+// src/posts/query/get-post-by-id.handler.ts
+
+const POST_CACHE_TTL = 300; // 5분
+
+@QueryHandler(GetPostByIdQuery)
+export class GetPostByIdHandler implements IQueryHandler<GetPostByIdQuery> {
+  constructor(
+    private readonly postReadRepository: IPostReadRepository,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(query: GetPostByIdQuery): Promise<PostResponseDto> {
+    // 1. 캐시 조회
+    const cacheKey = `post:${query.userId}:${query.id}`;
+    const cached = await this.cacheService.get<PostResponseDto>(cacheKey);
+    if (cached) return cached;
+
+    // 2. DB 조회 + 검증
+    const post = await this.postReadRepository.findById(query.id);
+    if (!post || post.userId !== query.userId) {
+      throw new NotFoundException(`Post with ID ${query.id} not found`);
+    }
+
+    // 3. DTO 변환 + 캐시 저장
+    const result = PostResponseDto.of(post);
+    await this.cacheService.set(cacheKey, result, POST_CACHE_TTL);
+    return result;
+  }
+}
+```
+
+### Command Handler에서 캐시 무효화
+
+```typescript
+// src/posts/command/update-post.handler.ts
+
+@CommandHandler(UpdatePostCommand)
+export class UpdatePostHandler implements ICommandHandler<UpdatePostCommand> {
+  constructor(
+    private readonly postWriteRepository: IPostWriteRepository,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(command: UpdatePostCommand): Promise<void> {
+    // 1. DB 쓰기
+    const affected = await this.postWriteRepository.update(
+      command.id, command.userId,
+      { title: command.title, content: command.content, isPublished: command.isPublished },
+    );
+    if (affected === 0) {
+      throw new NotFoundException(`Post with ID ${command.id} not found`);
+    }
+
+    // 2. 캐시 무효화 (개별 + 목록)
+    await this.cacheService.del(`post:${command.userId}:${command.id}`);
+    await this.cacheService.delByPattern(`posts:${command.userId}:*`);
+  }
+}
+```
+
+## 로깅
+
+`CacheService`는 NestJS `Logger`를 내장하며, 모든 연산을 `debug` 레벨로 로깅한다.
+
+### 로그 출력 예시
+
+```
+[CacheService] Cache HIT: post:1:5
+[CacheService] Cache MISS: post:1:10
+[CacheService] Cache SET: post:1:10 (TTL: 300s)
+[CacheService] Cache DEL: post:1:5
+[CacheService] Cache DEL pattern: posts:1:* (3 keys)
+```
+
+### 장애 시 로그
+
+```
+[CacheService] Cache GET failed: post:1:5 — Connection is closed
+[CacheService] Cache SET failed: post:1:10 — Connection is closed
+```
+
+- `debug` 레벨: 정상 캐시 히트/미스/SET/DEL
+- `warn` 레벨: Redis 장애, JSON 파싱 실패 등 예외 상황
+- `.env.*`의 `LOG_LEVEL=debug`일 때만 debug 로그 출력
+
+## 모듈 등록
+
+### PostsModule
+
+```typescript
+// src/posts/posts.module.ts
+@Module({
+  imports: [CqrsModule, AuthModule, SlackModule, AppCacheModule],
+  // ...
+})
+export class PostsModule {}
+```
+
+### AuthModule
+
+```typescript
+// src/auth/auth.module.ts
+@Module({
+  imports: [CqrsModule, PassportModule, JwtModule.register({}), AppCacheModule],
+  // ...
+})
+export class AuthModule {}
+```
+
+## 단위 테스트
+
+Handler 단위 테스트에서 `CacheService`를 mock으로 제공한다.
+
+```typescript
+const module: TestingModule = await Test.createTestingModule({
+  providers: [
+    GetPostByIdHandler,
+    { provide: IPostReadRepository, useValue: mockReadRepository },
+    {
+      provide: CacheService,
+      useValue: {
+        get: jest.fn(),
+        set: jest.fn(),
+        del: jest.fn(),
+        delByPattern: jest.fn(),
+      },
+    },
+  ],
+}).compile();
+```
+
+## 새 도메인에 캐시 추가하기
+
+1. 해당 모듈에 `AppCacheModule`을 imports에 추가
+2. Query Handler에 `CacheService`를 주입하고 `get()`/`set()` 패턴 적용
+3. Command Handler에 `CacheService`를 주입하고 `del()`/`delByPattern()` 패턴 적용
+4. 캐시 키에 반드시 `userId`를 포함하여 사용자 격리 유지
+5. TTL은 데이터 변경 빈도에 따라 설정 (자주 변경: 3분, 드물게 변경: 10분)
+6. 단위 테스트에 `CacheService` mock 추가
+
+## 관련 파일
+
+| 파일 | 역할 |
+|------|------|
+| `src/common/cache/cache.service.ts` | 캐시 유틸리티 서비스 |
+| `src/common/cache/cache.module.ts` | AppCacheModule |
+| `src/common/idempotency/idempotency.module.ts` | `REDIS_CLIENT` 제공 (글로벌) |
+| `src/posts/query/*.handler.ts` | Query 캐시 적용 |
+| `src/posts/command/*.handler.ts` | Command 캐시 무효화 |
+| `src/auth/query/get-profile.handler.ts` | 프로필 캐시 적용 |

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -11,6 +11,7 @@ import { userRepositoryProviders } from '@src/auth/user-repository.provider';
 import { JwtStrategy } from '@src/auth/strategy/jwt.strategy';
 import { JwtAuthGuard } from '@src/auth/guard/jwt-auth.guard';
 import { GetProfileHandler } from '@src/auth/query/get-profile.handler';
+import { AppCacheModule } from '@src/common/cache/cache.module';
 
 const commandHandlers = [
   RegisterHandler,
@@ -21,7 +22,7 @@ const commandHandlers = [
 const queryHandlers = [GetProfileHandler];
 
 @Module({
-  imports: [CqrsModule, PassportModule, JwtModule.register({})],
+  imports: [CqrsModule, PassportModule, JwtModule.register({}), AppCacheModule],
   controllers: [AuthController],
   providers: [
     ...commandHandlers,

--- a/src/auth/query/get-profile.handler.spec.ts
+++ b/src/auth/query/get-profile.handler.spec.ts
@@ -5,6 +5,7 @@ import { GetProfileQuery } from '@src/auth/query/get-profile.query';
 import { IUserReadRepository } from '@src/auth/interface/user-read-repository.interface';
 import { User } from '@src/auth/entities/user.entity';
 import { ProfileResponseDto } from '@src/auth/dto/response/profile.response.dto';
+import { CacheService } from '@src/common/cache/cache.service';
 
 describe('GetProfileHandler', () => {
   let handler: GetProfileHandler;
@@ -31,6 +32,15 @@ describe('GetProfileHandler', () => {
       providers: [
         GetProfileHandler,
         { provide: IUserReadRepository, useValue: mockReadRepository },
+        {
+          provide: CacheService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            delByPattern: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/src/auth/query/get-profile.handler.ts
+++ b/src/auth/query/get-profile.handler.ts
@@ -3,17 +3,29 @@ import { NotFoundException } from '@nestjs/common';
 import { GetProfileQuery } from '@src/auth/query/get-profile.query';
 import { IUserReadRepository } from '@src/auth/interface/user-read-repository.interface';
 import { ProfileResponseDto } from '@src/auth/dto/response/profile.response.dto';
+import { CacheService } from '@src/common/cache/cache.service';
+
+const PROFILE_CACHE_TTL = 600; // 10분
 
 @QueryHandler(GetProfileQuery)
 export class GetProfileHandler implements IQueryHandler<GetProfileQuery> {
-  constructor(private readonly userReadRepository: IUserReadRepository) {}
+  constructor(
+    private readonly userReadRepository: IUserReadRepository,
+    private readonly cacheService: CacheService,
+  ) {}
 
   async execute(query: GetProfileQuery): Promise<ProfileResponseDto> {
+    const cacheKey = `profile:${query.userId}`;
+    const cached = await this.cacheService.get<ProfileResponseDto>(cacheKey);
+    if (cached) return cached;
+
     const user = await this.userReadRepository.findById(query.userId);
     if (!user) {
       throw new NotFoundException(`User with ID ${query.userId} not found`);
     }
 
-    return ProfileResponseDto.of(user);
+    const result = ProfileResponseDto.of(user);
+    await this.cacheService.set(cacheKey, result, PROFILE_CACHE_TTL);
+    return result;
   }
 }

--- a/src/common/cache/cache.module.ts
+++ b/src/common/cache/cache.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CacheService } from './cache.service';
+
+@Module({
+  providers: [CacheService],
+  exports: [CacheService],
+})
+export class AppCacheModule {}

--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -1,37 +1,74 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import Redis from 'ioredis';
 
 @Injectable()
 export class CacheService {
+  private readonly logger = new Logger(CacheService.name);
+
   constructor(@Inject('REDIS_CLIENT') private readonly redis: Redis) {}
 
   async get<T>(key: string): Promise<T | undefined> {
-    const data = await this.redis.get(key);
-    return data ? (JSON.parse(data) as T) : undefined;
+    try {
+      const data = await this.redis.get(key);
+      if (!data) {
+        this.logger.debug(`Cache MISS: ${key}`);
+        return undefined;
+      }
+      this.logger.debug(`Cache HIT: ${key}`);
+      return JSON.parse(data) as T;
+    } catch (error) {
+      this.logger.warn(`Cache GET failed: ${key}`, (error as Error).message);
+      try {
+        await this.redis.del(key);
+      } catch {
+        // 키 삭제 실패도 무시
+      }
+      return undefined;
+    }
   }
 
   async set(key: string, value: unknown, ttlSeconds: number): Promise<void> {
-    await this.redis.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+    try {
+      await this.redis.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+      this.logger.debug(`Cache SET: ${key} (TTL: ${ttlSeconds}s)`);
+    } catch (error) {
+      this.logger.warn(`Cache SET failed: ${key}`, (error as Error).message);
+    }
   }
 
   async del(key: string): Promise<void> {
-    await this.redis.del(key);
+    try {
+      await this.redis.del(key);
+      this.logger.debug(`Cache DEL: ${key}`);
+    } catch (error) {
+      this.logger.warn(`Cache DEL failed: ${key}`, (error as Error).message);
+    }
   }
 
   async delByPattern(pattern: string): Promise<void> {
-    let cursor = '0';
-    do {
-      const [nextCursor, keys] = await this.redis.scan(
-        cursor,
-        'MATCH',
-        pattern,
-        'COUNT',
-        100,
+    try {
+      let cursor = '0';
+      let deletedCount = 0;
+      do {
+        const [nextCursor, keys] = await this.redis.scan(
+          cursor,
+          'MATCH',
+          pattern,
+          'COUNT',
+          100,
+        );
+        cursor = nextCursor;
+        if (keys.length > 0) {
+          await this.redis.del(...keys);
+          deletedCount += keys.length;
+        }
+      } while (cursor !== '0');
+      this.logger.debug(`Cache DEL pattern: ${pattern} (${deletedCount} keys)`);
+    } catch (error) {
+      this.logger.warn(
+        `Cache DEL pattern failed: ${pattern}`,
+        (error as Error).message,
       );
-      cursor = nextCursor;
-      if (keys.length > 0) {
-        await this.redis.del(...keys);
-      }
-    } while (cursor !== '0');
+    }
   }
 }

--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -1,0 +1,37 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+
+@Injectable()
+export class CacheService {
+  constructor(@Inject('REDIS_CLIENT') private readonly redis: Redis) {}
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const data = await this.redis.get(key);
+    return data ? (JSON.parse(data) as T) : undefined;
+  }
+
+  async set(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+    await this.redis.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+  }
+
+  async del(key: string): Promise<void> {
+    await this.redis.del(key);
+  }
+
+  async delByPattern(pattern: string): Promise<void> {
+    let cursor = '0';
+    do {
+      const [nextCursor, keys] = await this.redis.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        100,
+      );
+      cursor = nextCursor;
+      if (keys.length > 0) {
+        await this.redis.del(...keys);
+      }
+    } while (cursor !== '0');
+  }
+}

--- a/src/common/cache/cache.service.ts
+++ b/src/common/cache/cache.service.ts
@@ -45,6 +45,11 @@ export class CacheService {
     }
   }
 
+  /**
+   * 패턴에 매칭되는 모든 캐시 키를 일괄 삭제한다.
+   * 예: `posts:1:*` → userId=1인 사용자의 모든 목록 캐시 삭제.
+   * KEYS 대신 SCAN을 사용하여 Redis 블로킹 없이 점진적으로 처리한다.
+   */
   async delByPattern(pattern: string): Promise<void> {
     try {
       let cursor = '0';

--- a/src/posts/command/create-post.handler.spec.ts
+++ b/src/posts/command/create-post.handler.spec.ts
@@ -5,6 +5,7 @@ import { CreatePostHandler } from '@src/posts/command/create-post.handler';
 import { CreatePostCommand } from '@src/posts/command/create-post.command';
 import { IPostReadRepository } from '@src/posts/interface/post-read-repository.interface';
 import { IPostWriteRepository } from '@src/posts/interface/post-write-repository.interface';
+import { CacheService } from '@src/common/cache/cache.service';
 import { Post } from '@src/posts/entities/post.entity';
 
 describe('CreatePostHandler', () => {
@@ -36,6 +37,15 @@ describe('CreatePostHandler', () => {
         { provide: IPostReadRepository, useValue: mockReadRepository },
         { provide: IPostWriteRepository, useValue: mockWriteRepository },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: CacheService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            delByPattern: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/src/posts/command/create-post.handler.ts
+++ b/src/posts/command/create-post.handler.ts
@@ -6,6 +6,7 @@ import { CreatePostCommand } from '@src/posts/command/create-post.command';
 import { PostCreatedEvent } from '@src/posts/event/post-created.event';
 import { IPostReadRepository } from '@src/posts/interface/post-read-repository.interface';
 import { IPostWriteRepository } from '@src/posts/interface/post-write-repository.interface';
+import { CacheService } from '@src/common/cache/cache.service';
 
 @CommandHandler(CreatePostCommand)
 export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
@@ -13,6 +14,7 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
     private readonly postReadRepository: IPostReadRepository,
     private readonly postWriteRepository: IPostWriteRepository,
     private readonly eventEmitter: EventEmitter2,
+    private readonly cacheService: CacheService,
   ) {}
 
   async execute(command: CreatePostCommand): Promise<number> {
@@ -37,6 +39,7 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
         PostCreatedEvent.event,
         new PostCreatedEvent(post.id, command.title, command.userId),
       );
+      await this.cacheService.delByPattern(`posts:${command.userId}:*`);
       return post.id;
     } catch (error) {
       if (

--- a/src/posts/command/delete-post.handler.spec.ts
+++ b/src/posts/command/delete-post.handler.spec.ts
@@ -3,6 +3,7 @@ import { NotFoundException } from '@nestjs/common';
 import { DeletePostHandler } from '@src/posts/command/delete-post.handler';
 import { DeletePostCommand } from '@src/posts/command/delete-post.command';
 import { IPostWriteRepository } from '@src/posts/interface/post-write-repository.interface';
+import { CacheService } from '@src/common/cache/cache.service';
 
 describe('DeletePostHandler', () => {
   let handler: DeletePostHandler;
@@ -19,6 +20,15 @@ describe('DeletePostHandler', () => {
       providers: [
         DeletePostHandler,
         { provide: IPostWriteRepository, useValue: mockWriteRepository },
+        {
+          provide: CacheService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            delByPattern: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/src/posts/command/delete-post.handler.ts
+++ b/src/posts/command/delete-post.handler.ts
@@ -2,10 +2,14 @@ import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { NotFoundException } from '@nestjs/common';
 import { DeletePostCommand } from '@src/posts/command/delete-post.command';
 import { IPostWriteRepository } from '@src/posts/interface/post-write-repository.interface';
+import { CacheService } from '@src/common/cache/cache.service';
 
 @CommandHandler(DeletePostCommand)
 export class DeletePostHandler implements ICommandHandler<DeletePostCommand> {
-  constructor(private readonly postWriteRepository: IPostWriteRepository) {}
+  constructor(
+    private readonly postWriteRepository: IPostWriteRepository,
+    private readonly cacheService: CacheService,
+  ) {}
 
   async execute(command: DeletePostCommand): Promise<void> {
     const affected = await this.postWriteRepository.delete(
@@ -15,5 +19,8 @@ export class DeletePostHandler implements ICommandHandler<DeletePostCommand> {
     if (affected === 0) {
       throw new NotFoundException(`Post with ID ${command.id} not found`);
     }
+
+    await this.cacheService.del(`post:${command.userId}:${command.id}`);
+    await this.cacheService.delByPattern(`posts:${command.userId}:*`);
   }
 }

--- a/src/posts/command/update-post.handler.spec.ts
+++ b/src/posts/command/update-post.handler.spec.ts
@@ -3,6 +3,7 @@ import { NotFoundException } from '@nestjs/common';
 import { UpdatePostHandler } from '@src/posts/command/update-post.handler';
 import { UpdatePostCommand } from '@src/posts/command/update-post.command';
 import { IPostWriteRepository } from '@src/posts/interface/post-write-repository.interface';
+import { CacheService } from '@src/common/cache/cache.service';
 
 describe('UpdatePostHandler', () => {
   let handler: UpdatePostHandler;
@@ -19,6 +20,15 @@ describe('UpdatePostHandler', () => {
       providers: [
         UpdatePostHandler,
         { provide: IPostWriteRepository, useValue: mockWriteRepository },
+        {
+          provide: CacheService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            delByPattern: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/src/posts/command/update-post.handler.ts
+++ b/src/posts/command/update-post.handler.ts
@@ -2,10 +2,14 @@ import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { NotFoundException } from '@nestjs/common';
 import { UpdatePostCommand } from '@src/posts/command/update-post.command';
 import { IPostWriteRepository } from '@src/posts/interface/post-write-repository.interface';
+import { CacheService } from '@src/common/cache/cache.service';
 
 @CommandHandler(UpdatePostCommand)
 export class UpdatePostHandler implements ICommandHandler<UpdatePostCommand> {
-  constructor(private readonly postWriteRepository: IPostWriteRepository) {}
+  constructor(
+    private readonly postWriteRepository: IPostWriteRepository,
+    private readonly cacheService: CacheService,
+  ) {}
 
   async execute(command: UpdatePostCommand): Promise<void> {
     const affected = await this.postWriteRepository.update(
@@ -20,5 +24,8 @@ export class UpdatePostHandler implements ICommandHandler<UpdatePostCommand> {
     if (affected === 0) {
       throw new NotFoundException(`Post with ID ${command.id} not found`);
     }
+
+    await this.cacheService.del(`post:${command.userId}:${command.id}`);
+    await this.cacheService.delByPattern(`posts:${command.userId}:*`);
   }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -10,6 +10,7 @@ import { GetPostByIdHandler } from '@src/posts/query/get-post-by-id.handler';
 import { FindAllPostsPaginatedHandler } from '@src/posts/query/find-all-posts-paginated.handler';
 import { postRepositoryProviders } from '@src/posts/post-repository.provider';
 import { SlackModule } from '@src/slack/slack.module';
+import { AppCacheModule } from '@src/common/cache/cache.module';
 
 const commandHandlers = [
   CreatePostHandler,
@@ -22,7 +23,7 @@ const queryHandlers = [GetPostByIdHandler, FindAllPostsPaginatedHandler];
 const eventHandlers = [PostCreatedHandler];
 
 @Module({
-  imports: [CqrsModule, AuthModule, SlackModule],
+  imports: [CqrsModule, AuthModule, SlackModule, AppCacheModule],
   controllers: [PostsController],
   providers: [
     ...commandHandlers,

--- a/src/posts/query/find-all-posts-paginated.handler.spec.ts
+++ b/src/posts/query/find-all-posts-paginated.handler.spec.ts
@@ -4,6 +4,7 @@ import { FindAllPostsPaginatedQuery } from '@src/posts/query/find-all-posts-pagi
 import { IPostReadRepository } from '@src/posts/interface/post-read-repository.interface';
 import { Post } from '@src/posts/entities/post.entity';
 import { PostResponseDto } from '@src/posts/dto/response/post.response.dto';
+import { CacheService } from '@src/common/cache/cache.service';
 
 describe('FindAllPostsPaginatedHandler', () => {
   let handler: FindAllPostsPaginatedHandler;
@@ -42,6 +43,15 @@ describe('FindAllPostsPaginatedHandler', () => {
       providers: [
         FindAllPostsPaginatedHandler,
         { provide: IPostReadRepository, useValue: mockReadRepository },
+        {
+          provide: CacheService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            delByPattern: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/src/posts/query/find-all-posts-paginated.handler.ts
+++ b/src/posts/query/find-all-posts-paginated.handler.ts
@@ -3,14 +3,28 @@ import { FindAllPostsPaginatedQuery } from '@src/posts/query/find-all-posts-pagi
 import { IPostReadRepository } from '@src/posts/interface/post-read-repository.interface';
 import { PostResponseDto } from '@src/posts/dto/response/post.response.dto';
 import { PaginatedResponseDto } from '@src/common/dto/response/paginated.response.dto';
+import { CacheService } from '@src/common/cache/cache.service';
+
+const POSTS_LIST_CACHE_TTL = 180; // 3분
 
 @QueryHandler(FindAllPostsPaginatedQuery)
 export class FindAllPostsPaginatedHandler implements IQueryHandler<FindAllPostsPaginatedQuery> {
-  constructor(private readonly postReadRepository: IPostReadRepository) {}
+  constructor(
+    private readonly postReadRepository: IPostReadRepository,
+    private readonly cacheService: CacheService,
+  ) {}
 
   async execute(
     query: FindAllPostsPaginatedQuery,
   ): Promise<PaginatedResponseDto<PostResponseDto>> {
+    const { userId, isPublished } = query.filter;
+    const cacheKey = `posts:${userId}:${query.page}:${query.limit}:${isPublished ?? 'all'}`;
+    const cached =
+      await this.cacheService.get<PaginatedResponseDto<PostResponseDto>>(
+        cacheKey,
+      );
+    if (cached) return cached;
+
     const [posts, totalElements] =
       await this.postReadRepository.findAllPaginated(
         query.page,
@@ -19,12 +33,14 @@ export class FindAllPostsPaginatedHandler implements IQueryHandler<FindAllPostsP
       );
 
     const items = posts.map((post) => PostResponseDto.of(post));
-
-    return PaginatedResponseDto.of(
+    const result = PaginatedResponseDto.of(
       items,
       totalElements,
       query.page,
       query.limit,
     );
+
+    await this.cacheService.set(cacheKey, result, POSTS_LIST_CACHE_TTL);
+    return result;
   }
 }

--- a/src/posts/query/get-post-by-id.handler.spec.ts
+++ b/src/posts/query/get-post-by-id.handler.spec.ts
@@ -5,6 +5,7 @@ import { GetPostByIdQuery } from '@src/posts/query/get-post-by-id.query';
 import { IPostReadRepository } from '@src/posts/interface/post-read-repository.interface';
 import { Post } from '@src/posts/entities/post.entity';
 import { PostResponseDto } from '@src/posts/dto/response/post.response.dto';
+import { CacheService } from '@src/common/cache/cache.service';
 
 describe('GetPostByIdHandler', () => {
   let handler: GetPostByIdHandler;
@@ -32,6 +33,15 @@ describe('GetPostByIdHandler', () => {
       providers: [
         GetPostByIdHandler,
         { provide: IPostReadRepository, useValue: mockReadRepository },
+        {
+          provide: CacheService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            delByPattern: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/src/posts/query/get-post-by-id.handler.ts
+++ b/src/posts/query/get-post-by-id.handler.ts
@@ -3,17 +3,29 @@ import { NotFoundException } from '@nestjs/common';
 import { GetPostByIdQuery } from '@src/posts/query/get-post-by-id.query';
 import { IPostReadRepository } from '@src/posts/interface/post-read-repository.interface';
 import { PostResponseDto } from '@src/posts/dto/response/post.response.dto';
+import { CacheService } from '@src/common/cache/cache.service';
+
+const POST_CACHE_TTL = 300; // 5분
 
 @QueryHandler(GetPostByIdQuery)
 export class GetPostByIdHandler implements IQueryHandler<GetPostByIdQuery> {
-  constructor(private readonly postReadRepository: IPostReadRepository) {}
+  constructor(
+    private readonly postReadRepository: IPostReadRepository,
+    private readonly cacheService: CacheService,
+  ) {}
 
   async execute(query: GetPostByIdQuery): Promise<PostResponseDto> {
+    const cacheKey = `post:${query.userId}:${query.id}`;
+    const cached = await this.cacheService.get<PostResponseDto>(cacheKey);
+    if (cached) return cached;
+
     const post = await this.postReadRepository.findById(query.id);
     if (!post || post.userId !== query.userId) {
       throw new NotFoundException(`Post with ID ${query.id} not found`);
     }
 
-    return PostResponseDto.of(post);
+    const result = PostResponseDto.of(post);
+    await this.cacheService.set(cacheKey, result, POST_CACHE_TTL);
+    return result;
   }
 }


### PR DESCRIPTION
## Summary

- 기존 `REDIS_CLIENT`(ioredis)를 재사용하는 `CacheService` 추가 (추가 패키지 없음)
- CQRS Query Handler에 캐시 조회/저장 적용 (게시물 5분, 목록 3분, 프로필 10분)
- CQRS Command Handler에 쓰기 후 캐시 무효화 적용 (개별 + 목록)
- 모든 캐시 키에 `userId` 포함하여 사용자 격리

## Changes

| 파일 | 변경 |
|------|------|
| `src/common/cache/cache.service.ts` | 신규 — Redis 기반 캐시 유틸리티 (get/set/del/delByPattern) |
| `src/common/cache/cache.module.ts` | 신규 — AppCacheModule |
| `src/posts/query/*.handler.ts` | 캐시 조회/저장 추가 |
| `src/auth/query/get-profile.handler.ts` | 캐시 조회/저장 추가 |
| `src/posts/command/*.handler.ts` | 캐시 무효화 추가 |
| `src/posts/posts.module.ts` | AppCacheModule import |
| `src/auth/auth.module.ts` | AppCacheModule import |
| `*.spec.ts` | CacheService mock 추가 |

## Test plan

- [x] `pnpm format` — 포맷 확인
- [x] `pnpm lint:check` — 린트 통과
- [x] `pnpm build:local` — 빌드 성공
- [x] `pnpm test` — 단위 테스트 48개 통과
- [x] `pnpm test:e2e` — 통합 테스트 81개 통과

> **Merge Strategy**: Create a merge commit을 사용해주세요.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 조회, 개별 게시물 조회 및 게시물 목록에 캐시 적용으로 응답 속도 향상
  * 게시물 생성·수정·삭제 시 관련 캐시를 자동 무효화해 최신성 보장
  * 헬스체크(서비스/DB/Redis) 엔드포인트 및 전역 속도 제한(Throttling) 적용

* **문서**
  * 캐시 가이드와 README 업데이트로 사용법·키 패턴·TTL·실패 대처 방식 명세

* **테스트**
  * 캐시 의존성 모의(Mock) 설정이 테스트에 추가됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->