### PR TITLE
docs: PR #60 리뷰 학습을 가이드/스킬에 반영

### DIFF
--- a/.claude/agents/nestjs-expert.md
+++ b/.claude/agents/nestjs-expert.md
@@ -92,6 +92,8 @@ async execute(command: GoogleLoginCommand): Promise<AuthTokens> {
 
 `try` 블록 안에 이벤트 emit, 캐시 무효화, 추가 write를 함께 두지 않는다. catch 책임이 모호해지고 부분 실패 의미가 흐려진다.
 
+또한 **`cacheService.{get,set,del,delByPattern}` 호출 자체를 다시 `try/catch`로 감싸지 않는다.** `CacheService`가 내부적으로 Redis 에러를 swallow하므로 핸들러 측 wrap은 dead catch + 중복 warn 로그가 되고, `verify-handler-structure` R5에 의해 경고가 발생한다. `await this.cacheService.del(...)` 한 줄로만 호출한다.
+
 ```ts
 // ✅ Good — try는 write 한 줄만
 private async createUserOrConflict(input: CreateUserInput): Promise<User> {
@@ -275,7 +277,7 @@ Before completing any task, verify:
 - [ ] Handler는 `@CommandHandler`/`@QueryHandler` 데코레이터 적용됨
 - [ ] **Handler `execute()`는 호출만** — 검증/조회/조립이 private 메서드로 추출됨
 - [ ] **메서드 네이밍 규약 준수** — `validate*` / `load*OrThrow` / `*OrConflict` / `emit*Event` / `invalidate*Cache`
-- [ ] **try-catch는 단일 write 한 줄만 감쌈** — 이벤트 emit, 캐시 무효화, 추가 write가 try 안에 없음
+- [ ] **try-catch는 단일 write 한 줄만 감쌈** — 이벤트 emit, 캐시 무효화, 추가 write가 try 안에 없음. `cacheService.{get,set,del,delByPattern}` 호출에 핸들러 측 try/catch 없음 (CacheService가 이미 Fail-Open)
 - [ ] **`@Transactional()`은 다중 write 묶음 메서드에만** — `execute()` 전체에 달려 있지 않음, read-only 분기는 트랜잭션 밖
 - [ ] **데코레이터 메서드 파라미터 타입은 `import type`** — SWC TS1272 회피
 - [ ] **Pre-check + 23505 이중 안전망 유지** — 한쪽만 있지 않음

--- a/.claude/agents/tdd-test-writer.md
+++ b/.claude/agents/tdd-test-writer.md
@@ -213,6 +213,41 @@ describe('Posts (integration)', () => {
 });
 ```
 
+### 필수 필드 통합 테스트 — 3종 케이스 모두 커버
+
+`@IsString()` + `@IsNotEmpty()` + `@Length(min, max)`가 걸린 필수 필드는 통합 테스트에서 **빈 문자열 / 길이 초과 / 키 자체 부재** 3종을 각각 별도의 `it`으로 검증한다. 길이만 검증하면 `{}` 본문이 통과해도 회귀를 잡지 못한다 (PR #60 CodeRabbit 리뷰 학습).
+
+```ts
+it('name이 빈 문자열이면 400을 반환한다', async () => {
+  const { accessToken } = await registerAndLogin();
+  return request(app.getHttpServer())
+    .patch('/v1/auth/profile')
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send({ name: '' })
+    .expect(400);
+});
+
+it('name 필드가 누락되면 400을 반환한다', async () => {
+  const { accessToken } = await registerAndLogin();
+  return request(app.getHttpServer())
+    .patch('/v1/auth/profile')
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send({})
+    .expect(400);
+});
+
+it('name이 31자이면 400을 반환한다', async () => {
+  const { accessToken } = await registerAndLogin();
+  return request(app.getHttpServer())
+    .patch('/v1/auth/profile')
+    .set('Authorization', `Bearer ${accessToken}`)
+    .send({ name: 'a'.repeat(31) })
+    .expect(400);
+});
+```
+
+선택 필드(`@IsOptional()`)는 키 부재 케이스를 200/204로 검증하고, 빈 문자열/길이 초과만 400으로 분리한다.
+
 ## Quality Checks (작성 전후)
 
 1. ✅ 대상 레이어가 단위 테스트 대상인가? (pass-through면 통합으로 이동)

--- a/.claude/skills/verify-handler-structure/SKILL.md
+++ b/.claude/skills/verify-handler-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-handler-structure
-description: Service 앱 Command Handler의 구조 규칙(메서드 책임 분리, try-catch 범위, @Transactional 범위, 23505 매핑 위치) 회귀를 검증합니다. 핸들러 추가/수정 후 사용.
+description: Service 앱 Command Handler의 구조 규칙(메서드 책임 분리, try-catch 범위, @Transactional 범위, 23505 매핑 위치, cacheService wrap 금지) 회귀를 검증합니다. 핸들러 추가/수정 후 사용.
 ---
 
 # Command Handler 구조 검증
@@ -13,6 +13,7 @@ description: Service 앱 Command Handler의 구조 규칙(메서드 책임 분�
 2. **R2: try 블록 책임 단일화** — `try { ... }` 안에 `await` 호출이 2개 이상이면 경고. 단일 write 한 줄만 감싸야 함 (이벤트 emit, 캐시 무효화, 추가 write 금지).
 3. **R3: `@Transactional()` 안 read 금지** — `@Transactional()` 데코레이터가 붙은 메서드 본문에 `Read` 또는 `findBy` 호출이 있으면 경고. 트랜잭션 안에 read를 넣어 불필요한 락이 잡히는 것을 방지.
 4. **R4 (soft, 정보성): `execute()` 본문의 23505 매핑** — `execute()` 본문 안에 `QueryFailedError` 또는 `'23505'` 문자열이 직접 등장하면 경고. 추출된 private 메서드(예: `*OrConflict`) 안에 위치하도록 유도.
+5. **R5: `cacheService` 호출의 핸들러 측 wrap 금지** — `try` 블록 안에 `cacheService.{get,set,del,delByPattern}` 호출이 등장하면 경고. `CacheService`가 내부에서 Redis 에러를 swallow하므로 핸들러 측 try/catch는 dead catch + 중복 warn 로그가 된다.
 
 ## When to Run
 
@@ -302,6 +303,70 @@ done
 
 ---
 
+### Step 6: R5 — `cacheService` 호출의 핸들러 측 wrap 금지
+
+**도구:** Bash, Read
+
+**검사:** `try { ... }` 블록 안에 `cacheService.{get,set,del,delByPattern}` 호출이 등장하는지 확인합니다. `CacheService`가 이미 내부에서 Fail-Open으로 Redis 에러를 swallow하므로, 핸들러에서 다시 try/catch로 감싸면 dead catch + 중복 warn 로그가 발생합니다.
+
+```bash
+for f in $(find apps/service/src -path "*/command/*.handler.ts" -not -name "*.spec.ts"); do
+  awk '
+    /try[[:space:]]*\{/ { in_try = 1; depth = 0; start = NR }
+    in_try {
+      line = $0
+      if (NR == start) {
+        sub(/.*try[[:space:]]*\{/, "", line)
+      }
+      n = split(line, chars, "")
+      for (i = 1; i <= n; i++) {
+        c = chars[i]
+        if (c == "{") depth++
+        else if (c == "}") {
+          if (depth == 0) {
+            in_try = 0
+            break
+          }
+          depth--
+        }
+      }
+      if (in_try && line ~ /cacheService\.(get|set|del|delByPattern)\b/) {
+        printf "%s:%d try block wraps cacheService call: %s\n", FILENAME, NR, $0
+      }
+    }
+  ' "$f"
+done
+```
+
+**PASS 기준:**
+- `try` 블록 안에 `cacheService.{get,set,del,delByPattern}` 호출이 없음
+
+**FAIL 기준 (경고):**
+- `try` 블록 안에 `cacheService` 호출 발견 — `CacheService`가 이미 Fail-Open이라 dead code. 핸들러 측 wrap 제거 후 `await this.cacheService.del(...)` 한 줄로 단순화 권장.
+
+**수정 권장:**
+
+```ts
+// ❌ 핸들러에서 cacheService.del을 다시 try/catch로 감싼다
+private async invalidateProfileCache(userId: number): Promise<void> {
+  try {
+    await this.cacheService.del(`profile:${userId}`);
+  } catch (error) {
+    this.logger.warn(`Profile cache invalidation failed for userId=${userId}`, (error as Error).message);
+  }
+}
+
+// ✅ CacheService가 이미 Fail-Open이라 wrap 불필요
+async execute(command: UpdateProfileCommand): Promise<void> {
+  await this.updateNameOrThrow(command.userId, command.name);
+  await this.cacheService.del(`profile:${command.userId}`);
+}
+```
+
+기준 패턴: `CreatePostHandler`/`UpdatePostHandler`/`DeletePostHandler`는 `cacheService.{del,delByPattern}` 호출을 wrap 없이 직접 사용합니다.
+
+---
+
 ## Output Format
 
 ```markdown
@@ -313,6 +378,7 @@ done
 | 2   | R2   | `apps/service/src/posts/command/create-post.handler.ts`  | PASS | try 블록 모두 await 1개                             |
 | 3   | R3   | `apps/service/src/auth/command/google-login.handler.ts`  | PASS | @Transactional 안 read 없음 (read는 execute에 있음) |
 | 4   | R4   | (전체)                                                   | PASS | execute()에 23505 직접 등장 없음                    |
+| 5   | R5   | `apps/service/src/posts/command/update-post.handler.ts`  | PASS | try 블록 안 cacheService 호출 없음                  |
 | ... | ...  | ...                                                      | ...  | ...                                                 |
 
 **총 검사: N개 | PASS: X개 | FAIL: Y개 | 경고(soft): Z개**
@@ -326,8 +392,9 @@ done
 2. **단일 write 핸들러의 `@Transactional()` 미사용** — write가 1개라 트랜잭션이 불필요한 핸들러는 R3 검사 대상에서 제외 (메서드에 데코레이터가 없으면 검사 안 함).
 3. **`try` 블록 안 `await`가 1개인 경우** — `await this.userWriteRepository.create(...)`처럼 단일 write를 감싼 정상 패턴. R2는 ≥2개만 경고.
 4. **`finally` 블록의 cleanup `await`** — 본 프로젝트의 핸들러에는 일반적으로 없지만, `try { write }` + `finally { cleanup }` 구조에서 `finally`의 `await`는 R2 카운트에 포함하지 않음 (정리 책임은 catch와 분리됨).
-5. **back-office 앱 핸들러** — 본 스킬의 검사 범위(`apps/service/src/**/command/*.handler.ts`)에 포함되지 않음. back-office는 별도 리팩터링 스코프.
+5. **back-office 앱 핸들러** — 이 스킬의 검사 범위(`apps/service/src/**/command/*.handler.ts`)에 포함되지 않음. back-office는 별도 리팩터링 스코프.
 6. **R4의 정보성 경고** — `QueryFailedError`/`'23505'`가 `execute()` 본문에 등장해도 동작상 문제는 아님. 가독성/책임 분리를 위한 권장사항.
+7. **R5의 `try` 밖 `cacheService` 호출** — `await this.cacheService.del(...)`처럼 `try` 블록 밖에서 직접 호출하는 것이 정상 패턴. R5는 `try` 블록 안에 들어간 경우만 경고.
 
 ## Related Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Service 앱 Command Handler(`apps/service/src/**/command/*.handler.ts`)는 다�
 
 - **`execute()`는 호출만** — 검증/조회/조립은 private 메서드로 추출(≤50줄 목표). 검증 R1.
 - **메서드 네이밍** — `validate{Subject}{Predicate}`(검증), `load{Subject}…OrThrow`(조회+null체크+예외), `find{Subject}…`(단순 조회), `create/persist/link…OrConflict`(단일 write + 23505 매핑), `emit{Name}Event`/`invalidate{Name}Cache`(side-effect, try 밖에 위치).
-- **try-catch는 단일 write 1줄만 감싼다** — 이벤트 emit, 캐시 무효화, 추가 write를 try 안에 두지 않는다. 검증 R2.
+- **try-catch는 단일 write 1줄만 감싼다** — 이벤트 emit, 캐시 무효화, 추가 write를 try 안에 두지 않는다. 또한 `cacheService.{get,set,del,delByPattern}` 호출을 별도 try/catch로 다시 감싸지 않는다 — `CacheService` 자체가 Fail-Open이라 dead code가 된다(Cache Layer 항목 참고). 검증 R2.
 - **`@Transactional()`은 다중 write 묶음 메서드에만** — `execute()` 전체에 달지 않으며 read는 항상 트랜잭션 밖. 단일 write 핸들러는 `@Transactional()` 불필요. 검증 R3.
 - **데코레이터 메서드 파라미터 타입은 `import type`** — SWC + `isolatedModules` + `emitDecoratorMetadata` 조합에서 TS1272 회피 (엔티티 양방향 관계 `Relation<T>`와 동일 이유).
 
@@ -162,7 +162,8 @@ Controller → CommandBus / QueryBus → Handler (검증 + 로직) → IPostRead
 
 - `CacheService` (`libs/shared/src/cache/`) — 기존 `REDIS_CLIENT`(ioredis)를 재사용한 캐시 유틸리티. 추가 패키지 없음
 - **CQRS 정합**: Query Handler에서 캐시 읽기/저장, Command Handler에서 캐시 무효화
-- **Fail-Open 패턴**: 모든 Redis 연산을 try/catch로 감싸 Redis 장애 시 DB fallback. 캐시 장애가 서비스 가용성에 영향을 미치지 않음
+- **Fail-Open 패턴**: 모든 Redis 연산을 `CacheService` 내부에서 try/catch로 감싸 Redis 장애 시 DB fallback. 캐시 장애가 서비스 가용성에 영향을 미치지 않음
+- **핸들러 레벨 wrap 금지**: `CacheService.{get,set,del,delByPattern}` 호출은 Handler에서 다시 `try/catch`로 감싸지 않는다. `CacheService` 자체가 Redis 에러를 swallow하고 rethrow하지 않으므로 wrap하면 dead catch + 중복 warn 로그가 된다. `await this.cacheService.del(...)` 한 줄로만 호출한다. 동일 영역의 `CreatePostHandler`/`UpdatePostHandler`/`DeletePostHandler`가 기준 패턴.
 - **사용자 격리**: 모든 캐시 키에 `userId` 포함 (예: `post:{userId}:{postId}`)
 - 캐시 히트/미스/SET/DEL을 `debug` 레벨로 로깅, 장애 시 `warn` 레벨 로깅
 - 상세 가이드: `docs/cache-layer-guide.md`


### PR DESCRIPTION
## Summary

머지된 PR #60 (`feature/profile-update`)의 셀프 코드 리뷰와 CodeRabbit 리뷰가 공통으로 짚은 두 가지 학습 포인트를 가이드·에이전트·검증 스킬에 반영한다. 코드 변경은 없으며, 같은 회귀가 다음 PR에서 다시 발생하지 않도록 가드를 추가하는 문서 작업이다.

- **학습 1 — `CacheService` 핸들러 측 wrap 금지**: `UpdateProfileHandler`가 `cacheService.del()` 호출을 다시 `try/catch`로 감쌌으나 `CacheService` 자체가 이미 Fail-Open이라 dead catch가 되었다. 셀프 리뷰와 CodeRabbit 모두 동일 지적.
- **학습 2 — 필수 필드 통합 테스트 3종 케이스**: 빈 문자열·길이 초과만 검증하고 키 자체 부재 케이스를 빠뜨려, `@IsNotEmpty()`가 빠져도 회귀를 잡지 못할 수 있다는 CodeRabbit nitpick.

## Changes

| 파일 | 변경 성격 |
|---|---|
| `CLAUDE.md` — Cache Layer 섹션 | "핸들러 레벨 wrap 금지" 규칙 추가 |
| `CLAUDE.md` — Handler Authoring Rules R2 | `cacheService` 호출 wrap 금지 한 줄 추가 |
| `.claude/agents/nestjs-expert.md` — Handler Authoring Rule #3 | 동일 규칙 미러링 + Self-Verification 체크리스트 갱신 |
| `.claude/agents/tdd-test-writer.md` | "필수 필드 통합 테스트 — 3종 케이스 모두 커버" 절 신규 |
| `.claude/skills/verify-handler-structure/SKILL.md` | R5 룰 신규 — `try` 블록 안 `cacheService.{get,set,del,delByPattern}` 호출 감지. 현재 서비스 핸들러 dry-run 시 모두 PASS |

## Test plan

- [x] `pnpm format` — 변경 없음 (unchanged)
- [x] `pnpm lint:check` — 통과
- [x] R5 awk 스크립트 dry-run — 현재 서비스 핸들러 9개 대상 출력 없음(False Positive 없음). 동시에 PR #60 머지 직전 상태의 `UpdateProfileHandler.invalidateProfileCache`에 대해서는 의도대로 감지되도록 작성됨.
- [x] 코드 변경 없음 (docs/agent/skill만 수정) — `pnpm build:all` / `pnpm test` / `pnpm test:e2e` 영향 범위 외

## Related

- PR #60: https://github.com/inkweon7269/nest-repository-pattern/pull/60
- 학습 1의 코드 수정 커밋: `e0810a0 refactor: 코드 리뷰 피드백 반영 — 캐시 무효화 단순화 및 IsNotEmpty 추가`
- 학습 2는 통합 테스트 보강 없이 가이드 차원으로만 반영 (코드는 머지된 PR의 `@IsNotEmpty()` 추가로 누락 키 케이스도 400을 반환하지만, 통합 테스트 케이스 자체는 추가하지 않음 — 본 PR의 스코프는 가이드만)

> **Merge Strategy**: 이 PR은 `main` 브랜치 대상입니다. Create a merge commit을 사용해주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * NestJS 핸들러 개발 규칙 및 캐시 서비스 호출 패턴에 대한 코딩 가이드 강화
  * 통합 테스트 작성 지침 추가 (필수 필드 검증 기준)
  * 핸들러 구조 검증 스킬 문서 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inkweon7269/nest-repository-pattern/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->