### PR TITLE
build: SWC로 빌드/테스트 트랜스파일러 전환

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://swc.rs/schema.json",
+  "sourceMaps": true,
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "legacyDecorator": true,
+      "decoratorMetadata": true,
+      "useDefineForClassFields": false
+    },
+    "target": "es2021",
+    "keepClassNames": true
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,16 @@ Controller → CommandBus / QueryBus → Handler (검증 + 로직) → IPostRead
 - `OTEL_ENABLED` 환경변수로 활성화/비활성화 제어
 - `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`으로 trace 수집 대상 설정
 
+### Build Tooling (SWC)
+
+- 빌드는 **webpack + swc-loader**, 단위/통합 테스트는 **`@swc/jest`**. 모노레포 모드는 SWC builder를 직접 지원하지 않으므로 NestJS 공식 권장 경로인 webpack 경유.
+- `webpack.config.js`(루트)는 함수 형태 — nest CLI 기본값(`webpack-defaults`: externals, `TsconfigPathsPlugin`, `IgnorePlugin`, `ForkTsCheckerWebpackPlugin`, `node: { __dirname: false }`)을 그대로 spread로 보존하고 `module.rules`만 swc-loader로 교체. 새로운 webpack 옵션이 필요하면 spread 패턴을 깨지 않도록 주의(예: `node`/`plugins`/`module`을 통째로 덮어쓰지 말 것).
+- SWC 옵션은 `@nestjs/cli/lib/compiler/defaults/swc-defaults`의 `swcDefaultsFactory()`를 그대로 사용. 빌드는 `swcrc: false`로 격리, Jest는 루트 `.swcrc`를 사용.
+- **엔티티 양방향 관계는 SWC 호환 필수 패턴 적용**: 순환 참조 + `decoratorMetadata`가 TDZ를 유발하므로 관계 타입을 `Relation<T>`로 감싸고, `Relation`은 반드시 `import type { Relation } from 'typeorm'`로 들여온다(`isolatedModules` + `emitDecoratorMetadata` 조합에서 TS1272 회피). 새 엔티티가 양방향 관계를 가질 때마다 동일 패턴 강제.
+- `pnpm build:all`(non-watch)에선 ForkTsChecker가 비동기로 통과해도, `pnpm start:local`(watch)에서 차단되는 TS1272는 watch 모드에서 즉시 잡힘.
+- 마이그레이션 CLI(`migration:*`)는 `ts-node/register + tsconfig-paths/register` 그대로 유지. 운영 안정성 분리를 위해 SWC 전환 범위에서 제외.
+- 상세 가이드: `docs/swc-migration-guide.md`
+
 ### NestJS Conventions
 
 - 모듈 파일(`*.module.ts`) 수정 후 모든 providers, exports, imports가 올바르게 등록되었는지 확인한다. 흔한 실수: Guard/Service를 export하면서 providers에 추가하지 않는 것.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ NestJS **모노레포** 기반 Posts CRUD API + Admin Back-Office.
 | **Logging** | pino-http 기반 구조화 로깅 (correlation ID, redaction) |
 | **Slack 알림** | 게시물 생성 시 이벤트 기반 Slack 알림 |
 | **OpenTelemetry** | OTEL SDK 자동 계측 (트레이싱, `OTEL_ENABLED`로 제어) |
+| **Build Tooling (SWC)** | webpack + swc-loader (빌드) + `@swc/jest` (테스트). 모노레포 모드 호환을 위해 webpack 경유 |
 
 ## 목차
 
@@ -203,6 +204,15 @@ export const postRepositoryProviders: Provider[] = [
 - `libs/shared/src/instrumentation.ts` — OTEL SDK 자동 계측 (양쪽 앱에서 import)
 - `OTEL_ENABLED` 환경변수로 활성화/비활성화, `OTEL_EXPORTER_OTLP_ENDPOINT`로 수집 대상 설정
 
+### Build Tooling (SWC)
+
+- 빌드: **webpack + swc-loader**, 테스트: **`@swc/jest`**. 모노레포 모드는 SWC builder를 직접 지원하지 않아 NestJS 공식 권장 경로인 webpack 경유
+- `webpack.config.js`는 함수 형태로 nest CLI 기본값(externals, `TsconfigPathsPlugin`, `ForkTsCheckerWebpackPlugin`, `node: { __dirname: false }`)을 그대로 보존하고 `module.rules`만 swc-loader로 교체
+- SWC 옵션은 `swcDefaultsFactory()`(legacyDecorator + decoratorMetadata + keepClassNames) 그대로 사용. 빌드는 `swcrc: false`로 격리, Jest는 루트 `.swcrc`
+- 엔티티 양방향 관계 필드는 `Relation<T>` 래퍼 + `import type { Relation }` 필수 (순환 참조 TDZ + TS1272 회피)
+- 마이그레이션 CLI는 `ts-node/register` 그대로 유지 (운영 안정성 분리)
+- 상세 가이드: [docs/swc-migration-guide.md](./docs/swc-migration-guide.md)
+
 ---
 
 ## 시작하기
@@ -334,6 +344,7 @@ GitHub Actions로 코드 품질을 자동 검증한다.
 | [모노레포 분리 체크리스트](./docs/monorepo-separation-todo.md) | 마이그레이션 단계별 체크리스트 |
 | [Cache Layer 가이드](./docs/cache-layer-guide.md) | 캐시 적용 방법 및 전략 |
 | [Helmet + CORS 가이드](./docs/helmet-cors-guide.md) | 보안 헤더 및 CORS whitelist 설정 가이드 |
+| [SWC 적용 가이드](./docs/swc-migration-guide.md) | webpack + swc-loader 빌드 / `@swc/jest` 테스트 전환 가이드 |
 | [CQRS 가이드](./docs/cqrs-guide.md) | CQRS 패턴 적용 가이드 |
 | [테스트 전략](./docs/testing-strategy.md) | Classical School 테스트 구조 |
 | [멱등성 가이드](./docs/idempotency-guide.md) | Redis 기반 멱등성 처리 |

--- a/docs/swc-migration-guide.md
+++ b/docs/swc-migration-guide.md
@@ -1,0 +1,349 @@
+# SWC 적용 가이드 (모노레포 빌드 + Jest)
+
+## 개요
+
+NestJS 모노레포(`apps/service`, `apps/back-office`, `libs/shared`)의 트랜스파일링을 TypeScript 컴파일러(`tsc` / `ts-loader` / `ts-jest`)에서 Rust 기반 [SWC](https://swc.rs/)로 전환하는 가이드. 빌드는 **Webpack + swc-loader**, 테스트는 **`@swc/jest`**로 옮긴다. NestJS 공식 문서가 모노레포 모드에서는 SWC builder를 직접 사용할 수 없고 Webpack을 경유하도록 안내하므로, 본 가이드는 그 경로를 따른다.
+
+> 참고: [NestJS Recipes — SWC](https://docs.nestjs.com/recipes/swc)
+
+## 설계 원칙
+
+### 1. NestJS CLI 기본값 최대 활용
+
+- `@nestjs/cli`는 `webpack: true`일 때 `webpack-defaults.js`를 통해 `webpack-node-externals`, `tsconfig-paths-webpack-plugin`, `ForkTsCheckerWebpackPlugin`, `IgnorePlugin`(NestJS lazy import 무시), `node: { __dirname: false }`를 **자동으로 적용**한다. 사용자 `webpack.config.js`는 nest CLI 기본값을 spread로 보존하고 **`module.rules`만 swc-loader로 교체**한다.
+- 결과: 사용자 정의 webpack 설정이 ~15줄로 끝난다.
+
+### 2. SWC 옵션은 NestJS 공식 팩토리에서 받음
+
+- `@nestjs/cli/lib/compiler/defaults/swc-defaults`의 `swcDefaultsFactory()`가 반환하는 옵션은 NestJS DI / TypeORM 메타데이터에 필요한 다음을 모두 포함한다.
+  - `legacyDecorator: true`
+  - `decoratorMetadata: true`
+  - `useDefineForClassFields: false`
+  - `keepClassNames: true`
+- 직접 옵션을 작성하지 않고 팩토리를 재사용하여 NestJS 메이저 업그레이드 시에도 기본값을 자동 추종.
+
+### 3. 빌드와 테스트의 SWC 옵션 격리
+
+- Jest는 `.swcrc`(루트)를 읽고, 빌드(swc-loader)는 인라인 옵션 + `swcrc: false`로 `.swcrc`를 무시한다.
+- 결과: `.swcrc` 변경이 빌드 동작에 새는 것을 차단. 두 경로 모두 명시적으로 결정된 옵션만 사용.
+
+### 4. 마이그레이션 CLI는 ts-node 유지
+
+- TypeORM 마이그레이션은 운영 안정성이 가장 중요한 경로. `ts-node/register + tsconfig-paths/register` 조합을 그대로 둔다. SWC 전환의 검증이 끝난 후 별도 작업으로 `@swc-node/register` 교체를 검토.
+
+## 아키텍처
+
+```text
+[빌드 흐름 — nest build {service|back-office}]
+nest CLI
+   │
+   ▼
+WebpackCompiler (webpack: true 분기)
+   │
+   ├─ webpack-defaults (자동)
+   │     ├─ target: 'node'
+   │     ├─ externals: webpack-node-externals  ← node_modules 외부화
+   │     ├─ resolve.plugins: TsconfigPathsPlugin  ← @app/shared 등 별칭 해결
+   │     ├─ node: { __dirname: false }  ← typeorm.config 마이그레이션 glob 보존
+   │     ├─ IgnorePlugin (NestJS lazy import)
+   │     ├─ ignoreWarnings (CriticalDependenciesWarning 외)
+   │     └─ ForkTsCheckerWebpackPlugin  ← 타입 체크 병행
+   │
+   └─ webpack.config.js (사용자, 함수 형태)
+         └─ module.rules: swc-loader  ← .ts 파일 트랜스파일
+                            ↑
+                            options = swcDefaultsFactory().swcOptions + { swcrc: false }
+   │
+   ▼
+dist/apps/{name}/main.js  (단일 번들)
+   │
+   ▼
+node dist/apps/{name}/main  (start:*:prod 무수정 호환)
+```
+
+```text
+[테스트 흐름 — pnpm test / pnpm test:e2e]
+Jest
+   │
+   ▼
+transform: '@swc/jest'
+   │
+   ▼
+.swcrc (루트)  ← legacyDecorator, decoratorMetadata, target, parser
+   │
+   ▼
+moduleNameMapper (기존)  ← @app/shared, @service/*, @back-office/* 별칭 해결
+   │
+   ▼
+테스트 실행
+```
+
+## 구성 요소
+
+### `webpack.config.js`
+
+**파일**: `webpack.config.js` (프로젝트 루트, 신규)
+
+함수 형태로 nest CLI가 주입한 webpack 옵션 전체(`options`)를 받아 `module.rules`만 교체한다.
+
+```javascript
+const {
+  swcDefaultsFactory,
+} = require('@nestjs/cli/lib/compiler/defaults/swc-defaults');
+
+const baseSwcOptions = swcDefaultsFactory().swcOptions;
+const swcOptions = { ...baseSwcOptions, swcrc: false };
+
+module.exports = function (options) {
+  return {
+    ...options,
+    module: {
+      ...options.module,
+      rules: [
+        {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: { loader: 'swc-loader', options: swcOptions },
+        },
+      ],
+    },
+  };
+};
+```
+
+| 결정 | 이유 |
+|------|------|
+| 함수 형태 (`function(options) { ... }`) | nest CLI는 사용자 config를 `{...defaultOptions, ...userConfig}`로 얕게 머지. 객체 형태로 `module`을 주면 nest 기본 `module`이 통째로 교체됨. 함수 형태로 받아 `options.module`을 spread해야 안전 |
+| `swcrc: false` | Jest용 루트 `.swcrc`가 빌드 swc-loader에 새지 않도록 격리 |
+| 직접 require: `swcDefaultsFactory`만 | 외부 패키지(`webpack-node-externals` 등)를 직접 require하지 않으므로 pnpm strict node_modules 환경에서도 호이스팅 의존 없이 동작 |
+
+### `nest-cli.json` 변경
+
+```diff
+   "compilerOptions": {
+     "deleteOutDir": true,
+-    "webpack": false,
++    "webpack": true,
++    "webpackConfigPath": "webpack.config.js",
+     "tsConfigPath": "apps/service/tsconfig.app.json"
+   },
+```
+
+- `webpack: true` — nest CLI를 `WebpackCompiler` 분기로 진입.
+- `webpackConfigPath` — 위 `webpack.config.js` 사용.
+- `monorepo`, `root`, `projects`, 각 project의 `tsConfigPath`는 유지.
+
+### `.swcrc` (Jest 전용)
+
+**파일**: `.swcrc` (프로젝트 루트, 신규)
+
+```json
+{
+  "$schema": "https://swc.rs/schema.json",
+  "sourceMaps": true,
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "legacyDecorator": true,
+      "decoratorMetadata": true,
+      "useDefineForClassFields": false
+    },
+    "target": "es2021",
+    "keepClassNames": true
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}
+```
+
+| 옵션 | 값 | 이유 |
+|------|-----|------|
+| `parser.decorators` | `true` | NestJS 데코레이터 파싱 |
+| `transform.legacyDecorator` | `true` | TypeScript 5의 stage-3 데코레이터가 아닌 **legacy(experimental) 데코레이터** 사용. NestJS 11이 의존 |
+| `transform.decoratorMetadata` | `true` | `reflect-metadata` 기반 DI/엔티티 메타데이터 보존 |
+| `transform.useDefineForClassFields` | `false` | TypeScript의 기존 클래스 필드 시맨틱 유지 (NestJS DI에 필요) |
+| `target` | `es2021` | nest CLI `swcDefaultsFactory`의 빌드 target과 일치시켜 빌드/테스트 동작 차이 최소화 |
+| `keepClassNames` | `true` | 클래스 이름 기반 DI/로깅 안정성 |
+| `module.type` | `commonjs` | Jest 기본 모듈 시스템 |
+
+### Jest `transform` 변경
+
+**파일**: `package.json` 루트 `jest` 블록
+
+```diff
+   "jest": {
+     "transform": {
+-      "^.+\\.(t|j)s$": "ts-jest"
++      "^.+\\.(t|j)s$": "@swc/jest"
+     },
+     ...
+   }
+```
+
+**파일**: `test/service/jest-e2e.json`, `test/back-office/jest-e2e.json`
+
+```diff
+   "transform": {
+-    "^.+\\.(t|j)s$": "ts-jest"
++    "^.+\\.(t|j)s$": "@swc/jest"
+   },
+```
+
+`moduleNameMapper`, `globalSetup`, `globalTeardown`, `roots`, `testRegex`, `maxWorkers`는 변경 없음. `@swc/jest`는 같은 폴더의 `.swcrc`를 자동으로 발견.
+
+## 패키지 변경
+
+### 추가 (직접 devDeps)
+
+```bash
+pnpm add -D @swc/core @swc/jest swc-loader
+```
+
+| 패키지 | 용도 |
+|--------|------|
+| `@swc/core` | SWC 트랜스파일러 코어 (swc-loader / @swc/jest의 peer) |
+| `swc-loader` | webpack 로더 |
+| `@swc/jest` | Jest 트랜스폼 |
+
+### 제거
+
+```bash
+pnpm remove ts-jest ts-loader
+```
+
+| 패키지 | 제거 사유 |
+|--------|----------|
+| `ts-jest` | `@swc/jest`가 대체 |
+| `ts-loader` | nest webpack 기본 rule을 우리 webpack.config.js가 swc-loader로 교체하므로 더 이상 직접 의존하지 않음 |
+
+### 추가하지 않는 것
+
+`webpack`, `webpack-node-externals`, `tsconfig-paths-webpack-plugin`, `fork-ts-checker-webpack-plugin`은 **`@nestjs/cli`의 직접 dependency로 이미 설치**되어 있다. nest CLI 내부에서만 require하므로 사용자가 직접 deps에 추가할 필요 없음.
+
+## 빌드 동작 비교
+
+| 항목 | tsc (이전) | webpack + swc-loader (이후) |
+|------|-----------|----------------------------|
+| 트랜스파일러 | TypeScript 컴파일러 | SWC (Rust) |
+| 타입 체크 | tsc가 동시 수행 | `ForkTsCheckerWebpackPlugin`이 별도 프로세스로 병행 |
+| 출력 구조 | 모노레포 미러 트리 (`dist/apps/{name}/apps/{name}/src/main.js` 등) | 단일 번들 (`dist/apps/{name}/main.js`) |
+| node_modules 처리 | 미번들 | `webpack-node-externals`로 외부화 (런타임에 require) |
+| path alias | nest CLI tsc 빌더가 별칭을 상대 경로로 emit | `TsconfigPathsPlugin`이 컴파일 타임에 해결 |
+| `__dirname` | 진짜 경로 유지 | nest 기본 `node: { __dirname: false }`로 진짜 경로 유지 |
+| `start:*:prod` | `node dist/apps/{name}/main` | 동일 (출력 경로 호환) |
+
+## 검증
+
+### 자동 검증
+
+작업 완료 후 프로젝트 표준 검증을 실행:
+
+```bash
+pnpm format
+pnpm lint:check
+pnpm build:all     # webpack + swc-loader 빌드. ForkTsChecker가 타입 체크 병행
+pnpm test          # 단위 테스트 — @swc/jest
+pnpm test:e2e      # service + back-office 통합 테스트 — Docker + Testcontainers
+pnpm test:cov      # 커버리지 정상 수집
+```
+
+### 수동 검증 (DI 메타데이터 + path alias + `__dirname` 통합 검증)
+
+```bash
+NODE_ENV=local node dist/apps/service/main &
+SERVICE_PID=$!
+NODE_ENV=local node dist/apps/back-office/main &
+BO_PID=$!
+sleep 3
+curl -i http://localhost:3000/health
+curl -i http://localhost:3001/health
+kill $SERVICE_PID $BO_PID
+```
+
+| 검증 항목 | 기대 결과 |
+|-----------|----------|
+| 두 앱 부팅 | DI 메타데이터/path alias/`__dirname` 모두 동작 |
+| `GET /health` 200 OK | TypeORM `entityMetadatas` 정상 로드 (DB 헬스체크가 entity 의존) |
+| 통합 테스트 통과 | controller → handler → repository → DB 플로우 SWC 트랜스파일된 코드로 통과 |
+| `pnpm build:all` 타입 에러 시 실패 | `ForkTsCheckerWebpackPlugin` 동작 확인 |
+
+### 성능 측정 (선택)
+
+```bash
+time pnpm build:all
+time pnpm test
+```
+
+전환 전후 시간을 비교하여 효과를 정량화. CI 빌드 시간 절감 추정 자료로 활용.
+
+## 트러블슈팅
+
+### `Cannot find module '@nestjs/cli/lib/compiler/defaults/swc-defaults'`
+
+`@nestjs/cli`가 설치되지 않았거나 버전이 너무 낮음. `pnpm install`로 재설치하고 `@nestjs/cli@^11.0.16` 이상인지 확인.
+
+### `decorator metadata` 관련 DI 오류 (`Nest can't resolve dependencies`)
+
+`.swcrc`의 `transform.legacyDecorator: true` + `transform.decoratorMetadata: true`가 누락된 경우. 또는 빌드의 swc-loader 옵션이 `swcDefaultsFactory()` 결과가 아닌 직접 작성한 옵션이라면 동일 키 누락 의심.
+
+### TypeORM이 entityMetadatas를 로드하지 못함
+
+`libs/shared/src/database/typeorm.config.ts`의 `migrations: [__dirname + '/../migrations/*{.ts,.js}']` 경로가 빌드 후에 깨진 경우. nest 기본 `node: { __dirname: false }`가 사용자 webpack.config의 spread 머지로 보존되는지 확인.
+
+```javascript
+// 잘못된 패턴 — node 기본값을 통째로 덮어씀
+return {
+  ...options,
+  node: { __dirname: 'mock' },  // ❌ 절대 금지
+};
+
+// 올바른 패턴 — node 키 자체를 두지 않음 (nest 기본값 보존)
+return {
+  ...options,
+  module: { ...options.module, rules: [...] },
+};
+```
+
+### Swagger UI에서 `Cannot find module 'class-transformer/storage'`
+
+nest 기본 `IgnorePlugin`이 사용자 webpack.config에서 보존되지 않은 경우. `plugins`를 사용자 config에서 새로 정의하지 말고, 정의가 필요하면 `[...options.plugins, myPlugin]` 형태로 spread.
+
+### `pnpm test`에서 `Unexpected token` (데코레이터)
+
+`.swcrc`가 Jest에 의해 발견되지 않음. 루트(`package.json`과 동일 디렉토리)에 위치하는지 확인. 또는 inline 옵션 형태로 명시:
+
+```json
+"transform": {
+  "^.+\\.(t|j)s$": ["@swc/jest", { /* .swcrc 내용과 동일 */ }]
+}
+```
+
+### webpack 빌드가 `.swcrc`를 읽음
+
+빌드 swc-loader 옵션에 `swcrc: false`가 누락된 경우. `webpack.config.js`의 `swcOptions`가 `{ ...baseSwcOptions, swcrc: false }`인지 확인.
+
+### 빌드는 통과하지만 타입 에러가 잡히지 않음
+
+`ForkTsCheckerWebpackPlugin`이 비활성화된 경우. nest 기본값은 nest 플러그인이 등록되지 않았을 때만 ForkTsChecker를 추가한다 (`webpack-defaults.js:87-95`). 사용자 webpack.config의 spread 머지로 자동 보존되어야 함. 빌드 출력에 `ts-checker` 관련 메시지가 보이지 않으면 `options.plugins` 머지 누락 의심.
+
+## 적용하지 않은 것 (Out of Scope)
+
+- **마이그레이션 CLI의 SWC 전환**. `ts-node/register` → `@swc-node/register` 교체는 운영 영향이 큰 별도 작업으로 분리.
+- **HMR (Hot Module Replacement)**. `nest start --watch`는 webpack watch 모드로 충분히 빠르게 동작. 필요 시 NestJS 공식 [hot-reload 레시피](https://docs.nestjs.com/recipes/hot-reload)를 따라 `webpack-hmr.config.js`를 별도 추가.
+- **`assets` / `watchAssets`**. 현재 정적 자산 의존이 없으므로 미설정.
+- **별도 `tsc --noEmit` CI 단계**. nest 기본 `ForkTsCheckerWebpackPlugin`이 빌드 시 타입 체크를 병행하므로 불필요.
+- **SWC `paths` (jsc.baseUrl/paths)**. 빌드는 `TsconfigPathsPlugin`(nest 기본), Jest는 `moduleNameMapper`로 별칭을 해결. SWC 자체 별칭 해석을 추가하면 단일 진실 원천이 분산되므로 의도적으로 회피.
+
+## 참고
+
+- [NestJS Recipes — SWC](https://docs.nestjs.com/recipes/swc)
+- [NestJS CLI — Workspaces (Monorepo)](https://docs.nestjs.com/cli/monorepo)
+- [SWC 공식 문서](https://swc.rs/docs/configuration/swcrc)
+- [@swc/jest README](https://github.com/swc-project/jest)
+- [swc-loader README](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader)
+- [tsconfig-paths-webpack-plugin](https://github.com/dividab/tsconfig-paths-webpack-plugin)

--- a/docs/swc-migration-guide.md
+++ b/docs/swc-migration-guide.md
@@ -225,6 +225,50 @@ pnpm remove ts-jest ts-loader
 
 `webpack`, `webpack-node-externals`, `tsconfig-paths-webpack-plugin`, `fork-ts-checker-webpack-plugin`은 **`@nestjs/cli`의 직접 dependency로 이미 설치**되어 있다. nest CLI 내부에서만 require하므로 사용자가 직접 deps에 추가할 필요 없음.
 
+## 엔티티 호환성 — 순환 참조 + 데코레이터 메타데이터
+
+TypeORM 엔티티가 `@OneToMany` / `@ManyToOne` 등으로 양방향 관계를 가지면 두 엔티티 파일 사이에 **순환 참조**가 생긴다 (예: `User` ↔ `Post`). tsc는 이를 무리 없이 처리하지만, SWC + `decoratorMetadata: true` 조합은 두 가지 문제를 일으킨다.
+
+### 문제 1 — `Reflect.metadata('design:type', ClassRef)` TDZ
+
+**증상**: 단위 테스트 또는 부팅 시 `ReferenceError: Cannot access 'User' before initialization`.
+
+**원인**: SWC는 `decoratorMetadata: true`일 때 데코레이터가 붙은 프로퍼티의 타입을 `Reflect.metadata('design:type', User)`로 즉시 emit. 하지만 순환 참조 중인 모듈은 클래스 선언 직전에 평가되어 TDZ에 빠짐.
+
+**해결**: TypeORM이 SWC 호환을 위해 제공하는 **`Relation<T>` 래퍼**를 사용. `Relation<T>`는 단순 타입 별칭(`type Relation<T> = T`)이지만, 제네릭으로 감싸진 타입은 데코레이터 메타데이터 emit 시 `Object`로 처리되어 클래스 참조를 우회한다.
+
+```diff
+  // libs/shared/src/entities/post.entity.ts
+- @ManyToOne(() => User)
+- user: User;
++ @ManyToOne(() => User)
++ user: Relation<User>;
+
+  // libs/shared/src/entities/user.entity.ts
+- @OneToMany(() => Post, (post) => post.user)
+- posts: Post[];
++ @OneToMany(() => Post, (post) => post.user)
++ posts: Relation<Post[]>;
+```
+
+### 문제 2 — `TS1272: 데코레이터 시그니처의 타입은 import type 필수`
+
+**증상**: `pnpm start:local`(watch 모드) 시 `ForkTsCheckerWebpackPlugin`이 `TS1272: A type referenced in a decorated signature must be imported with 'import type' or a namespace import when 'isolatedModules' and 'emitDecoratorMetadata' are enabled.`로 빌드 거부.
+
+**원인**: `Relation`은 런타임 값이 없는 순수 타입 별칭. `tsconfig.json`이 `isolatedModules: true` + `emitDecoratorMetadata: true`일 때 TypeScript는 데코레이터 시그니처에 등장하는 **타입 전용** 심볼을 반드시 `import type`으로 들여오라고 요구.
+
+**해결**: `Relation`을 `import type`으로 분리 (`User`/`Post`처럼 클래스인 값 import는 그대로 둠).
+
+```diff
+- import { Column, Entity, OneToMany, Relation } from 'typeorm';
++ import { Column, Entity, OneToMany } from 'typeorm';
++ import type { Relation } from 'typeorm';
+```
+
+### 적용 범위
+
+본 프로젝트에서는 `libs/shared/src/entities/user.entity.ts`와 `post.entity.ts`만 해당. `Admin` 엔티티는 다른 엔티티와 관계가 없어 변경 불요. **새 엔티티가 양방향 관계를 가질 때마다 동일 패턴을 적용해야 한다**.
+
 ## 빌드 동작 비교
 
 | 항목 | tsc (이전) | webpack + swc-loader (이후) |
@@ -282,6 +326,14 @@ time pnpm test
 전환 전후 시간을 비교하여 효과를 정량화. CI 빌드 시간 절감 추정 자료로 활용.
 
 ## 트러블슈팅
+
+### `ReferenceError: Cannot access 'User' before initialization` (또는 다른 엔티티명)
+
+순환 참조된 엔티티에 `decoratorMetadata`가 즉시 `Reflect.metadata('design:type', ClassRef)`를 emit하면서 TDZ. 위 [엔티티 호환성 — 순환 참조 + 데코레이터 메타데이터](#엔티티-호환성--순환-참조--데코레이터-메타데이터) 참조. **해결**: 양방향 관계 필드 타입을 `Relation<T>`로 감싸기.
+
+### `TS1272: A type referenced in a decorated signature must be imported with 'import type' ...`
+
+`tsconfig.json`이 `isolatedModules: true` + `emitDecoratorMetadata: true`일 때 데코레이터 시그니처에 사용된 타입은 `import type` 필수. `Relation`이 대표적. **해결**: `import type { Relation } from 'typeorm'`로 분리. `User`/`Post` 같은 클래스(값 + 타입)는 `import type`으로 옮길 필요 없음. `pnpm build:all`(non-watch, `mode: 'none'`)에서는 ForkTsChecker가 비동기 모드라 통과해도, `pnpm start:local`(watch, `mode: 'development'`)에서는 차단된다는 점에 주의.
 
 ### `Cannot find module '@nestjs/cli/lib/compiler/defaults/swc-defaults'`
 

--- a/libs/shared/src/entities/post.entity.ts
+++ b/libs/shared/src/entities/post.entity.ts
@@ -4,6 +4,7 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  Relation,
 } from 'typeorm';
 import { User } from './user.entity';
 import { BaseTimeEntity } from './base.entity';
@@ -15,7 +16,7 @@ export class Post extends BaseTimeEntity {
 
   @ManyToOne(() => User)
   @JoinColumn({ name: 'userId' })
-  user: User;
+  user: Relation<User>;
 
   @Column({ length: 200 })
   title: string;

--- a/libs/shared/src/entities/post.entity.ts
+++ b/libs/shared/src/entities/post.entity.ts
@@ -4,8 +4,8 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
-  Relation,
 } from 'typeorm';
+import type { Relation } from 'typeorm';
 import { User } from './user.entity';
 import { BaseTimeEntity } from './base.entity';
 

--- a/libs/shared/src/entities/user.entity.ts
+++ b/libs/shared/src/entities/user.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, OneToMany, Relation } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
+import type { Relation } from 'typeorm';
 import { BaseTimeEntity } from './base.entity';
 import { Post } from './post.entity';
 

--- a/libs/shared/src/entities/user.entity.ts
+++ b/libs/shared/src/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany } from 'typeorm';
+import { Column, Entity, OneToMany, Relation } from 'typeorm';
 import { BaseTimeEntity } from './base.entity';
 import { Post } from './post.entity';
 
@@ -17,5 +17,5 @@ export class User extends BaseTimeEntity {
   hashedRefreshToken: string | null;
 
   @OneToMany(() => Post, (post) => post.user)
-  posts: Post[];
+  posts: Relation<Post[]>;
 }

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,8 @@
   "sourceRoot": "apps/service/src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "webpack": false,
+    "webpack": true,
+    "webpackConfigPath": "webpack.config.js",
     "tsConfigPath": "apps/service/tsconfig.app.json"
   },
   "monorepo": true,

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "@nestjs/cli": "^11.0.16",
     "@nestjs/schematics": "^11.0.9",
     "@nestjs/testing": "^11.1.17",
+    "@swc/core": "^1.15.30",
+    "@swc/jest": "^0.2.39",
     "@testcontainers/postgresql": "^11.13.0",
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.6",
@@ -99,9 +101,8 @@
     "prettier": "^3.8.1",
     "source-map-support": "^0.5.21",
     "supertest": "^7.2.2",
+    "swc-loader": "^0.2.7",
     "testcontainers": "^11.13.0",
-    "ts-jest": "^29.4.6",
-    "ts-loader": "^9.5.4",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3",
@@ -116,7 +117,7 @@
     "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.(t|j)s$": "@swc/jest"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,13 +37,13 @@ importers:
         version: 11.2.6(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       '@nestjs/terminus':
         specifier: ^11.1.1
-        version: 11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))
+        version: 11.1.1(vkku3l2d4d7xtoycdinksj4lwm)
       '@nestjs/throttler':
         specifier: ^6.5.0
         version: 6.5.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))
+        version: 11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)))
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -106,7 +106,7 @@ importers:
         version: 7.8.2
       typeorm:
         specifier: ^0.3.28
-        version: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.5
@@ -116,13 +116,19 @@ importers:
         version: 10.0.1(eslint@10.0.3)
       '@nestjs/cli':
         specifier: ^11.0.16
-        version: 11.0.16(@types/node@25.5.0)
+        version: 11.0.16(@swc/core@1.15.30)(@types/node@25.5.0)
       '@nestjs/schematics':
         specifier: ^11.0.9
         version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.17
         version: 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17))
+      '@swc/core':
+        specifier: ^1.15.30
+        version: 1.15.30
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.30)
       '@testcontainers/postgresql':
         specifier: ^11.13.0
         version: 11.13.0
@@ -164,7 +170,7 @@ importers:
         version: 17.4.0
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
@@ -177,18 +183,15 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
+      swc-loader:
+        specifier: ^0.2.7
+        version: 0.2.7(@swc/core@1.15.30)(webpack@5.104.1(@swc/core@1.15.30))
       testcontainers:
         specifier: ^11.13.0
         version: 11.13.0
-      ts-jest:
-        specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
-      ts-loader:
-        specifier: ^9.5.4
-        version: 9.5.4(typescript@5.9.3)(webpack@5.104.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -666,6 +669,10 @@ packages:
     peerDependenciesMeta:
       node-notifier:
         optional: true
+
+  '@jest/create-cache-key-function@30.3.0':
+    resolution: {integrity: sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/diff-sequences@30.3.0':
     resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
@@ -1531,6 +1538,99 @@ packages:
   '@sqltools/formatter@1.2.5':
     resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
 
+  '@swc/core-darwin-arm64@1.15.30':
+    resolution: {integrity: sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.30':
+    resolution: {integrity: sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.30':
+    resolution: {integrity: sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.30':
+    resolution: {integrity: sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.30':
+    resolution: {integrity: sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.30':
+    resolution: {integrity: sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.30':
+    resolution: {integrity: sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.30':
+    resolution: {integrity: sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.30':
+    resolution: {integrity: sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.30':
+    resolution: {integrity: sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.30':
+    resolution: {integrity: sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.30':
+    resolution: {integrity: sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.30':
+    resolution: {integrity: sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/jest@0.2.39':
+    resolution: {integrity: sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+
   '@testcontainers/postgresql@11.13.0':
     resolution: {integrity: sha512-Y+HLf+IEu9+h3MgxRhnFunw9ldk3jxN2PO6zyejN5AiDd1aSeBQ7hfpc/4MlMm65St2DdLGf39oE/vdW1+hc/Q==}
 
@@ -2201,18 +2301,10 @@ packages:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
-
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  bs-logger@0.2.6:
-    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
-    engines: {node: '>= 6'}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -2805,10 +2897,6 @@ packages:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
 
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
-
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -2975,11 +3063,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -3097,10 +3180,6 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -3408,9 +3487,6 @@ packages:
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
-  lodash.memoize@4.1.2:
-    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
-
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
@@ -3473,10 +3549,6 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
-
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -4096,10 +4168,6 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
-  source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
-
   split-ca@1.0.1:
     resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
 
@@ -4208,6 +4276,12 @@ packages:
   swagger-ui-dist@5.31.0:
     resolution: {integrity: sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==}
 
+  swc-loader@0.2.7:
+    resolution: {integrity: sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w==}
+    peerDependencies:
+      '@swc/core': ^1.2.147
+      webpack: '>=2'
+
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
@@ -4286,10 +4360,6 @@ packages:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
     engines: {node: '>= 0.4'}
 
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -4307,40 +4377,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-jest@29.4.6:
-    resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/transform': ^29.0.0 || ^30.0.0
-      '@jest/types': ^29.0.0 || ^30.0.0
-      babel-jest: ^29.0.0 || ^30.0.0
-      esbuild: '*'
-      jest: ^29.0.0 || ^30.0.0
-      jest-util: ^29.0.0 || ^30.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/transform':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-      jest-util:
-        optional: true
-
-  ts-loader@9.5.4:
-    resolution: {integrity: sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      typescript: '*'
-      webpack: ^5.0.0
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -4385,10 +4421,6 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
-
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -4470,11 +4502,6 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
-    hasBin: true
-
-  uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
-    engines: {node: '>=0.8.0'}
     hasBin: true
 
   uid@2.0.2:
@@ -4593,9 +4620,6 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -5181,7 +5205,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))':
+  '@jest/core@30.3.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -5196,7 +5220,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -5215,6 +5239,10 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+
+  '@jest/create-cache-key-function@30.3.0':
+    dependencies:
+      '@jest/types': 30.3.0
 
   '@jest/diff-sequences@30.3.0': {}
 
@@ -5397,7 +5425,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nestjs/cli@11.0.16(@types/node@25.5.0)':
+  '@nestjs/cli@11.0.16(@swc/core@1.15.30)(@types/node@25.5.0)':
     dependencies:
       '@angular-devkit/core': 19.2.19(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.19(chokidar@4.0.3)
@@ -5408,15 +5436,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.104.1)
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.30))
       glob: 13.0.0
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.104.1
+      webpack: 5.104.1(@swc/core@1.15.30)
       webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/core': 1.15.30
     transitivePeerDependencies:
       - '@types/node'
       - esbuild
@@ -5530,7 +5560,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.4
 
-  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))':
+  '@nestjs/terminus@11.1.1(vkku3l2d4d7xtoycdinksj4lwm)':
     dependencies:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -5541,8 +5571,8 @@ snapshots:
     optionalDependencies:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.8.0
-      '@nestjs/typeorm': 11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))
-      typeorm: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@nestjs/typeorm': 11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)))
+      typeorm: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
 
   '@nestjs/testing@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17))':
     dependencies:
@@ -5558,13 +5588,13 @@ snapshots:
       '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)))':
     dependencies:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
-      typeorm: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      typeorm: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
 
   '@noble/hashes@1.8.0': {}
 
@@ -6350,6 +6380,73 @@ snapshots:
 
   '@sqltools/formatter@1.2.5': {}
 
+  '@swc/core-darwin-arm64@1.15.30':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.30':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.30':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.30':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.30':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.30':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.30':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.30':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.30':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.30':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.30':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.30':
+    optional: true
+
+  '@swc/core@1.15.30':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.30
+      '@swc/core-darwin-x64': 1.15.30
+      '@swc/core-linux-arm-gnueabihf': 1.15.30
+      '@swc/core-linux-arm64-gnu': 1.15.30
+      '@swc/core-linux-arm64-musl': 1.15.30
+      '@swc/core-linux-ppc64-gnu': 1.15.30
+      '@swc/core-linux-s390x-gnu': 1.15.30
+      '@swc/core-linux-x64-gnu': 1.15.30
+      '@swc/core-linux-x64-musl': 1.15.30
+      '@swc/core-win32-arm64-msvc': 1.15.30
+      '@swc/core-win32-ia32-msvc': 1.15.30
+      '@swc/core-win32-x64-msvc': 1.15.30
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/jest@0.2.39(@swc/core@1.15.30)':
+    dependencies:
+      '@jest/create-cache-key-function': 30.3.0
+      '@swc/core': 1.15.30
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.3.1
+
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@testcontainers/postgresql@11.13.0':
     dependencies:
       testcontainers: 11.13.0
@@ -7129,10 +7226,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
-
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.8
@@ -7140,10 +7233,6 @@ snapshots:
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  bs-logger@0.2.6:
-    dependencies:
-      fast-json-stable-stringify: 2.1.0
 
   bser@2.1.1:
     dependencies:
@@ -7719,10 +7808,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
-
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -7762,7 +7847,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.104.1):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.30)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
@@ -7777,7 +7862,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.104.1
+      webpack: 5.104.1(@swc/core@1.15.30)
 
   form-data@4.0.5:
     dependencies:
@@ -7907,15 +7992,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -8025,8 +8101,6 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
-  is-number@7.0.0: {}
-
   is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
@@ -8114,15 +8188,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -8133,7 +8207,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -8160,7 +8234,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.5.0
-      ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8386,12 +8460,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
+  jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -8511,8 +8585,6 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
-  lodash.memoize@4.1.2: {}
-
   lodash.once@4.1.1: {}
 
   lodash@4.17.23: {}
@@ -8561,11 +8633,6 @@ snapshots:
   merge-stream@2.0.0: {}
 
   methods@1.1.2: {}
-
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.1
 
   mime-db@1.52.0: {}
 
@@ -9201,8 +9268,6 @@ snapshots:
 
   source-map@0.7.4: {}
 
-  source-map@0.7.6: {}
-
   split-ca@1.0.1: {}
 
   split2@4.2.0: {}
@@ -9324,6 +9389,12 @@ snapshots:
     dependencies:
       '@scarf/scarf': 1.4.0
 
+  swc-loader@0.2.7(@swc/core@1.15.30)(webpack@5.104.1(@swc/core@1.15.30)):
+    dependencies:
+      '@swc/core': 1.15.30
+      '@swc/counter': 0.1.3
+      webpack: 5.104.1(@swc/core@1.15.30)
+
   symbol-observable@4.0.0: {}
 
   synckit@0.11.12:
@@ -9377,13 +9448,15 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.4.0(webpack@5.104.1):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.30)(webpack@5.104.1(@swc/core@1.15.30)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.104.1
+      webpack: 5.104.1(@swc/core@1.15.30)
+    optionalDependencies:
+      '@swc/core': 1.15.30
 
   terser@5.46.1:
     dependencies:
@@ -9446,10 +9519,6 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
-
   toidentifier@1.0.1: {}
 
   token-types@6.1.2:
@@ -9464,37 +9533,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.4
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      jest-util: 30.3.0
-
-  ts-loader@9.5.4(typescript@5.9.3)(webpack@5.104.1):
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 5.20.1
-      micromatch: 4.0.8
-      semver: 7.7.4
-      source-map: 0.7.6
-      typescript: 5.9.3
-      webpack: 5.104.1
-
-  ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -9511,6 +9550,8 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.30
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -9539,8 +9580,6 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  type-fest@4.41.0: {}
-
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -9560,7 +9599,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
+  typeorm@0.3.28(ioredis@5.10.1)(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0
@@ -9581,7 +9620,7 @@ snapshots:
       ioredis: 5.10.1
       pg: 8.20.0
       redis: 4.7.1
-      ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@25.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9598,9 +9637,6 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
-
-  uglify-js@3.19.3:
-    optional: true
 
   uid@2.0.2:
     dependencies:
@@ -9691,7 +9727,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.104.1:
+  webpack@5.104.1(@swc/core@1.15.30):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -9715,7 +9751,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(webpack@5.104.1)
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.30)(webpack@5.104.1(@swc/core@1.15.30))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:
@@ -9742,8 +9778,6 @@ snapshots:
       string-width: 4.2.3
 
   word-wrap@1.2.5: {}
-
-  wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/test/back-office/jest-e2e.json
+++ b/test/back-office/jest-e2e.json
@@ -5,7 +5,7 @@
   "testRegex": ".(e2e|integration)-spec.ts$",
   "testTimeout": 30000,
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t|j)s$": "@swc/jest"
   },
   "moduleNameMapper": {
     "^@app/shared/(.*)$": "<rootDir>/../../libs/shared/src/$1",

--- a/test/service/jest-e2e.json
+++ b/test/service/jest-e2e.json
@@ -5,7 +5,7 @@
   "testRegex": ".(e2e|integration)-spec.ts$",
   "testTimeout": 30000,
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t|j)s$": "@swc/jest"
   },
   "moduleNameMapper": {
     "^@app/shared/(.*)$": "<rootDir>/../../libs/shared/src/$1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,22 @@
+const {
+  swcDefaultsFactory,
+} = require('@nestjs/cli/lib/compiler/defaults/swc-defaults');
+
+const baseSwcOptions = swcDefaultsFactory().swcOptions;
+const swcOptions = { ...baseSwcOptions, swcrc: false };
+
+module.exports = function (options) {
+  return {
+    ...options,
+    module: {
+      ...options.module,
+      rules: [
+        {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: { loader: 'swc-loader', options: swcOptions },
+        },
+      ],
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- NestJS 모노레포의 트랜스파일링을 tsc/ts-loader/ts-jest에서 **webpack + swc-loader**(빌드) + **`@swc/jest`**(테스트)로 전환
- 모노레포 모드는 SWC builder를 직접 지원하지 않아 NestJS 공식 권장 경로인 webpack 경유. `webpack.config.js`는 함수 형태로 nest CLI 기본값(externals, `TsconfigPathsPlugin`, `ForkTsCheckerWebpackPlugin`, `__dirname` 보존)을 그대로 보존하고 `module.rules`만 swc-loader로 교체 — 사용자 정의 ~15줄
- 회귀 두 건 해결: ① 순환 참조 엔티티(`User` ↔ `Post`)에서 SWC `decoratorMetadata`가 TDZ 유발 → TypeORM `Relation<T>` 래퍼로 우회. ② `isolatedModules` + `emitDecoratorMetadata`에서 `Relation` 데코레이터 시그니처 사용 시 TS1272 → `import type { Relation }`로 분리
- 패키지: `@swc/core`, `@swc/jest`, `swc-loader` 추가 / `ts-jest`, `ts-loader` 제거. `webpack`/`webpack-node-externals`/`tsconfig-paths-webpack-plugin`/`fork-ts-checker-webpack-plugin`은 `@nestjs/cli` transitive로 이미 포함되어 있어 직접 추가 불요
- 마이그레이션 CLI(`migration:*`)는 운영 안정성 분리를 위해 `ts-node/register` 그대로 유지
- 가이드 문서 신규(`docs/swc-migration-guide.md`) + CLAUDE.md/README.md 반영

## 검증

- `pnpm build:all` ✓ webpack 5.104.1, 양쪽 앱 ~5.2초 (tsc 대비 빠름)
- `pnpm test` ✓ 21 suites / 61 tests, **6.7s → 4.9s (~26% 단축)**
- `pnpm test:e2e` ✓ service 3/87 + back-office 2/33 (총 120 tests)
- `pnpm start:local` ✓ 양쪽 앱 부팅 + `/health` 200 OK + watch 모드 정상

## Test plan

- [x] `pnpm format` / `pnpm lint:check` 통과
- [x] `pnpm build:all` 통과 — webpack 단일 번들 산출 (`dist/apps/{name}/main.js`)
- [x] `pnpm test` 통과 — `@swc/jest`로 단위 테스트
- [x] `pnpm test:e2e` 통과 — Testcontainers 포함 통합 테스트
- [x] `pnpm start:local` 부팅 + `/health` 응답 확인
- [x] 양방향 엔티티 관계 SWC 호환 확인 (`Relation<T>` + `import type`)

> **Merge Strategy**: Create a merge commit을 사용해주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 빌드 도구 설정 및 마이그레이션 가이드 문서 추가
  * 양방향 엔티티 관계 타입 정의 가이드 추가

* **Chores**
  * 빌드 컴파일러를 SWC로 업데이트
  * 테스트 변환 도구를 SWC 기반으로 변경
  * 웹팩 설정을 통한 번들 프로세스 최적화
  * 엔티티 관계 타입 정의 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->