### PR TITLE
chore: 워크트리 병렬 작업용 start/finish 스킬 추가

### DIFF
--- a/.claude/skills/finish-worktree/SKILL.md
+++ b/.claude/skills/finish-worktree/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: finish-worktree
+description: PR 머지를 확인한 뒤 워크트리와 로컬 작업 브랜치를 정리하고 base 브랜치를 갱신합니다. 워크트리에서 작업한 PR이 머지된 후 사용.
+argument-hint: '[브랜치명]'
+---
+
+# Finish Worktree Skill
+
+워크트리 작업이 GitHub에 머지된 뒤, 워크트리·로컬 브랜치를 안전하게 제거하고 base 브랜치를 최신화한다.
+
+> **전제: 메인 체크아웃에서 실행한다.** 제거 대상 워크트리 안에 서 있으면 워크트리를 지울 수 없다.
+
+## Workflow
+
+1. **대상 식별** — `git worktree list`로 정리할 워크트리와 그 브랜치를 확인한다. 인자로 브랜치명을 받았으면 그것을, 없으면 사용자에게 대상을 확인한다.
+
+2. **PR 머지 확정 검증** — 머지되지 않은 작업을 지워 유실하지 않도록 반드시 먼저 확인한다.
+   ```bash
+   gh pr view <branch> --json state,mergedAt,baseRefName
+   ```
+   - `state`가 `MERGED`가 아니면 **중단**하고 사용자에게 알린다.
+   - `baseRefName`(머지된 대상 브랜치, 보통 `dev` 또는 `main`)을 4번에서 사용한다.
+
+3. **세션이 워크트리 안이면 메인 복귀** — 현재 세션 작업 디렉터리가 제거 대상 워크트리이면 `ExitWorktree`(`action: keep`)로 메인 체크아웃으로 돌아온 뒤 진행한다.
+
+4. **base 브랜치 갱신** — 2번에서 얻은 `baseRefName`으로 전환해 최신화한다.
+   ```bash
+   git checkout <baseRefName>
+   git fetch origin --prune
+   git pull --ff-only
+   ```
+
+5. **워크트리 제거** — 워크트리 경로명은 브랜치명의 `/`를 `-`로 치환한 값이다(예: `feature/comments` → `feature-comments`).
+   ```bash
+   git worktree remove .claude/worktrees/<name>
+   ```
+   - uncommitted 변경이 있으면 git이 거부한다. 그 변경을 **정말 버려도 되는지 사용자에게 확인**한 뒤에만 `--force`를 붙인다.
+
+6. **로컬 브랜치 삭제** — 2번에서 `MERGED`를 확정했으므로 강제 삭제한다.
+   ```bash
+   git branch -D <branch>
+   ```
+   - `feature/* → dev`는 squash-merge라 로컬 브랜치가 git상 "미머지"로 남아 `-d`는 거부된다. `-D`가 정상 경로다.
+
+7. **메타데이터 정리** — `git worktree prune`.
+
+8. **결과 보고** — 제거한 워크트리/브랜치, 갱신한 base 브랜치를 사용자에게 보고한다.
+
+## Notes
+
+- 생성은 `/start-worktree`로 수행한다.
+- 2번 검증 없이 5·6번을 실행하지 않는다 — 머지 안 된 작업의 영구 유실을 막는 핵심 안전장치다.

--- a/.claude/skills/start-worktree/SKILL.md
+++ b/.claude/skills/start-worktree/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: start-worktree
+description: 타입별 base 브랜치에서 git 워크트리를 생성하고, gitignore된 env·설정 복사와 pnpm install까지 자동화합니다. 병렬 작업용 새 워크트리를 시작할 때 사용.
+argument-hint: '[브랜치명]'
+---
+
+# Start Worktree Skill
+
+병렬 작업용 워크트리를 `.claude/worktrees/` 아래에 만들고, 이 레포에서 워크트리가 그냥은 동작하지 않는 함정(gitignore된 env 누락, node_modules 미공유)을 자동으로 해소한다.
+
+## Workflow
+
+1. **브랜치명 정규화** — 인자로 받은 이름을 정리한다.
+   - `feature/`, `dev`, `hotfix/`, `docs/`, `refactor/` 등 접두사가 있으면 그대로 사용한다.
+   - 접두사가 없으면 사용자에게 타입을 확인한다 (기본 `feature/<name>`).
+
+2. **원격 동기화** — `git fetch origin --prune`.
+
+3. **타입별 base 브랜치 결정** — `create-pr` 스킬의 머지 방향과 대칭으로 정한다.
+   - `feature/*` → `origin/dev`
+   - `dev` → `origin/main`
+   - 그 외(`hotfix/*`·`docs/*`·`refactor/*` 등) → 사용자에게 확인 (기본 `origin/main`)
+
+4. **워크트리 경로명 생성** — 브랜치명의 `/`를 `-`로 치환한다. 예: `feature/comments` → `feature-comments`. 경로는 `.claude/worktrees/<name>`.
+
+5. **워크트리 + 브랜치 동시 생성** — 메인 체크아웃에서 실행한다.
+   ```bash
+   git worktree add -b <branch> .claude/worktrees/<name> <base>
+   ```
+   - 같은 이름의 브랜치/워크트리가 이미 있으면 중단하고 사용자에게 알린다.
+
+6. **gitignore된 파일 복사** — 메인 체크아웃에 서 있는 상태에서, 새 워크트리로 복사한다. 이 파일들은 gitignore라 워크트리 체크아웃에 빠져 있어, 빠지면 부팅·마이그레이션·통합테스트가 전부 실패한다.
+   ```bash
+   cp .env.local .env.development .env.production .claude/worktrees/<name>/ 2>/dev/null || true
+   cp .claude/settings.local.json .claude/worktrees/<name>/.claude/ 2>/dev/null || true
+   ```
+   - 존재하는 env 파일만 복사된다(없는 파일은 무시). `settings.local.json`은 권한 승인을 워크트리에서도 잇기 위해 복사한다.
+
+7. **세션을 워크트리로 전환** — `EnterWorktree` 도구를 `path: .claude/worktrees/<name>`로 호출한다. (5번에서 이미 등록된 워크트리에 진입하는 방식)
+
+8. **의존성 설치** — 워크트리는 node_modules를 공유하지 않으므로 워크트리 안에서 설치한다.
+   ```bash
+   pnpm install
+   ```
+
+9. **준비 완료 보고** — 브랜치명 / base 브랜치 / 워크트리 경로를 사용자에게 보고한다.
+
+## Notes
+
+- 워크트리 폴더(`.claude/worktrees/`)는 `.gitignore`에 등록되어 있어 메인 체크아웃의 `git status`를 더럽히지 않는다.
+- 정리는 작업 머지 후 `/finish-worktree`로 수행한다.
+- 이 스킬이 만드는 `feature/*` 브랜치는 `origin/dev`에서 분기한다 — 머지 PR도 `feature/* → dev`로 올린다(`create-pr` 참고).

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # claude
 .claude/settings.local.json
+.claude/worktrees/
 
 # misc
 *.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,14 @@ pnpm test:e2e           # 통합 테스트 통과 확인 (Docker 필수)
 
 - 사용자가 커밋과 푸시를 요청하면, 변경 사항을 재분석하거나 재계획하지 않고 즉시 수행한다. 사용자가 이미 작업을 검토했다고 가정한다.
 
+### Worktree Workflow
+
+병렬 작업은 워크트리로 격리한다. 워크트리는 Claude 네이티브 기본 위치인 `.claude/worktrees/`에 두며(`.gitignore`에 등록되어 메인 체크아웃 `git status`를 더럽히지 않음), 생성·정리는 전용 스킬로 표준화한다.
+
+- **생성**: `/start-worktree <브랜치명>`. 타입별 base(`feature/*`→`origin/dev`, 그 외→`origin/main`)에서 분기하고, gitignore된 `.env.*`·`settings.local.json`을 복사한 뒤 `pnpm install`까지 수행한다. 이 레포는 env 누락 시 부팅·마이그레이션·통합테스트가 모두 실패하고 node_modules도 공유되지 않으므로, 이 두 단계가 빠지면 워크트리가 동작하지 않는다.
+- **정리**: `/finish-worktree <브랜치명>`. **반드시 메인 체크아웃에서 실행**(제거 대상 워크트리 안에서는 삭제 불가). `gh pr view`로 머지(MERGED)를 확인한 뒤에만 워크트리·로컬 브랜치를 제거한다.
+- **squash 삭제 주의**: `feature/* → dev`는 squash-merge라 로컬 브랜치가 git상 "미머지"로 남는다. 머지 확정 후 `git branch -D`(강제)가 정상 경로이며, `-d`는 거부된다.
+
 ### Planning
 
 - 작업 계획 시 사용자가 명시적으로 요청한 범위만으로 제한한다. 요청하지 않은 추가 작업이나 단계를 포함하지 않는다.
@@ -324,3 +332,5 @@ pnpm test:e2e           # 통합 테스트 통과 확인 (Docker 필수)
 | `respond-coderabbit`    | CodeRabbit PR 리뷰 코멘트를 자동 분석하고 응답합니다                            |
 | `commit`                | 검증(`format` → `lint:check` → `build` → `test` → `test:e2e`) 후 한국어 conventional commit 생성 및 푸시 |
 | `create-pr`             | 브랜치 정책에 따라 대상 브랜치(`feature/*`→`dev`, `dev`→`main`)를 판별해 PR 생성 |
+| `start-worktree`        | 타입별 base(`feature/*`→`origin/dev`, 그 외→`origin/main`)에서 워크트리 생성 + gitignore된 env·설정 복사 + `pnpm install` 자동화 |
+| `finish-worktree`       | PR 머지 확인(`gh pr view` state=MERGED) 후 워크트리·로컬 브랜치 정리 + base 브랜치 갱신 |


### PR DESCRIPTION
## Summary

병렬 작업을 워크트리로 격리하기 위해, 생성·정리를 자동화하는 슬래시 스킬 2종을 추가한다. 이 레포는 `.env.*`가 gitignore라 워크트리 체크아웃에 빠지고 node_modules도 공유되지 않아, 수동 워크트리는 부팅·통합테스트가 실패한다. 두 스킬이 이 함정을 절차로 흡수한다.

- `.gitignore`: `.claude/worktrees/`를 추가해, 워크트리가 메인 체크아웃의 `git status`를 더럽히지 않도록 제외한다.
- `start-worktree`: 타입별 base(`feature/*`→`origin/dev`, 그 외→`origin/main`)에서 워크트리를 만들고, gitignore된 `.env.*`·`settings.local.json`을 복사한 뒤 `pnpm install`까지 수행한다.
- `finish-worktree`: `gh pr view`로 머지(MERGED)를 확인한 뒤에만 워크트리·로컬 브랜치를 정리하고 base 브랜치를 갱신한다. squash-merge 특성상 로컬 브랜치는 `git branch -D`로 강제 삭제한다.
- `CLAUDE.md`: Skills 표에 두 스킬을 추가하고 "Worktree Workflow" 섹션으로 위치·정리 규칙·squash 삭제 주의를 문서화한다.

## Test plan

- 마크다운·설정만 바뀌어 빌드·테스트 대상 TS 소스는 없다.
- `pnpm format` 통과(변경 없음). 새 스킬 2종은 `Skill` 목록에 정상 등록됨을 확인했다.
- 라이브 스모크 테스트(`/start-worktree`로 실제 워크트리 생성→install→빌드→정리)는 부수효과가 커 이 PR에 포함하지 않는다.

## Notes

- 이 브랜치는 사용자 지시에 따라 `main` 기준으로 분기했고, 그에 맞춰 대상도 `main`으로 한다(`feature/*`→`dev` 정책의 예외).
- `libs/shared/src/bootstrap/compression.ts`의 `compression.filter` 관련 lint 에러는 이전 머지(`33ddc6f`)에서 들어온 기존 문제로, 이 변경과 무관하다.

> **Merge Strategy**: Create a merge commit을 사용해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 병렬 작업을 효율적으로 관리하기 위한 워크트리 기반 워크플로우 도입

* **Documentation**
  * 워크트리 생성 및 초기화 프로세스 상세 문서화
  * 워크트리 정리 및 브랜치 정리 절차 가이드 추가
  * 전체 워크트리 워크플로우 개요 및 주의사항 문서화

* **Chores**
  * 워크트리 디렉터리를 Git 추적 제외 목록에 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inkweon7269/nest-repository-pattern/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->