### PR TITLE
docs: README 인프라 기능에 Compression 섹션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ export const postRepositoryProviders: Provider[] = [
 - fallback: `local`/`development`에서 env 미설정 시 모든 origin 허용, `production`에서는 env 누락 시 CORS 비활성화(fail-safe)
 - 상세 가이드: [docs/helmet-cors-guide.md](./docs/helmet-cors-guide.md)
 
+### Compression
+
+- HTTP 응답 본문을 gzip으로 압축해 전송량/지연을 줄인다. `applyCompressionMiddleware` 공유 헬퍼(`libs/shared/src/bootstrap/compression.ts`)가 service/back-office main.ts + `createIntegrationApp`에서 동일 호출 — 압축 설정 단일 소스(security.ts 선례와 동일)
+- threshold 1KB(`compression` 기본값) — 본문이 1KB 미만이면 압축 오버헤드를 피해 압축하지 않는다
+- 라우트별 opt-out: 응답에 `x-no-compression` 헤더를 설정하면 해당 응답은 압축에서 제외(SSE/스트리밍 등)
+- 미들웨어 순서: `applySecurityMiddleware` 직후 호출하여 보안 → 압축 순서를 모든 진입점에서 일관 유지
+- 상세 가이드: [docs/compression-guide.md](./docs/compression-guide.md)
+
 ### Database Naming Convention
 
 - 코드는 **camelCase**, DB 컬럼은 **snake_case**. `typeorm-naming-strategies`의 `SnakeNamingStrategy`를 `DataSourceOptions.namingStrategy`로 적용 (`libs/shared/src/database/typeorm.config.ts`)


### PR DESCRIPTION
## Summary

`README.md`의 "인프라 기능"에 다른 항목(Security·Cache·Idempotency 등)은 모두 문서화돼 있으나 **Compression만 누락**돼 있어 보완한다. compression은 PR #62에서 main에 머지됐지만 README에 반영되지 않았다.

- `### Security (helmet + CORS)` 직후 / `### Database Naming Convention` 앞에 `### Compression` 섹션을 추가한다.
- 기존 인프라 하위섹션 형식(설명 + threshold + opt-out + 미들웨어 순서 + 가이드 링크)을 그대로 따른다.
- 내용은 CLAUDE.md의 Compression 섹션 및 `libs/shared/src/bootstrap/compression.ts`와 일치시킨다.

## Test plan

- 마크다운 추가뿐이라 빌드·테스트 대상 소스는 없다.
- 섹션 위치(Security↔Database Naming 사이)와 `docs/compression-guide.md` 링크 유효성을 육안 확인했다.

> **Merge Strategy**: Create a merge commit을 사용해주세요.