### PR TITLE
feat(versioning): URI 기반 API Versioning 적용

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,13 @@ Controller → CommandBus / QueryBus → Handler (검증 + 로직) → IPostRead
 - User 엔티티와 Post 엔티티는 `userId` FK로 연결 (1:N)
 - Posts와 동일한 Repository Pattern DI 구조 적용 (`IUserReadRepository` / `IUserWriteRepository`)
 
+### API Versioning
+
+- URI 기반 버전 관리 (`VersioningType.URI`, `defaultVersion: '1'`) — 모든 API 라우트에 `/v1/` 프리픽스 자동 적용
+- Health 엔드포인트는 `VERSION_NEUTRAL` — `/health`로 버전 프리픽스 없이 접근 (K8s probe 호환)
+- 새 컨트롤러 추가 시 `defaultVersion`에 의해 자동으로 `/v1/` 적용. 별도 `@Version()` 데코레이터 불필요
+- 통합 테스트 URL도 `/v1/` 프리픽스 사용 필수
+
 ### Soft Delete
 
 - Post 엔티티에 `@DeleteDateColumn()` 적용 — 삭제 시 `deletedAt` 타임스탬프 기록, 실제 행은 유지

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { SkipThrottle } from '@nestjs/throttler';
 import {
@@ -11,7 +11,7 @@ import { RedisHealthIndicator } from './redis-health.indicator';
 
 @ApiTags('Health')
 @SkipThrottle({ short: true, long: true })
-@Controller('health')
+@Controller({ path: 'health', version: VERSION_NEUTRAL })
 export class HealthController {
   constructor(
     private readonly health: HealthCheckService,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import './instrumentation';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { Logger } from 'nestjs-pino';
@@ -21,6 +21,11 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
 
   const config = new DocumentBuilder()
     .setTitle('Posts API')

--- a/test/auth.integration-spec.ts
+++ b/test/auth.integration-spec.ts
@@ -33,14 +33,14 @@ describe('Auth (integration)', () => {
 
   function registerUser(body: Record<string, unknown> = {}) {
     return request(app.getHttpServer())
-      .post('/auth/register')
+      .post('/v1/auth/register')
       .send({ ...defaultUser, ...body });
   }
 
   async function registerAndLogin(body: Record<string, unknown> = {}) {
     await registerUser(body).expect(201);
     const loginRes = await request(app.getHttpServer())
-      .post('/auth/login')
+      .post('/v1/auth/login')
       .send({
         email: (body.email as string) ?? defaultUser.email,
         password: (body.password as string) ?? defaultUser.password,
@@ -65,7 +65,7 @@ describe('Auth (integration)', () => {
       await registerUser().expect(201);
 
       await request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ email: defaultUser.email, password: defaultUser.password })
         .expect(200);
     });
@@ -80,14 +80,14 @@ describe('Auth (integration)', () => {
 
     it('should return 400 when email is missing', () => {
       return request(app.getHttpServer())
-        .post('/auth/register')
+        .post('/v1/auth/register')
         .send({ password: 'password123', name: '테스트' })
         .expect(400);
     });
 
     it('should return 400 when email format is invalid', () => {
       return request(app.getHttpServer())
-        .post('/auth/register')
+        .post('/v1/auth/register')
         .send({
           email: 'not-an-email',
           password: 'password123',
@@ -98,28 +98,28 @@ describe('Auth (integration)', () => {
 
     it('should return 400 when password is missing', () => {
       return request(app.getHttpServer())
-        .post('/auth/register')
+        .post('/v1/auth/register')
         .send({ email: 'a@b.com', name: '테스트' })
         .expect(400);
     });
 
     it('should return 400 when password is shorter than 8 characters', () => {
       return request(app.getHttpServer())
-        .post('/auth/register')
+        .post('/v1/auth/register')
         .send({ email: 'a@b.com', password: 'short', name: '테스트' })
         .expect(400);
     });
 
     it('should return 400 when name is missing', () => {
       return request(app.getHttpServer())
-        .post('/auth/register')
+        .post('/v1/auth/register')
         .send({ email: 'a@b.com', password: 'password123' })
         .expect(400);
     });
 
     it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
-        .post('/auth/register')
+        .post('/v1/auth/register')
         .send({ ...defaultUser, hacked: true })
         .expect(400);
     });
@@ -133,7 +133,7 @@ describe('Auth (integration)', () => {
       await registerUser().expect(201);
 
       const res = await request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ email: defaultUser.email, password: defaultUser.password })
         .expect(200);
 
@@ -149,7 +149,7 @@ describe('Auth (integration)', () => {
 
     it('should return 401 for non-existent email', () => {
       return request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ email: 'nobody@example.com', password: 'password123' })
         .expect(401);
     });
@@ -158,28 +158,28 @@ describe('Auth (integration)', () => {
       await registerUser().expect(201);
 
       return request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ email: defaultUser.email, password: 'wrongpassword' })
         .expect(401);
     });
 
     it('should return 400 when email is missing', () => {
       return request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ password: 'password123' })
         .expect(400);
     });
 
     it('should return 400 when password is missing', () => {
       return request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ email: 'a@b.com' })
         .expect(400);
     });
 
     it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
-        .post('/auth/login')
+        .post('/v1/auth/login')
         .send({ email: 'a@b.com', password: 'password123', hacked: true })
         .expect(400);
     });
@@ -193,7 +193,7 @@ describe('Auth (integration)', () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .send({ refreshToken: tokens.refreshToken })
         .expect(200);
 
@@ -207,34 +207,34 @@ describe('Auth (integration)', () => {
 
       // 첫 번째 refresh — 성공
       await request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .send({ refreshToken: tokens.refreshToken })
         .expect(200);
 
       // 이전 토큰으로 다시 시도 — 실패 (rotation됨)
       await request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .send({ refreshToken: tokens.refreshToken })
         .expect(401);
     });
 
     it('should return 401 for invalid token', () => {
       return request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .send({ refreshToken: 'invalid-token' })
         .expect(401);
     });
 
     it('should return 400 when refreshToken is missing', () => {
       return request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .send({})
         .expect(400);
     });
 
     it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .send({ refreshToken: 'some-token', hacked: true })
         .expect(400);
     });
@@ -248,7 +248,7 @@ describe('Auth (integration)', () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
-        .get('/auth/profile')
+        .get('/v1/auth/profile')
         .set('Authorization', `Bearer ${tokens.accessToken}`)
         .expect(200);
 
@@ -271,7 +271,7 @@ describe('Auth (integration)', () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
-        .get('/auth/profile')
+        .get('/v1/auth/profile')
         .set('Authorization', `Bearer ${tokens.accessToken}`)
         .expect(200);
 
@@ -280,12 +280,12 @@ describe('Auth (integration)', () => {
     });
 
     it('should return 401 without token', () => {
-      return request(app.getHttpServer()).get('/auth/profile').expect(401);
+      return request(app.getHttpServer()).get('/v1/auth/profile').expect(401);
     });
 
     it('should return 401 with invalid token', () => {
       return request(app.getHttpServer())
-        .get('/auth/profile')
+        .get('/v1/auth/profile')
         .set('Authorization', 'Bearer invalid-token')
         .expect(401);
     });
@@ -299,7 +299,7 @@ describe('Auth (integration)', () => {
       const { accessToken } = await registerAndLogin();
 
       await request(app.getHttpServer())
-        .post('/auth/logout')
+        .post('/v1/auth/logout')
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(204);
     });
@@ -308,23 +308,23 @@ describe('Auth (integration)', () => {
       const { accessToken, refreshToken } = await registerAndLogin();
 
       await request(app.getHttpServer())
-        .post('/auth/logout')
+        .post('/v1/auth/logout')
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(204);
 
       await request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/v1/auth/refresh')
         .send({ refreshToken })
         .expect(401);
     });
 
     it('should return 401 when no Authorization header is provided', async () => {
-      await request(app.getHttpServer()).post('/auth/logout').expect(401);
+      await request(app.getHttpServer()).post('/v1/auth/logout').expect(401);
     });
 
     it('should return 401 when an invalid token is provided', async () => {
       await request(app.getHttpServer())
-        .post('/auth/logout')
+        .post('/v1/auth/logout')
         .set('Authorization', 'Bearer invalid-token')
         .expect(401);
     });

--- a/test/posts.integration-spec.ts
+++ b/test/posts.integration-spec.ts
@@ -34,11 +34,11 @@ describe('Posts (integration)', () => {
   async function registerAndLogin(body: Record<string, unknown> = {}) {
     const user = { ...defaultUser, ...body };
     await request(app.getHttpServer())
-      .post('/auth/register')
+      .post('/v1/auth/register')
       .send(user)
       .expect(201);
     const loginRes = await request(app.getHttpServer())
-      .post('/auth/login')
+      .post('/v1/auth/login')
       .send({ email: user.email, password: user.password })
       .expect(200);
     return loginRes.body as { accessToken: string; refreshToken: string };
@@ -46,7 +46,7 @@ describe('Posts (integration)', () => {
 
   function createPost(token: string, body: Record<string, unknown> = {}) {
     return request(app.getHttpServer())
-      .post('/posts')
+      .post('/v1/posts')
       .set('Authorization', `Bearer ${token}`)
       .set('Idempotency-Key', crypto.randomUUID())
       .send({ title: 'Default Title', content: 'Default Content', ...body });
@@ -59,7 +59,7 @@ describe('Posts (integration)', () => {
     const createRes = await createPost(token, body).expect(201);
     const id = createRes.body.id as number;
     const getRes = await request(app.getHttpServer())
-      .get(`/posts/${id}`)
+      .get(`/v1/posts/${id}`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
     return getRes;
@@ -70,29 +70,29 @@ describe('Posts (integration)', () => {
   // ============================================================
   describe('Authentication required', () => {
     it('should return 401 for GET /posts without token', () => {
-      return request(app.getHttpServer()).get('/posts').expect(401);
+      return request(app.getHttpServer()).get('/v1/posts').expect(401);
     });
 
     it('should return 401 for GET /posts/:id without token', () => {
-      return request(app.getHttpServer()).get('/posts/1').expect(401);
+      return request(app.getHttpServer()).get('/v1/posts/1').expect(401);
     });
 
     it('should return 401 for POST /posts without token', () => {
       return request(app.getHttpServer())
-        .post('/posts')
+        .post('/v1/posts')
         .send({ title: 'Test', content: 'Content' })
         .expect(401);
     });
 
     it('should return 401 for PATCH /posts/:id without token', () => {
       return request(app.getHttpServer())
-        .patch('/posts/1')
+        .patch('/v1/posts/1')
         .send({ title: 'Test', content: 'Content', isPublished: false })
         .expect(401);
     });
 
     it('should return 401 for DELETE /posts/:id without token', () => {
-      return request(app.getHttpServer()).delete('/posts/1').expect(401);
+      return request(app.getHttpServer()).delete('/v1/posts/1').expect(401);
     });
   });
 
@@ -181,7 +181,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 when title is missing', () => {
       return request(app.getHttpServer())
-        .post('/posts')
+        .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .send({ content: 'No title' })
         .expect(400);
@@ -189,7 +189,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 when content is missing', () => {
       return request(app.getHttpServer())
-        .post('/posts')
+        .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'No content' })
         .expect(400);
@@ -197,7 +197,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 when body is empty', () => {
       return request(app.getHttpServer())
-        .post('/posts')
+        .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .send({})
         .expect(400);
@@ -205,7 +205,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
-        .post('/posts')
+        .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'Post', content: 'Content', hacked: true })
         .expect(400);
@@ -258,7 +258,7 @@ describe('Posts (integration)', () => {
       await createPost(token, { title: 'Post A' }).expect(201);
 
       const res = await request(app.getHttpServer())
-        .get('/posts')
+        .get('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -275,7 +275,7 @@ describe('Posts (integration)', () => {
 
     it('should return empty items when no posts exist', async () => {
       const res = await request(app.getHttpServer())
-        .get('/posts')
+        .get('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -290,7 +290,7 @@ describe('Posts (integration)', () => {
       }
 
       const res = await request(app.getHttpServer())
-        .get('/posts?page=2&limit=2')
+        .get('/v1/posts?page=2&limit=2')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -309,7 +309,7 @@ describe('Posts (integration)', () => {
       await createPost(token, { title: 'Third' }).expect(201);
 
       const res = await request(app.getHttpServer())
-        .get('/posts?limit=3')
+        .get('/v1/posts?limit=3')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -324,7 +324,7 @@ describe('Posts (integration)', () => {
       }
 
       const res = await request(app.getHttpServer())
-        .get('/posts?page=2&limit=2')
+        .get('/v1/posts?page=2&limit=2')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -337,7 +337,7 @@ describe('Posts (integration)', () => {
       await createPost(token).expect(201);
 
       const res = await request(app.getHttpServer())
-        .get('/posts')
+        .get('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -353,21 +353,21 @@ describe('Posts (integration)', () => {
 
     it('should return 400 when page is 0', () => {
       return request(app.getHttpServer())
-        .get('/posts?page=0')
+        .get('/v1/posts?page=0')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
 
     it('should return 400 when limit exceeds 100', () => {
       return request(app.getHttpServer())
-        .get('/posts?limit=101')
+        .get('/v1/posts?limit=101')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
 
     it('should return 400 when page is not a number', () => {
       return request(app.getHttpServer())
-        .get('/posts?page=abc')
+        .get('/v1/posts?page=abc')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -383,7 +383,7 @@ describe('Posts (integration)', () => {
       }).expect(201);
 
       const res = await request(app.getHttpServer())
-        .get('/posts?isPublished=true')
+        .get('/v1/posts?isPublished=true')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -400,7 +400,7 @@ describe('Posts (integration)', () => {
       await createPost(token, { title: 'Draft' }).expect(201);
 
       const res = await request(app.getHttpServer())
-        .get('/posts?isPublished=false')
+        .get('/v1/posts?isPublished=false')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -419,7 +419,7 @@ describe('Posts (integration)', () => {
       await createPost(token, { title: 'Draft' }).expect(201);
 
       const res = await request(app.getHttpServer())
-        .get('/posts?isPublished=true&limit=2&page=1')
+        .get('/v1/posts?isPublished=true&limit=2&page=1')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -430,7 +430,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 for invalid isPublished value', () => {
       return request(app.getHttpServer())
-        .get('/posts?isPublished=notabool')
+        .get('/v1/posts?isPublished=notabool')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -447,7 +447,7 @@ describe('Posts (integration)', () => {
       );
 
       const res = await request(app.getHttpServer())
-        .get('/posts')
+        .get('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -465,7 +465,7 @@ describe('Posts (integration)', () => {
       });
 
       const res = await request(app.getHttpServer())
-        .get('/posts')
+        .get('/v1/posts')
         .set('Authorization', `Bearer ${tokens2.accessToken}`)
         .expect(200);
 
@@ -493,7 +493,7 @@ describe('Posts (integration)', () => {
 
       const id = createRes.body.id as number;
       const res = await request(app.getHttpServer())
-        .get(`/posts/${id}`)
+        .get(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -510,7 +510,7 @@ describe('Posts (integration)', () => {
       }).expect(201);
 
       const res = await request(app.getHttpServer())
-        .get(`/posts/${createRes.body.id as number}`)
+        .get(`/v1/posts/${createRes.body.id as number}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -525,7 +525,7 @@ describe('Posts (integration)', () => {
 
     it('should return 404 when post not found', () => {
       return request(app.getHttpServer())
-        .get('/posts/99999')
+        .get('/v1/posts/99999')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .expect((res) => {
@@ -546,14 +546,14 @@ describe('Posts (integration)', () => {
       });
 
       await request(app.getHttpServer())
-        .get(`/posts/${id}`)
+        .get(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${tokens2.accessToken}`)
         .expect(404);
     });
 
     it('should return 400 for non-numeric id', () => {
       return request(app.getHttpServer())
-        .get('/posts/abc')
+        .get('/v1/posts/abc')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -581,13 +581,13 @@ describe('Posts (integration)', () => {
       const id = createRes.body.id as number;
 
       await request(app.getHttpServer())
-        .patch(`/posts/${id}`)
+        .patch(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${token}`)
         .send(fullUpdate)
         .expect(204);
 
       const getRes = await request(app.getHttpServer())
-        .get(`/posts/${id}`)
+        .get(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -598,7 +598,7 @@ describe('Posts (integration)', () => {
 
     it('should return 404 when post not found', () => {
       return request(app.getHttpServer())
-        .patch('/posts/99999')
+        .patch('/v1/posts/99999')
         .set('Authorization', `Bearer ${token}`)
         .send(fullUpdate)
         .expect(404)
@@ -617,7 +617,7 @@ describe('Posts (integration)', () => {
       });
 
       return request(app.getHttpServer())
-        .patch(`/posts/${id}`)
+        .patch(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${tokens2.accessToken}`)
         .send(fullUpdate)
         .expect(404);
@@ -625,7 +625,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 for non-numeric id', () => {
       return request(app.getHttpServer())
-        .patch('/posts/abc')
+        .patch('/v1/posts/abc')
         .set('Authorization', `Bearer ${token}`)
         .send(fullUpdate)
         .expect(400);
@@ -633,7 +633,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 for invalid body (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
-        .patch('/posts/1')
+        .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
         .send({ ...fullUpdate, hacked: true })
         .expect(400);
@@ -641,7 +641,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 when required field is missing', () => {
       return request(app.getHttpServer())
-        .patch('/posts/1')
+        .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'Only Title' })
         .expect(400);
@@ -649,7 +649,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 when title is empty string', () => {
       return request(app.getHttpServer())
-        .patch('/posts/1')
+        .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: '', content: 'Content', isPublished: false })
         .expect(400);
@@ -657,7 +657,7 @@ describe('Posts (integration)', () => {
 
     it('should return 400 when content is empty string', () => {
       return request(app.getHttpServer())
-        .patch('/posts/1')
+        .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
         .send({ title: 'Title', content: '', isPublished: false })
         .expect(400);
@@ -680,19 +680,19 @@ describe('Posts (integration)', () => {
       const id = createRes.body.id as number;
 
       await request(app.getHttpServer())
-        .delete(`/posts/${id}`)
+        .delete(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(204);
 
       await request(app.getHttpServer())
-        .get(`/posts/${id}`)
+        .get(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(404);
     });
 
     it('should return 404 when post not found', () => {
       return request(app.getHttpServer())
-        .delete('/posts/99999')
+        .delete('/v1/posts/99999')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .expect((res) => {
@@ -710,14 +710,14 @@ describe('Posts (integration)', () => {
       });
 
       return request(app.getHttpServer())
-        .delete(`/posts/${id}`)
+        .delete(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${tokens2.accessToken}`)
         .expect(404);
     });
 
     it('should return 400 for non-numeric id', () => {
       return request(app.getHttpServer())
-        .delete('/posts/abc')
+        .delete('/v1/posts/abc')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
@@ -730,7 +730,7 @@ describe('Posts (integration)', () => {
       const id = createRes.body.id as number;
 
       await request(app.getHttpServer())
-        .delete(`/posts/${id}`)
+        .delete(`/v1/posts/${id}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(204);
 
@@ -742,7 +742,7 @@ describe('Posts (integration)', () => {
       expect(newRes.body.id).not.toBe(id);
 
       const getRes = await request(app.getHttpServer())
-        .get(`/posts/${newRes.body.id as number}`)
+        .get(`/v1/posts/${newRes.body.id as number}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
@@ -755,12 +755,12 @@ describe('Posts (integration)', () => {
       const res2 = await createPost(token, { title: 'Delete Me' }).expect(201);
 
       await request(app.getHttpServer())
-        .delete(`/posts/${res2.body.id as number}`)
+        .delete(`/v1/posts/${res2.body.id as number}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(204);
 
       const getRes = await request(app.getHttpServer())
-        .get(`/posts/${res1.body.id as number}`)
+        .get(`/v1/posts/${res1.body.id as number}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 

--- a/test/setup/integration-helper.ts
+++ b/test/setup/integration-helper.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import {
+  INestApplication,
+  ValidationPipe,
+  VersioningType,
+} from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { App } from 'supertest/types';
 import { DataSource, EntityManager, QueryRunner } from 'typeorm';
@@ -36,6 +40,11 @@ export async function createIntegrationApp(): Promise<INestApplication<App>> {
       transform: true,
     }),
   );
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
+
   await app.init();
 
   return app;


### PR DESCRIPTION
## Summary

- `VersioningType.URI` + `defaultVersion: '1'` 설정으로 모든 API 라우트에 `/v1/` 프리픽스 자동 적용
- HealthController에 `VERSION_NEUTRAL` 설정 — `/health` 경로는 K8s probe 호환을 위해 버전 프리픽스 없이 유지
- 통합 테스트 헬퍼 및 테스트 URL 일괄 업데이트 (`/posts` → `/v1/posts`, `/auth/*` → `/v1/auth/*`)

> **Merge Strategy**: Create a merge commit을 사용해주세요.

## 변경 파일

| 파일 | 변경 |
|------|------|
| `src/main.ts` | `app.enableVersioning()` 추가 |
| `src/health/health.controller.ts` | `VERSION_NEUTRAL` 설정 |
| `test/setup/integration-helper.ts` | 테스트 앱 versioning 설정 |
| `test/posts.integration-spec.ts` | URL `/v1/` 프리픽스 적용 |
| `test/auth.integration-spec.ts` | URL `/v1/` 프리픽스 적용 |
| `CLAUDE.md` | API Versioning 섹션 추가 |

## Test Plan

- [x] `pnpm format` — 통과
- [x] `pnpm lint:check` — 통과
- [x] `pnpm build:local` — 통과
- [x] `pnpm test` — 단위 테스트 48개 통과
- [x] `pnpm test:e2e` — 통합 테스트 81개 통과

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * URI 기반 API 버전 관리 도입으로 모든 API 엔드포인트에 `/v1/` 프리픽스 적용
  * 헬스체크 엔드포인트는 버전 중립으로 유지

* **문서**
  * API 버전 관리 섹션 추가

* **테스트**
  * 통합 테스트 업데이트하여 버전 관리 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->