### PR TITLE
docs: finish-worktree 스킬에 머지 후 의존성 동기화 안내 추가

### DIFF
--- a/.claude/skills/finish-worktree/SKILL.md
+++ b/.claude/skills/finish-worktree/SKILL.md
@@ -29,6 +29,7 @@ argument-hint: '[브랜치명]'
    git fetch origin --prune
    git pull --ff-only
    ```
+   - 머지된 작업이 `package.json`/`pnpm-lock.yaml`을 바꿨다면 이어서 `pnpm install`로 base 체크아웃의 node_modules를 동기화한다. 워크트리는 node_modules를 공유하지 않아, 빼먹으면 lint·build가 stale 의존성으로 깨진다.
 
 5. **워크트리 제거** — 워크트리 경로명은 브랜치명의 `/`를 `-`로 치환한 값이다(예: `feature/comments` → `feature-comments`).
    ```bash
@@ -50,3 +51,4 @@ argument-hint: '[브랜치명]'
 
 - 생성은 `/start-worktree`로 수행한다.
 - 2번 검증 없이 5·6번을 실행하지 않는다 — 머지 안 된 작업의 영구 유실을 막는 핵심 안전장치다.
+- 머지된 워크트리가 의존성(`package.json`)을 바꿨다면 base 체크아웃에서 `pnpm install`을 잊지 않는다 — 오늘 `@types/compression` 누락으로 lint가 깨진 사례가 이 경우다.


### PR DESCRIPTION
## Summary

워크트리는 `node_modules`를 공유하지 않아, **의존성을 바꾼 워크트리를 머지한 뒤 base 체크아웃에서 `pnpm install`을 빼먹으면 stale 의존성으로 lint·build가 깨진다.** 실제로 이전에 compression 패키지를 워크트리에서 설치하고 머지한 뒤 main 체크아웃에서 install을 안 해 `@types/compression` 누락으로 lint가 깨진 사례가 있었다. 이 교훈을 `finish-worktree` 스킬에 인코딩한다.

- "base 브랜치 갱신" 단계에 `package.json`/`pnpm-lock.yaml` 변경 시 `pnpm install`로 동기화하라는 안내를 추가한다.
- `## Notes`에 동일 취지의 한 줄(겪은 사례 포함)을 보강한다.

## Test plan

- 스킬 마크다운 2줄 추가뿐이라 빌드·테스트 대상 소스는 없다.
- frontmatter·번호 절차 정합성과 스킬 목록 노출을 확인했다.

> **Merge Strategy**: Create a merge commit을 사용해주세요.