### PR TITLE
feat(admin): 별도 admins 테이블 기반 관리자 모듈 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ JWT_REFRESH_SECRET=your-refresh-secret-key
 JWT_ACCESS_EXPIRATION=15m
 JWT_REFRESH_EXPIRATION=7d
 
+JWT_ADMIN_ACCESS_SECRET=your-admin-access-secret-key
+JWT_ADMIN_REFRESH_SECRET=your-admin-refresh-secret-key
+JWT_ADMIN_ACCESS_EXPIRATION=15m
+JWT_ADMIN_REFRESH_EXPIRATION=7d
+
 LOG_LEVEL=debug
 
 SLACK_BOT_TOKEN=xoxb-your-slack-bot-token

--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,10 @@ JWT_REFRESH_SECRET=your-refresh-secret-key
 JWT_ACCESS_EXPIRATION=15m
 JWT_REFRESH_EXPIRATION=7d
 
-JWT_ADMIN_ACCESS_SECRET=your-admin-access-secret-key
-JWT_ADMIN_REFRESH_SECRET=your-admin-refresh-secret-key
 JWT_ADMIN_ACCESS_EXPIRATION=15m
+JWT_ADMIN_ACCESS_SECRET=your-admin-access-secret-key
 JWT_ADMIN_REFRESH_EXPIRATION=7d
+JWT_ADMIN_REFRESH_SECRET=your-admin-refresh-secret-key
 
 LOG_LEVEL=debug
 

--- a/src/admin/admin-repository.provider.ts
+++ b/src/admin/admin-repository.provider.ts
@@ -1,0 +1,10 @@
+import { Provider } from '@nestjs/common';
+import { IAdminReadRepository } from '@src/admin/interface/admin-read-repository.interface';
+import { IAdminWriteRepository } from '@src/admin/interface/admin-write-repository.interface';
+import { AdminRepository } from '@src/admin/admin.repository';
+
+export const adminRepositoryProviders: Provider[] = [
+  AdminRepository,
+  { provide: IAdminReadRepository, useExisting: AdminRepository },
+  { provide: IAdminWriteRepository, useExisting: AdminRepository },
+];

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { PassportModule } from '@nestjs/passport';
+import { JwtModule } from '@nestjs/jwt';
+import { AdminAuthController } from '@src/admin/auth/admin-auth.controller';
+import { AdminRegisterHandler } from '@src/admin/auth/command/admin-register.handler';
+import { AdminLoginHandler } from '@src/admin/auth/command/admin-login.handler';
+import { AdminRefreshTokenHandler } from '@src/admin/auth/command/admin-refresh-token.handler';
+import { AdminLogoutHandler } from '@src/admin/auth/command/admin-logout.handler';
+import { GetAdminProfileHandler } from '@src/admin/auth/query/get-admin-profile.handler';
+import { adminRepositoryProviders } from '@src/admin/admin-repository.provider';
+import { AdminJwtStrategy } from '@src/admin/strategy/admin-jwt.strategy';
+import { AdminJwtAuthGuard } from '@src/admin/guard/admin-jwt-auth.guard';
+
+const commandHandlers = [
+  AdminRegisterHandler,
+  AdminLoginHandler,
+  AdminRefreshTokenHandler,
+  AdminLogoutHandler,
+];
+
+const queryHandlers = [GetAdminProfileHandler];
+
+@Module({
+  imports: [CqrsModule, PassportModule, JwtModule.register({})],
+  controllers: [AdminAuthController],
+  providers: [
+    ...commandHandlers,
+    ...queryHandlers,
+    ...adminRepositoryProviders,
+    AdminJwtStrategy,
+    AdminJwtAuthGuard,
+  ],
+  exports: [AdminJwtAuthGuard],
+})
+export class AdminModule {}

--- a/src/admin/admin.repository.ts
+++ b/src/admin/admin.repository.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { BaseRepository } from '@src/common/base.repository';
+import { IAdminReadRepository } from '@src/admin/interface/admin-read-repository.interface';
+import {
+  CreateAdminInput,
+  IAdminWriteRepository,
+  UpdateAdminInput,
+} from '@src/admin/interface/admin-write-repository.interface';
+import { Admin } from '@src/admin/entities/admin.entity';
+
+@Injectable()
+export class AdminRepository
+  extends BaseRepository
+  implements IAdminReadRepository, IAdminWriteRepository
+{
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+
+  private get adminRepository() {
+    return this.getRepository(Admin);
+  }
+
+  async findById(id: number): Promise<Admin | null> {
+    return this.adminRepository.findOneBy({ id });
+  }
+
+  async findByEmail(email: string): Promise<Admin | null> {
+    return this.adminRepository.findOneBy({ email });
+  }
+
+  async create(input: CreateAdminInput): Promise<Admin> {
+    const admin = this.adminRepository.create(input);
+    return this.adminRepository.save(admin);
+  }
+
+  async update(id: number, input: UpdateAdminInput): Promise<number> {
+    const result = await this.adminRepository.update(id, input);
+    return result.affected ?? 0;
+  }
+}

--- a/src/admin/auth/admin-auth.controller.ts
+++ b/src/admin/auth/admin-auth.controller.ts
@@ -104,6 +104,7 @@ export class AdminAuthController {
   @ApiOkResponse({ type: AdminAuthTokensResponseDto })
   @ApiBadRequestResponse({ description: '잘못된 요청' })
   @ApiUnauthorizedResponse({ description: '유효하지 않은 리프레시 토큰' })
+  @ApiTooManyRequestsResponse({ description: '요청 횟수 초과' })
   async refresh(
     @Body() dto: AdminRefreshTokenRequestDto,
   ): Promise<AdminAuthTokensResponseDto> {

--- a/src/admin/auth/admin-auth.controller.ts
+++ b/src/admin/auth/admin-auth.controller.ts
@@ -1,0 +1,127 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiTooManyRequestsResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { AdminJwtAuthGuard } from '@src/admin/guard/admin-jwt-auth.guard';
+import { CurrentAdmin } from '@src/admin/decorator/current-admin.decorator';
+import { AuthAdmin } from '@src/admin/decorator/auth-admin.type';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+import { AdminRegisterCommand } from '@src/admin/auth/command/admin-register.command';
+import { AdminLoginCommand } from '@src/admin/auth/command/admin-login.command';
+import { AdminRefreshTokenCommand } from '@src/admin/auth/command/admin-refresh-token.command';
+import { AdminLogoutCommand } from '@src/admin/auth/command/admin-logout.command';
+import { GetAdminProfileQuery } from '@src/admin/auth/query/get-admin-profile.query';
+import { AdminRegisterRequestDto } from '@src/admin/dto/request/admin-register.request.dto';
+import { AdminLoginRequestDto } from '@src/admin/dto/request/admin-login.request.dto';
+import { AdminRefreshTokenRequestDto } from '@src/admin/dto/request/admin-refresh-token.request.dto';
+import { AdminRegisterResponseDto } from '@src/admin/dto/response/admin-register.response.dto';
+import { AdminAuthTokensResponseDto } from '@src/admin/dto/response/admin-auth-tokens.response.dto';
+import { AdminProfileResponseDto } from '@src/admin/dto/response/admin-profile.response.dto';
+import { AuthTokens } from '@src/auth/auth.types';
+
+@ApiTags('Admin Auth')
+@Controller('admin/auth')
+export class AdminAuthController {
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) {}
+
+  @Get('profile')
+  @UseGuards(AdminJwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '관리자 프로필 조회' })
+  @ApiOkResponse({ type: AdminProfileResponseDto })
+  @ApiUnauthorizedResponse({ description: '인증되지 않은 요청' })
+  @ApiNotFoundResponse({ description: '관리자를 찾을 수 없음' })
+  async getProfile(
+    @CurrentAdmin() admin: AuthAdmin,
+  ): Promise<AdminProfileResponseDto> {
+    return this.queryBus.execute(new GetAdminProfileQuery(admin.id));
+  }
+
+  @Post('register')
+  @Throttle({ short: { ttl: 1000, limit: 2 }, long: { ttl: 60000, limit: 5 } })
+  @ApiOperation({ summary: '관리자 등록' })
+  @ApiCreatedResponse({ type: AdminRegisterResponseDto })
+  @ApiBadRequestResponse({ description: '잘못된 요청' })
+  @ApiConflictResponse({ description: '중복된 이메일' })
+  @ApiTooManyRequestsResponse({ description: '요청 횟수 초과' })
+  async register(
+    @Body() dto: AdminRegisterRequestDto,
+  ): Promise<AdminRegisterResponseDto> {
+    const id = await this.commandBus.execute<AdminRegisterCommand, number>(
+      new AdminRegisterCommand(
+        dto.email,
+        dto.password,
+        dto.name,
+        dto.role ?? AdminRole.MANAGER,
+      ),
+    );
+    return AdminRegisterResponseDto.of(id);
+  }
+
+  @Post('login')
+  @Throttle({ short: { ttl: 1000, limit: 2 }, long: { ttl: 60000, limit: 5 } })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '관리자 로그인' })
+  @ApiOkResponse({ type: AdminAuthTokensResponseDto })
+  @ApiBadRequestResponse({ description: '잘못된 요청' })
+  @ApiUnauthorizedResponse({ description: '인증 실패' })
+  @ApiTooManyRequestsResponse({ description: '요청 횟수 초과' })
+  async login(
+    @Body() dto: AdminLoginRequestDto,
+  ): Promise<AdminAuthTokensResponseDto> {
+    const tokens = await this.commandBus.execute<AdminLoginCommand, AuthTokens>(
+      new AdminLoginCommand(dto.email, dto.password),
+    );
+    return AdminAuthTokensResponseDto.of(tokens);
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '관리자 토큰 갱신' })
+  @ApiOkResponse({ type: AdminAuthTokensResponseDto })
+  @ApiBadRequestResponse({ description: '잘못된 요청' })
+  @ApiUnauthorizedResponse({ description: '유효하지 않은 리프레시 토큰' })
+  async refresh(
+    @Body() dto: AdminRefreshTokenRequestDto,
+  ): Promise<AdminAuthTokensResponseDto> {
+    const tokens = await this.commandBus.execute<
+      AdminRefreshTokenCommand,
+      AuthTokens
+    >(new AdminRefreshTokenCommand(dto.refreshToken));
+    return AdminAuthTokensResponseDto.of(tokens);
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(AdminJwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '관리자 로그아웃' })
+  @ApiNoContentResponse({ description: '로그아웃 성공' })
+  @ApiUnauthorizedResponse({ description: '인증 실패' })
+  async logout(@CurrentAdmin() admin: AuthAdmin): Promise<void> {
+    await this.commandBus.execute(new AdminLogoutCommand(admin.id));
+  }
+}

--- a/src/admin/auth/admin-auth.controller.ts
+++ b/src/admin/auth/admin-auth.controller.ts
@@ -75,7 +75,7 @@ export class AdminAuthController {
         dto.email,
         dto.password,
         dto.name,
-        dto.role ?? AdminRole.MANAGER,
+        AdminRole.MANAGER,
       ),
     );
     return AdminRegisterResponseDto.of(id);

--- a/src/admin/auth/command/admin-login.command.ts
+++ b/src/admin/auth/command/admin-login.command.ts
@@ -1,0 +1,6 @@
+export class AdminLoginCommand {
+  constructor(
+    public readonly email: string,
+    public readonly password: string,
+  ) {}
+}

--- a/src/admin/auth/command/admin-login.handler.ts
+++ b/src/admin/auth/command/admin-login.handler.ts
@@ -1,0 +1,62 @@
+import { createHash, randomUUID } from 'crypto';
+import { UnauthorizedException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { JwtService, JwtSignOptions } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import { AdminLoginCommand } from '@src/admin/auth/command/admin-login.command';
+import { IAdminReadRepository } from '@src/admin/interface/admin-read-repository.interface';
+import { IAdminWriteRepository } from '@src/admin/interface/admin-write-repository.interface';
+import { AuthTokens } from '@src/auth/auth.types';
+
+@CommandHandler(AdminLoginCommand)
+export class AdminLoginHandler implements ICommandHandler<AdminLoginCommand> {
+  constructor(
+    private readonly adminReadRepository: IAdminReadRepository,
+    private readonly adminWriteRepository: IAdminWriteRepository,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async execute(command: AdminLoginCommand): Promise<AuthTokens> {
+    const admin = await this.adminReadRepository.findByEmail(command.email);
+    if (!admin) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    const isPasswordValid = await bcrypt.compare(
+      command.password,
+      admin.password,
+    );
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    const payload = { sub: admin.id, email: admin.email, role: admin.role };
+
+    const accessToken = this.jwtService.sign(payload, {
+      secret: this.configService.get<string>('JWT_ADMIN_ACCESS_SECRET'),
+      expiresIn: this.configService.get<string>(
+        'JWT_ADMIN_ACCESS_EXPIRATION',
+        '15m',
+      ),
+    } as JwtSignOptions);
+
+    const refreshToken = this.jwtService.sign(
+      { ...payload, type: 'refresh', jti: randomUUID() },
+      {
+        secret: this.configService.get<string>('JWT_ADMIN_REFRESH_SECRET'),
+        expiresIn: this.configService.get<string>(
+          'JWT_ADMIN_REFRESH_EXPIRATION',
+          '7d',
+        ),
+      } as JwtSignOptions,
+    );
+
+    const tokenDigest = createHash('sha256').update(refreshToken).digest('hex');
+    const hashedRefreshToken = await bcrypt.hash(tokenDigest, 10);
+    await this.adminWriteRepository.update(admin.id, { hashedRefreshToken });
+
+    return { accessToken, refreshToken };
+  }
+}

--- a/src/admin/auth/command/admin-logout.command.ts
+++ b/src/admin/auth/command/admin-logout.command.ts
@@ -1,0 +1,3 @@
+export class AdminLogoutCommand {
+  constructor(public readonly adminId: number) {}
+}

--- a/src/admin/auth/command/admin-logout.handler.spec.ts
+++ b/src/admin/auth/command/admin-logout.handler.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { AdminLogoutHandler } from '@src/admin/auth/command/admin-logout.handler';
+import { AdminLogoutCommand } from '@src/admin/auth/command/admin-logout.command';
+import { IAdminWriteRepository } from '@src/admin/interface/admin-write-repository.interface';
+
+describe('AdminLogoutHandler', () => {
+  let handler: AdminLogoutHandler;
+  let mockWriteRepository: jest.Mocked<IAdminWriteRepository>;
+
+  beforeEach(async () => {
+    mockWriteRepository = {
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminLogoutHandler,
+        { provide: IAdminWriteRepository, useValue: mockWriteRepository },
+      ],
+    }).compile();
+
+    handler = module.get(AdminLogoutHandler);
+
+    jest.clearAllMocks();
+  });
+
+  it('정상 로그아웃 시 update가 올바른 인자로 호출된다', async () => {
+    mockWriteRepository.update.mockResolvedValue(1);
+
+    const command = new AdminLogoutCommand(1);
+    await handler.execute(command);
+
+    expect(mockWriteRepository.update).toHaveBeenCalledWith(1, {
+      hashedRefreshToken: null,
+    });
+  });
+
+  it('존재하지 않는 관리자 ID (affected=0) → NotFoundException', async () => {
+    mockWriteRepository.update.mockResolvedValue(0);
+
+    const command = new AdminLogoutCommand(999);
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+    expect(mockWriteRepository.update).toHaveBeenCalledWith(999, {
+      hashedRefreshToken: null,
+    });
+  });
+});

--- a/src/admin/auth/command/admin-logout.handler.ts
+++ b/src/admin/auth/command/admin-logout.handler.ts
@@ -1,0 +1,19 @@
+import { NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { AdminLogoutCommand } from '@src/admin/auth/command/admin-logout.command';
+import { IAdminWriteRepository } from '@src/admin/interface/admin-write-repository.interface';
+
+@CommandHandler(AdminLogoutCommand)
+export class AdminLogoutHandler implements ICommandHandler<AdminLogoutCommand> {
+  constructor(private readonly adminWriteRepository: IAdminWriteRepository) {}
+
+  async execute(command: AdminLogoutCommand): Promise<void> {
+    const affected = await this.adminWriteRepository.update(command.adminId, {
+      hashedRefreshToken: null,
+    });
+
+    if (affected === 0) {
+      throw new NotFoundException(`Admin with id ${command.adminId} not found`);
+    }
+  }
+}

--- a/src/admin/auth/command/admin-refresh-token.command.ts
+++ b/src/admin/auth/command/admin-refresh-token.command.ts
@@ -1,0 +1,3 @@
+export class AdminRefreshTokenCommand {
+  constructor(public readonly refreshToken: string) {}
+}

--- a/src/admin/auth/command/admin-refresh-token.handler.ts
+++ b/src/admin/auth/command/admin-refresh-token.handler.ts
@@ -1,0 +1,90 @@
+import { createHash, randomUUID } from 'crypto';
+import { UnauthorizedException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { JwtService, JwtSignOptions } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import { AdminRefreshTokenCommand } from '@src/admin/auth/command/admin-refresh-token.command';
+import { IAdminReadRepository } from '@src/admin/interface/admin-read-repository.interface';
+import { IAdminWriteRepository } from '@src/admin/interface/admin-write-repository.interface';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+import { AuthTokens } from '@src/auth/auth.types';
+
+@CommandHandler(AdminRefreshTokenCommand)
+export class AdminRefreshTokenHandler implements ICommandHandler<AdminRefreshTokenCommand> {
+  constructor(
+    private readonly adminReadRepository: IAdminReadRepository,
+    private readonly adminWriteRepository: IAdminWriteRepository,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async execute(command: AdminRefreshTokenCommand): Promise<AuthTokens> {
+    let payload: {
+      sub: number;
+      email: string;
+      role?: AdminRole;
+      type?: string;
+    };
+    try {
+      payload = this.jwtService.verify(command.refreshToken, {
+        secret: this.configService.get<string>('JWT_ADMIN_REFRESH_SECRET'),
+      });
+    } catch {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    if (payload.type !== 'refresh') {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    const admin = await this.adminReadRepository.findById(payload.sub);
+    if (!admin || !admin.hashedRefreshToken) {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    const tokenDigest = createHash('sha256')
+      .update(command.refreshToken)
+      .digest('hex');
+    const isRefreshTokenValid = await bcrypt.compare(
+      tokenDigest,
+      admin.hashedRefreshToken,
+    );
+    if (!isRefreshTokenValid) {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    const newPayload = {
+      sub: admin.id,
+      email: admin.email,
+      role: admin.role,
+    };
+
+    const accessToken = this.jwtService.sign(newPayload, {
+      secret: this.configService.get<string>('JWT_ADMIN_ACCESS_SECRET'),
+      expiresIn: this.configService.get<string>(
+        'JWT_ADMIN_ACCESS_EXPIRATION',
+        '15m',
+      ),
+    } as JwtSignOptions);
+
+    const refreshToken = this.jwtService.sign(
+      { ...newPayload, type: 'refresh', jti: randomUUID() },
+      {
+        secret: this.configService.get<string>('JWT_ADMIN_REFRESH_SECRET'),
+        expiresIn: this.configService.get<string>(
+          'JWT_ADMIN_REFRESH_EXPIRATION',
+          '7d',
+        ),
+      } as JwtSignOptions,
+    );
+
+    const newTokenDigest = createHash('sha256')
+      .update(refreshToken)
+      .digest('hex');
+    const hashedRefreshToken = await bcrypt.hash(newTokenDigest, 10);
+    await this.adminWriteRepository.update(admin.id, { hashedRefreshToken });
+
+    return { accessToken, refreshToken };
+  }
+}

--- a/src/admin/auth/command/admin-register.command.ts
+++ b/src/admin/auth/command/admin-register.command.ts
@@ -1,0 +1,10 @@
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+export class AdminRegisterCommand {
+  constructor(
+    public readonly email: string,
+    public readonly password: string,
+    public readonly name: string,
+    public readonly role: AdminRole,
+  ) {}
+}

--- a/src/admin/auth/command/admin-register.handler.ts
+++ b/src/admin/auth/command/admin-register.handler.ts
@@ -1,0 +1,46 @@
+import { ConflictException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { QueryFailedError } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { AdminRegisterCommand } from '@src/admin/auth/command/admin-register.command';
+import { IAdminReadRepository } from '@src/admin/interface/admin-read-repository.interface';
+import { IAdminWriteRepository } from '@src/admin/interface/admin-write-repository.interface';
+
+@CommandHandler(AdminRegisterCommand)
+export class AdminRegisterHandler implements ICommandHandler<AdminRegisterCommand> {
+  constructor(
+    private readonly adminReadRepository: IAdminReadRepository,
+    private readonly adminWriteRepository: IAdminWriteRepository,
+  ) {}
+
+  async execute(command: AdminRegisterCommand): Promise<number> {
+    const existing = await this.adminReadRepository.findByEmail(command.email);
+    if (existing) {
+      throw new ConflictException(
+        `Admin with email '${command.email}' already exists`,
+      );
+    }
+
+    const hashedPassword = await bcrypt.hash(command.password, 10);
+
+    try {
+      const admin = await this.adminWriteRepository.create({
+        email: command.email,
+        password: hashedPassword,
+        name: command.name,
+        role: command.role,
+      });
+      return admin.id;
+    } catch (error) {
+      if (
+        error instanceof QueryFailedError &&
+        (error.driverError as { code?: string })?.code === '23505'
+      ) {
+        throw new ConflictException(
+          `Admin with email '${command.email}' already exists`,
+        );
+      }
+      throw error;
+    }
+  }
+}

--- a/src/admin/auth/query/get-admin-profile.handler.spec.ts
+++ b/src/admin/auth/query/get-admin-profile.handler.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { GetAdminProfileHandler } from '@src/admin/auth/query/get-admin-profile.handler';
+import { GetAdminProfileQuery } from '@src/admin/auth/query/get-admin-profile.query';
+import { IAdminReadRepository } from '@src/admin/interface/admin-read-repository.interface';
+import { Admin } from '@src/admin/entities/admin.entity';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+import { AdminProfileResponseDto } from '@src/admin/dto/response/admin-profile.response.dto';
+
+describe('GetAdminProfileHandler', () => {
+  let handler: GetAdminProfileHandler;
+  let mockReadRepository: jest.Mocked<IAdminReadRepository>;
+
+  const now = new Date();
+  const mockAdmin: Admin = {
+    id: 1,
+    email: 'admin@example.com',
+    password: 'hashed-password',
+    name: '관리자',
+    role: AdminRole.MANAGER,
+    hashedRefreshToken: 'hashed-token',
+    createdAt: now,
+    updatedAt: now,
+  } as Admin;
+
+  beforeEach(async () => {
+    mockReadRepository = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetAdminProfileHandler,
+        { provide: IAdminReadRepository, useValue: mockReadRepository },
+      ],
+    }).compile();
+
+    handler = module.get(GetAdminProfileHandler);
+  });
+
+  it('존재하는 관리자의 프로필을 조회하면 AdminProfileResponseDto를 반환한다', async () => {
+    mockReadRepository.findById.mockResolvedValue(mockAdmin);
+
+    const query = new GetAdminProfileQuery(1);
+    const result = await handler.execute(query);
+
+    expect(result).toBeInstanceOf(AdminProfileResponseDto);
+    expect(result.id).toBe(1);
+    expect(result.email).toBe('admin@example.com');
+    expect(result.name).toBe('관리자');
+    expect(result.role).toBe(AdminRole.MANAGER);
+  });
+
+  it('존재하지 않는 관리자를 조회하면 NotFoundException을 발생시킨다', async () => {
+    mockReadRepository.findById.mockResolvedValue(null);
+
+    const query = new GetAdminProfileQuery(999);
+
+    await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+  });
+});

--- a/src/admin/auth/query/get-admin-profile.handler.ts
+++ b/src/admin/auth/query/get-admin-profile.handler.ts
@@ -1,0 +1,19 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { NotFoundException } from '@nestjs/common';
+import { GetAdminProfileQuery } from '@src/admin/auth/query/get-admin-profile.query';
+import { IAdminReadRepository } from '@src/admin/interface/admin-read-repository.interface';
+import { AdminProfileResponseDto } from '@src/admin/dto/response/admin-profile.response.dto';
+
+@QueryHandler(GetAdminProfileQuery)
+export class GetAdminProfileHandler implements IQueryHandler<GetAdminProfileQuery> {
+  constructor(private readonly adminReadRepository: IAdminReadRepository) {}
+
+  async execute(query: GetAdminProfileQuery): Promise<AdminProfileResponseDto> {
+    const admin = await this.adminReadRepository.findById(query.adminId);
+    if (!admin) {
+      throw new NotFoundException(`Admin with ID ${query.adminId} not found`);
+    }
+
+    return AdminProfileResponseDto.of(admin);
+  }
+}

--- a/src/admin/auth/query/get-admin-profile.query.ts
+++ b/src/admin/auth/query/get-admin-profile.query.ts
@@ -1,0 +1,3 @@
+export class GetAdminProfileQuery {
+  constructor(public readonly adminId: number) {}
+}

--- a/src/admin/decorator/auth-admin.type.ts
+++ b/src/admin/decorator/auth-admin.type.ts
@@ -1,0 +1,7 @@
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+export class AuthAdmin {
+  id: number;
+  email: string;
+  role: AdminRole;
+}

--- a/src/admin/decorator/current-admin.decorator.ts
+++ b/src/admin/decorator/current-admin.decorator.ts
@@ -1,0 +1,16 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthAdmin } from '@src/admin/decorator/auth-admin.type';
+
+export const CurrentAdmin = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthAdmin => {
+    const request = ctx.switchToHttp().getRequest<{ user?: AuthAdmin }>();
+    if (!request.user) {
+      throw new UnauthorizedException('Authenticated admin not found');
+    }
+    return request.user;
+  },
+);

--- a/src/admin/dto/request/admin-login.request.dto.ts
+++ b/src/admin/dto/request/admin-login.request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class AdminLoginRequestDto {
+  @ApiProperty({ description: '이메일', example: 'admin@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({ description: '비밀번호', example: 'password123' })
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}

--- a/src/admin/dto/request/admin-refresh-token.request.dto.ts
+++ b/src/admin/dto/request/admin-refresh-token.request.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AdminRefreshTokenRequestDto {
+  @ApiProperty({ description: '리프레시 토큰' })
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}

--- a/src/admin/dto/request/admin-register.request.dto.ts
+++ b/src/admin/dto/request/admin-register.request.dto.ts
@@ -1,13 +1,5 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  IsEmail,
-  IsEnum,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-  MinLength,
-} from 'class-validator';
-import { AdminRole } from '@src/admin/enum/admin-role.enum';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 
 export class AdminRegisterRequestDto {
   @ApiProperty({ description: '이메일', example: 'admin@example.com' })
@@ -25,13 +17,4 @@ export class AdminRegisterRequestDto {
   @IsString()
   @IsNotEmpty()
   name: string;
-
-  @ApiPropertyOptional({
-    description: '관리자 등급',
-    enum: AdminRole,
-    default: AdminRole.MANAGER,
-  })
-  @IsEnum(AdminRole)
-  @IsOptional()
-  role?: AdminRole;
 }

--- a/src/admin/dto/request/admin-register.request.dto.ts
+++ b/src/admin/dto/request/admin-register.request.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+export class AdminRegisterRequestDto {
+  @ApiProperty({ description: '이메일', example: 'admin@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({ description: '비밀번호 (최소 8자)', example: 'password123' })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(8)
+  password: string;
+
+  @ApiProperty({ description: '이름', example: '관리자' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiPropertyOptional({
+    description: '관리자 등급',
+    enum: AdminRole,
+    default: AdminRole.MANAGER,
+  })
+  @IsEnum(AdminRole)
+  @IsOptional()
+  role?: AdminRole;
+}

--- a/src/admin/dto/response/admin-auth-tokens.response.dto.spec.ts
+++ b/src/admin/dto/response/admin-auth-tokens.response.dto.spec.ts
@@ -1,0 +1,24 @@
+import { AdminAuthTokensResponseDto } from '@src/admin/dto/response/admin-auth-tokens.response.dto';
+
+describe('AdminAuthTokensResponseDto', () => {
+  describe('of', () => {
+    it('accessToken과 refreshToken을 DTO로 매핑한다', () => {
+      const dto = AdminAuthTokensResponseDto.of({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      });
+
+      expect(dto.accessToken).toBe('access-token');
+      expect(dto.refreshToken).toBe('refresh-token');
+    });
+
+    it('AdminAuthTokensResponseDto 인스턴스를 반환한다', () => {
+      const dto = AdminAuthTokensResponseDto.of({
+        accessToken: 'a',
+        refreshToken: 'r',
+      });
+
+      expect(dto).toBeInstanceOf(AdminAuthTokensResponseDto);
+    });
+  });
+});

--- a/src/admin/dto/response/admin-auth-tokens.response.dto.ts
+++ b/src/admin/dto/response/admin-auth-tokens.response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AuthTokens } from '@src/auth/auth.types';
+
+export class AdminAuthTokensResponseDto {
+  @ApiProperty({ description: '액세스 토큰' })
+  accessToken: string;
+
+  @ApiProperty({ description: '리프레시 토큰' })
+  refreshToken: string;
+
+  static of(tokens: AuthTokens): AdminAuthTokensResponseDto {
+    const dto = new AdminAuthTokensResponseDto();
+    dto.accessToken = tokens.accessToken;
+    dto.refreshToken = tokens.refreshToken;
+    return dto;
+  }
+}

--- a/src/admin/dto/response/admin-profile.response.dto.spec.ts
+++ b/src/admin/dto/response/admin-profile.response.dto.spec.ts
@@ -1,0 +1,68 @@
+import { AdminProfileResponseDto } from '@src/admin/dto/response/admin-profile.response.dto';
+import { Admin } from '@src/admin/entities/admin.entity';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+describe('AdminProfileResponseDto', () => {
+  const now = new Date();
+
+  const createAdmin = (overrides: Partial<Admin> = {}): Admin => {
+    const admin = new Admin();
+    admin.id = 1;
+    admin.email = 'admin@example.com';
+    admin.password = 'hashed-password';
+    admin.name = '관리자';
+    admin.role = AdminRole.MANAGER;
+    admin.hashedRefreshToken = 'hashed-token';
+    admin.createdAt = now;
+    admin.updatedAt = now;
+    Object.assign(admin, overrides);
+    return admin;
+  };
+
+  describe('of', () => {
+    it('Admin 엔티티의 공개 필드를 DTO로 매핑한다', () => {
+      const admin = createAdmin();
+
+      const dto = AdminProfileResponseDto.of(admin);
+
+      expect(dto.id).toBe(admin.id);
+      expect(dto.email).toBe(admin.email);
+      expect(dto.name).toBe(admin.name);
+      expect(dto.role).toBe(admin.role);
+      expect(dto.createdAt).toBe(admin.createdAt);
+      expect(dto.updatedAt).toBe(admin.updatedAt);
+    });
+
+    it('AdminProfileResponseDto 인스턴스를 반환한다', () => {
+      const admin = createAdmin();
+
+      const dto = AdminProfileResponseDto.of(admin);
+
+      expect(dto).toBeInstanceOf(AdminProfileResponseDto);
+    });
+
+    it('password를 포함하지 않는다', () => {
+      const admin = createAdmin();
+
+      const dto = AdminProfileResponseDto.of(admin);
+
+      expect(dto).not.toHaveProperty('password');
+    });
+
+    it('hashedRefreshToken을 포함하지 않는다', () => {
+      const admin = createAdmin();
+
+      const dto = AdminProfileResponseDto.of(admin);
+
+      expect(dto).not.toHaveProperty('hashedRefreshToken');
+    });
+
+    it('SUPER 등급을 올바르게 매핑한다', () => {
+      const admin = createAdmin({ role: AdminRole.SUPER });
+
+      const dto = AdminProfileResponseDto.of(admin);
+
+      expect(dto.role).toBe(AdminRole.SUPER);
+    });
+  });
+});

--- a/src/admin/dto/response/admin-profile.response.dto.ts
+++ b/src/admin/dto/response/admin-profile.response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Admin } from '@src/admin/entities/admin.entity';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+export class AdminProfileResponseDto {
+  @ApiProperty({ description: '관리자 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '이메일', example: 'admin@example.com' })
+  email: string;
+
+  @ApiProperty({ description: '이름', example: '관리자' })
+  name: string;
+
+  @ApiProperty({
+    description: '등급',
+    enum: AdminRole,
+    example: AdminRole.MANAGER,
+  })
+  role: AdminRole;
+
+  @ApiProperty({ description: '생성일시' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '수정일시' })
+  updatedAt: Date;
+
+  static of(admin: Admin): AdminProfileResponseDto {
+    const dto = new AdminProfileResponseDto();
+    dto.id = admin.id;
+    dto.email = admin.email;
+    dto.name = admin.name;
+    dto.role = admin.role;
+    dto.createdAt = admin.createdAt;
+    dto.updatedAt = admin.updatedAt;
+    return dto;
+  }
+}

--- a/src/admin/dto/response/admin-register.response.dto.spec.ts
+++ b/src/admin/dto/response/admin-register.response.dto.spec.ts
@@ -1,0 +1,17 @@
+import { AdminRegisterResponseDto } from '@src/admin/dto/response/admin-register.response.dto';
+
+describe('AdminRegisterResponseDto', () => {
+  describe('of', () => {
+    it('id를 DTO로 매핑한다', () => {
+      const dto = AdminRegisterResponseDto.of(42);
+
+      expect(dto.id).toBe(42);
+    });
+
+    it('AdminRegisterResponseDto 인스턴스를 반환한다', () => {
+      const dto = AdminRegisterResponseDto.of(1);
+
+      expect(dto).toBeInstanceOf(AdminRegisterResponseDto);
+    });
+  });
+});

--- a/src/admin/dto/response/admin-register.response.dto.ts
+++ b/src/admin/dto/response/admin-register.response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AdminRegisterResponseDto {
+  @ApiProperty({ description: '생성된 관리자 ID', example: 1 })
+  id: number;
+
+  static of(id: number): AdminRegisterResponseDto {
+    const dto = new AdminRegisterResponseDto();
+    dto.id = id;
+    return dto;
+  }
+}

--- a/src/admin/entities/admin.entity.ts
+++ b/src/admin/entities/admin.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity } from 'typeorm';
+import { BaseTimeEntity } from '@src/common/entities/base.entity';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+@Entity('admins')
+export class Admin extends BaseTimeEntity {
+  @Column({ length: 255, unique: true })
+  email: string;
+
+  @Column({ length: 255 })
+  password: string;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 20, default: AdminRole.MANAGER })
+  role: AdminRole;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  hashedRefreshToken: string | null;
+}

--- a/src/admin/enum/admin-role.enum.ts
+++ b/src/admin/enum/admin-role.enum.ts
@@ -1,0 +1,4 @@
+export enum AdminRole {
+  SUPER = 'SUPER',
+  MANAGER = 'MANAGER',
+}

--- a/src/admin/guard/admin-jwt-auth.guard.ts
+++ b/src/admin/guard/admin-jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class AdminJwtAuthGuard extends AuthGuard('jwt-admin') {}

--- a/src/admin/interface/admin-read-repository.interface.ts
+++ b/src/admin/interface/admin-read-repository.interface.ts
@@ -1,0 +1,6 @@
+import { Admin } from '@src/admin/entities/admin.entity';
+
+export abstract class IAdminReadRepository {
+  abstract findById(id: number): Promise<Admin | null>;
+  abstract findByEmail(email: string): Promise<Admin | null>;
+}

--- a/src/admin/interface/admin-write-repository.interface.ts
+++ b/src/admin/interface/admin-write-repository.interface.ts
@@ -1,0 +1,18 @@
+import { Admin } from '@src/admin/entities/admin.entity';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+export interface CreateAdminInput {
+  email: string;
+  password: string;
+  name: string;
+  role: AdminRole;
+}
+
+export interface UpdateAdminInput {
+  hashedRefreshToken?: string | null;
+}
+
+export abstract class IAdminWriteRepository {
+  abstract create(input: CreateAdminInput): Promise<Admin>;
+  abstract update(id: number, input: UpdateAdminInput): Promise<number>;
+}

--- a/src/admin/strategy/admin-jwt.strategy.ts
+++ b/src/admin/strategy/admin-jwt.strategy.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { AdminRole } from '@src/admin/enum/admin-role.enum';
+
+export interface AdminJwtPayload {
+  sub: number;
+  email: string;
+  role: AdminRole;
+}
+
+@Injectable()
+export class AdminJwtStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.getOrThrow<string>('JWT_ADMIN_ACCESS_SECRET'),
+    });
+  }
+
+  validate(payload: AdminJwtPayload) {
+    return { id: payload.sub, email: payload.email, role: payload.role };
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { IdempotencyModule } from '@src/common/idempotency/idempotency.module';
 import { PostsModule } from '@src/posts/posts.module';
 import { AuthModule } from '@src/auth/auth.module';
 import { HealthModule } from '@src/health/health.module';
+import { AdminModule } from '@src/admin/admin.module';
 
 const nodeEnv = process.env.NODE_ENV || 'local';
 
@@ -38,6 +39,7 @@ const nodeEnv = process.env.NODE_ENV || 'local';
     }),
     PostsModule,
     AuthModule,
+    AdminModule,
     HealthModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/src/migrations/1773000000000-CreateAdminTable.ts
+++ b/src/migrations/1773000000000-CreateAdminTable.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateAdminTable1773000000000 implements MigrationInterface {
+  name = 'CreateAdminTable1773000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'admins',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'email',
+            type: 'varchar',
+            length: '255',
+            isUnique: true,
+          },
+          {
+            name: 'password',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '100',
+          },
+          {
+            name: 'role',
+            type: 'varchar',
+            length: '20',
+            default: "'MANAGER'",
+          },
+          {
+            name: 'hashedRefreshToken',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('admins');
+  }
+}

--- a/test/admin.integration-spec.ts
+++ b/test/admin.integration-spec.ts
@@ -1,0 +1,375 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import {
+  createIntegrationApp,
+  useTransactionRollback,
+  TransactionHelper,
+} from './setup/integration-helper';
+
+describe('Admin (integration)', () => {
+  let app: INestApplication<App>;
+  let txHelper: TransactionHelper;
+
+  beforeAll(async () => {
+    app = await createIntegrationApp();
+    txHelper = useTransactionRollback(app);
+  });
+
+  beforeEach(() => txHelper.start());
+  afterEach(() => txHelper.rollback());
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  // ── 헬퍼 ─────────────────────────────────
+
+  const defaultAdmin = {
+    email: 'admin@example.com',
+    password: 'password123',
+    name: '관리자',
+  };
+
+  function registerAdmin(body: Record<string, unknown> = {}) {
+    return request(app.getHttpServer())
+      .post('/v1/admin/auth/register')
+      .send({ ...defaultAdmin, ...body });
+  }
+
+  async function registerAndLogin(body: Record<string, unknown> = {}) {
+    await registerAdmin(body).expect(201);
+    const loginRes = await request(app.getHttpServer())
+      .post('/v1/admin/auth/login')
+      .send({
+        email: (body.email as string) ?? defaultAdmin.email,
+        password: (body.password as string) ?? defaultAdmin.password,
+      })
+      .expect(200);
+    return loginRes.body as { accessToken: string; refreshToken: string };
+  }
+
+  // ── User 토큰 발급 헬퍼 ─────────────────
+
+  async function registerAndLoginUser() {
+    await request(app.getHttpServer())
+      .post('/v1/auth/register')
+      .send({
+        email: 'user@example.com',
+        password: 'password123',
+        name: '일반유저',
+      })
+      .expect(201);
+    const res = await request(app.getHttpServer())
+      .post('/v1/auth/login')
+      .send({ email: 'user@example.com', password: 'password123' })
+      .expect(200);
+    return res.body as { accessToken: string; refreshToken: string };
+  }
+
+  // ============================================================
+  // POST /admin/auth/register
+  // ============================================================
+  describe('POST /admin/auth/register', () => {
+    it('should register and return { id } with 201', async () => {
+      const res = await registerAdmin().expect(201);
+
+      expect(res.body.id).toBeDefined();
+      expect(typeof res.body.id).toBe('number');
+      expect(Object.keys(res.body)).toEqual(['id']);
+    });
+
+    it('should persist admin (verified via login)', async () => {
+      await registerAdmin().expect(201);
+
+      await request(app.getHttpServer())
+        .post('/v1/admin/auth/login')
+        .send({ email: defaultAdmin.email, password: defaultAdmin.password })
+        .expect(200);
+    });
+
+    it('should register with SUPER role', async () => {
+      await registerAdmin({ role: 'SUPER' }).expect(201);
+
+      const loginRes = await request(app.getHttpServer())
+        .post('/v1/admin/auth/login')
+        .send({ email: defaultAdmin.email, password: defaultAdmin.password })
+        .expect(200);
+
+      const profileRes = await request(app.getHttpServer())
+        .get('/v1/admin/auth/profile')
+        .set(
+          'Authorization',
+          `Bearer ${(loginRes.body as { accessToken: string }).accessToken}`,
+        )
+        .expect(200);
+
+      expect(profileRes.body.role).toBe('SUPER');
+    });
+
+    it('should default to MANAGER role when not specified', async () => {
+      const tokens = await registerAndLogin();
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/admin/auth/profile')
+        .set('Authorization', `Bearer ${tokens.accessToken}`)
+        .expect(200);
+
+      expect(res.body.role).toBe('MANAGER');
+    });
+
+    it('should return 409 for duplicate email', async () => {
+      await registerAdmin().expect(201);
+
+      const res = await registerAdmin().expect(409);
+
+      expect(res.body.message).toContain(defaultAdmin.email);
+    });
+
+    it('should return 400 when email is missing', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/register')
+        .send({ password: 'password123', name: '테스트' })
+        .expect(400);
+    });
+
+    it('should return 400 when password is shorter than 8 characters', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/register')
+        .send({ email: 'a@b.com', password: 'short', name: '테스트' })
+        .expect(400);
+    });
+
+    it('should return 400 when name is missing', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/register')
+        .send({ email: 'a@b.com', password: 'password123' })
+        .expect(400);
+    });
+
+    it('should return 400 for invalid role value', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/register')
+        .send({ ...defaultAdmin, role: 'INVALID' })
+        .expect(400);
+    });
+  });
+
+  // ============================================================
+  // POST /admin/auth/login
+  // ============================================================
+  describe('POST /admin/auth/login', () => {
+    it('should login and return { accessToken, refreshToken } with 200', async () => {
+      await registerAdmin().expect(201);
+
+      const res = await request(app.getHttpServer())
+        .post('/v1/admin/auth/login')
+        .send({ email: defaultAdmin.email, password: defaultAdmin.password })
+        .expect(200);
+
+      expect(res.body.accessToken).toBeDefined();
+      expect(res.body.refreshToken).toBeDefined();
+      expect(typeof res.body.accessToken).toBe('string');
+      expect(typeof res.body.refreshToken).toBe('string');
+      expect(Object.keys(res.body).sort()).toEqual([
+        'accessToken',
+        'refreshToken',
+      ]);
+    });
+
+    it('should return 401 for non-existent email', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/login')
+        .send({ email: 'nobody@example.com', password: 'password123' })
+        .expect(401);
+    });
+
+    it('should return 401 for wrong password', async () => {
+      await registerAdmin().expect(201);
+
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/login')
+        .send({ email: defaultAdmin.email, password: 'wrongpassword' })
+        .expect(401);
+    });
+
+    it('should return 400 when email is missing', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/login')
+        .send({ password: 'password123' })
+        .expect(400);
+    });
+
+    it('should return 400 when password is missing', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/login')
+        .send({ email: 'a@b.com' })
+        .expect(400);
+    });
+  });
+
+  // ============================================================
+  // POST /admin/auth/refresh
+  // ============================================================
+  describe('POST /admin/auth/refresh', () => {
+    it('should return new { accessToken, refreshToken } with 200', async () => {
+      const tokens = await registerAndLogin();
+
+      const res = await request(app.getHttpServer())
+        .post('/v1/admin/auth/refresh')
+        .send({ refreshToken: tokens.refreshToken })
+        .expect(200);
+
+      expect(res.body.accessToken).toBeDefined();
+      expect(res.body.refreshToken).toBeDefined();
+      expect(res.body.refreshToken).not.toBe(tokens.refreshToken);
+    });
+
+    it('should invalidate old refresh token after rotation', async () => {
+      const tokens = await registerAndLogin();
+
+      await request(app.getHttpServer())
+        .post('/v1/admin/auth/refresh')
+        .send({ refreshToken: tokens.refreshToken })
+        .expect(200);
+
+      await request(app.getHttpServer())
+        .post('/v1/admin/auth/refresh')
+        .send({ refreshToken: tokens.refreshToken })
+        .expect(401);
+    });
+
+    it('should return 401 for invalid token', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/refresh')
+        .send({ refreshToken: 'invalid-token' })
+        .expect(401);
+    });
+
+    it('should return 400 when refreshToken is missing', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/refresh')
+        .send({})
+        .expect(400);
+    });
+  });
+
+  // ============================================================
+  // GET /admin/auth/profile
+  // ============================================================
+  describe('GET /admin/auth/profile', () => {
+    it('should return profile with { id, email, name, role, createdAt, updatedAt } and 200', async () => {
+      const tokens = await registerAndLogin();
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/admin/auth/profile')
+        .set('Authorization', `Bearer ${tokens.accessToken}`)
+        .expect(200);
+
+      expect(res.body.id).toBeDefined();
+      expect(typeof res.body.id).toBe('number');
+      expect(res.body.email).toBe(defaultAdmin.email);
+      expect(res.body.name).toBe(defaultAdmin.name);
+      expect(res.body.role).toBe('MANAGER');
+      expect(res.body.createdAt).toBeDefined();
+      expect(res.body.updatedAt).toBeDefined();
+      expect(Object.keys(res.body).sort()).toEqual([
+        'createdAt',
+        'email',
+        'id',
+        'name',
+        'role',
+        'updatedAt',
+      ]);
+    });
+
+    it('should not include password or hashedRefreshToken in response', async () => {
+      const tokens = await registerAndLogin();
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/admin/auth/profile')
+        .set('Authorization', `Bearer ${tokens.accessToken}`)
+        .expect(200);
+
+      expect(res.body).not.toHaveProperty('password');
+      expect(res.body).not.toHaveProperty('hashedRefreshToken');
+    });
+
+    it('should return 401 without token', () => {
+      return request(app.getHttpServer())
+        .get('/v1/admin/auth/profile')
+        .expect(401);
+    });
+
+    it('should return 401 with invalid token', () => {
+      return request(app.getHttpServer())
+        .get('/v1/admin/auth/profile')
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(401);
+    });
+  });
+
+  // ============================================================
+  // POST /admin/auth/logout
+  // ============================================================
+  describe('POST /admin/auth/logout', () => {
+    it('should return 204 on successful logout', async () => {
+      const { accessToken } = await registerAndLogin();
+
+      await request(app.getHttpServer())
+        .post('/v1/admin/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+    });
+
+    it('should invalidate refresh token after logout', async () => {
+      const { accessToken, refreshToken } = await registerAndLogin();
+
+      await request(app.getHttpServer())
+        .post('/v1/admin/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+
+      await request(app.getHttpServer())
+        .post('/v1/admin/auth/refresh')
+        .send({ refreshToken })
+        .expect(401);
+    });
+
+    it('should return 401 when no Authorization header is provided', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/logout')
+        .expect(401);
+    });
+
+    it('should return 401 when an invalid token is provided', () => {
+      return request(app.getHttpServer())
+        .post('/v1/admin/auth/logout')
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(401);
+    });
+  });
+
+  // ============================================================
+  // 토큰 격리: User ↔ Admin 토큰 교차 사용 불가
+  // ============================================================
+  describe('Token isolation', () => {
+    it('should reject User token on Admin endpoints (401)', async () => {
+      const userTokens = await registerAndLoginUser();
+
+      await request(app.getHttpServer())
+        .get('/v1/admin/auth/profile')
+        .set('Authorization', `Bearer ${userTokens.accessToken}`)
+        .expect(401);
+    });
+
+    it('should reject Admin token on User endpoints (401)', async () => {
+      const adminTokens = await registerAndLogin();
+
+      await request(app.getHttpServer())
+        .get('/v1/auth/profile')
+        .set('Authorization', `Bearer ${adminTokens.accessToken}`)
+        .expect(401);
+    });
+  });
+});

--- a/test/admin.integration-spec.ts
+++ b/test/admin.integration-spec.ts
@@ -88,26 +88,7 @@ describe('Admin (integration)', () => {
         .expect(200);
     });
 
-    it('should register with SUPER role', async () => {
-      await registerAdmin({ role: 'SUPER' }).expect(201);
-
-      const loginRes = await request(app.getHttpServer())
-        .post('/v1/admin/auth/login')
-        .send({ email: defaultAdmin.email, password: defaultAdmin.password })
-        .expect(200);
-
-      const profileRes = await request(app.getHttpServer())
-        .get('/v1/admin/auth/profile')
-        .set(
-          'Authorization',
-          `Bearer ${(loginRes.body as { accessToken: string }).accessToken}`,
-        )
-        .expect(200);
-
-      expect(profileRes.body.role).toBe('SUPER');
-    });
-
-    it('should default to MANAGER role when not specified', async () => {
+    it('should always register with MANAGER role', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -147,10 +128,10 @@ describe('Admin (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 for invalid role value', () => {
+    it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
         .post('/v1/admin/auth/register')
-        .send({ ...defaultAdmin, role: 'INVALID' })
+        .send({ ...defaultAdmin, role: 'SUPER' })
         .expect(400);
     });
   });

--- a/test/setup/global-setup.ts
+++ b/test/setup/global-setup.ts
@@ -69,6 +69,10 @@ export default async function globalSetup() {
       JWT_REFRESH_SECRET: 'test-refresh-secret',
       JWT_ACCESS_EXPIRATION: '15m',
       JWT_REFRESH_EXPIRATION: '7d',
+      JWT_ADMIN_ACCESS_SECRET: 'test-admin-access-secret',
+      JWT_ADMIN_REFRESH_SECRET: 'test-admin-refresh-secret',
+      JWT_ADMIN_ACCESS_EXPIRATION: '15m',
+      JWT_ADMIN_REFRESH_EXPIRATION: '7d',
       THROTTLE_SKIP: 'true',
       OTEL_ENABLED: 'false',
     };


### PR DESCRIPTION
## Summary
- User와 완전 독립된 Admin 인증 체계 구축 (별도 `admins` 테이블, 별도 JWT 시크릿)
- AdminRole enum (`SUPER`, `MANAGER`) 등급 구분
- CQRS + Repository Pattern ISP 적용 (register, login, refresh, logout, profile)
- 단위 테스트 13개 + 통합 테스트 (토큰 교차 사용 불가 검증 포함)

## Test plan
- [x] `pnpm build:local` 빌드 통과
- [x] `pnpm test` 단위 테스트 61개 통과
- [x] `pnpm test:e2e` 통합 테스트 109개 통과
- [x] `pnpm lint:check` 린트 통과
- [x] User 토큰 → Admin 엔드포인트 401 검증
- [x] Admin 토큰 → User 엔드포인트 401 검증

> **Merge Strategy**: Create a merge commit을 사용해주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 계정 등록, 로그인, 로그아웃 및 프로필 조회 API 추가
  * 액세스/리프레시 토큰 발급 및 리프레시 토큰 회전(재발급 시 이전 토큰 무효화) 지원
  * 관리자 역할(SUPER, MANAGER) 적용 및 관리자 전용 인증 가드 적용

* **테스트**
  * 관리자 인증 통합 및 단위 테스트 추가 (토큰 회전, 접근 제어 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->