### PR TITLE
feat(auth): 회원가입 마케팅 수신 동의 추가

### DIFF
--- a/apps/service/src/auth/auth.controller.ts
+++ b/apps/service/src/auth/auth.controller.ts
@@ -86,9 +86,14 @@ export class AuthController {
     @Body() dto: RegisterRequestDto,
   ): Promise<RegisterResponseDto> {
     const id = await this.commandBus.execute<RegisterCommand, number>(
-      new RegisterCommand(dto.email, dto.password, dto.name),
+      new RegisterCommand(
+        dto.email,
+        dto.password,
+        dto.name,
+        dto.marketingConsent,
+      ),
     );
-    return RegisterResponseDto.of(id);
+    return RegisterResponseDto.of(id, dto.marketingConsent);
   }
 
   @Post('login')

--- a/apps/service/src/auth/command/google-login.handler.spec.ts
+++ b/apps/service/src/auth/command/google-login.handler.spec.ts
@@ -153,6 +153,7 @@ describe('GoogleLoginHandler', () => {
       email: 'newuser@example.com',
       password: 'hashed-random-secret',
       name: '홍길동',
+      marketingConsent: false,
     });
     expect(oauthWriteRepository.create).toHaveBeenCalledWith({
       userId: 7,

--- a/apps/service/src/auth/command/google-login.handler.ts
+++ b/apps/service/src/auth/command/google-login.handler.ts
@@ -100,6 +100,8 @@ export class GoogleLoginHandler implements ICommandHandler<
         email: profile.email,
         password: hashedPassword,
         name: profile.displayName,
+        // OAuth 가입자는 동의 화면을 거치지 않으므로 기본 미동의
+        marketingConsent: false,
       });
     } catch (error) {
       if (

--- a/apps/service/src/auth/command/register.command.ts
+++ b/apps/service/src/auth/command/register.command.ts
@@ -3,5 +3,6 @@ export class RegisterCommand {
     public readonly email: string,
     public readonly password: string,
     public readonly name: string,
+    public readonly marketingConsent: boolean,
   ) {}
 }

--- a/apps/service/src/auth/command/register.handler.spec.ts
+++ b/apps/service/src/auth/command/register.handler.spec.ts
@@ -38,6 +38,7 @@ describe('RegisterHandler', () => {
       'user@example.com',
       'password123',
       '홍길동',
+      true,
     );
     const result = await handler.execute(command);
 
@@ -50,6 +51,27 @@ describe('RegisterHandler', () => {
       email: 'user@example.com',
       password: 'hashed-password',
       name: '홍길동',
+      marketingConsent: true,
+    });
+  });
+
+  it('marketingConsent가 false면 create input에 false가 그대로 전달된다', async () => {
+    userReadRepository.findByEmail.mockResolvedValue(null);
+    userWriteRepository.create.mockResolvedValue({ id: 1 } as User);
+
+    const command = new RegisterCommand(
+      'user@example.com',
+      'password123',
+      '홍길동',
+      false,
+    );
+    await handler.execute(command);
+
+    expect(userWriteRepository.create).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'hashed-password',
+      name: '홍길동',
+      marketingConsent: false,
     });
   });
 
@@ -60,6 +82,7 @@ describe('RegisterHandler', () => {
       'user@example.com',
       'password123',
       '홍길동',
+      true,
     );
 
     await expect(handler.execute(command)).rejects.toThrow(ConflictException);
@@ -77,6 +100,7 @@ describe('RegisterHandler', () => {
       'user@example.com',
       'password123',
       '홍길동',
+      true,
     );
 
     await expect(handler.execute(command)).rejects.toThrow(ConflictException);

--- a/apps/service/src/auth/command/register.handler.ts
+++ b/apps/service/src/auth/command/register.handler.ts
@@ -23,6 +23,7 @@ export class RegisterHandler implements ICommandHandler<RegisterCommand> {
       email: command.email,
       password: hashedPassword,
       name: command.name,
+      marketingConsent: command.marketingConsent,
     });
   }
 

--- a/apps/service/src/auth/dto/request/register.request.dto.ts
+++ b/apps/service/src/auth/dto/request/register.request.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  MinLength,
+} from 'class-validator';
 
 export class RegisterRequestDto {
   @ApiProperty({ description: '이메일', example: 'user@example.com' })
@@ -17,4 +23,8 @@ export class RegisterRequestDto {
   @IsString()
   @IsNotEmpty()
   name: string;
+
+  @ApiProperty({ description: '마케팅 수신 동의', example: true })
+  @IsBoolean()
+  marketingConsent: boolean;
 }

--- a/apps/service/src/auth/dto/response/profile.response.dto.spec.ts
+++ b/apps/service/src/auth/dto/response/profile.response.dto.spec.ts
@@ -30,6 +30,22 @@ describe('ProfileResponseDto', () => {
       expect(dto.updatedAt).toBe(user.updatedAt);
     });
 
+    it('user.marketingConsent를 DTO에 매핑한다 (true)', () => {
+      const user = createUser({ marketingConsent: true });
+
+      const dto = ProfileResponseDto.of(user);
+
+      expect(dto.marketingConsent).toBe(true);
+    });
+
+    it('user.marketingConsent를 DTO에 매핑한다 (false)', () => {
+      const user = createUser({ marketingConsent: false });
+
+      const dto = ProfileResponseDto.of(user);
+
+      expect(dto.marketingConsent).toBe(false);
+    });
+
     it('ProfileResponseDto 인스턴스를 반환한다', () => {
       const user = createUser();
 

--- a/apps/service/src/auth/dto/response/profile.response.dto.ts
+++ b/apps/service/src/auth/dto/response/profile.response.dto.ts
@@ -17,6 +17,9 @@ export class ProfileResponseDto {
   @ApiProperty({ description: '수정일시' })
   updatedAt: Date;
 
+  @ApiProperty({ description: '마케팅 수신 동의', example: true })
+  marketingConsent: boolean;
+
   static of(user: User): ProfileResponseDto {
     const dto = new ProfileResponseDto();
     dto.id = user.id;
@@ -24,6 +27,7 @@ export class ProfileResponseDto {
     dto.name = user.name;
     dto.createdAt = user.createdAt;
     dto.updatedAt = user.updatedAt;
+    dto.marketingConsent = user.marketingConsent;
     return dto;
   }
 }

--- a/apps/service/src/auth/dto/response/register.response.dto.spec.ts
+++ b/apps/service/src/auth/dto/response/register.response.dto.spec.ts
@@ -3,15 +3,27 @@ import { RegisterResponseDto } from './register.response.dto';
 describe('RegisterResponseDto', () => {
   describe('of', () => {
     it('should map id to DTO', () => {
-      const dto = RegisterResponseDto.of(42);
+      const dto = RegisterResponseDto.of(42, true);
 
       expect(dto.id).toBe(42);
     });
 
     it('should return an instance of RegisterResponseDto', () => {
-      const dto = RegisterResponseDto.of(1);
+      const dto = RegisterResponseDto.of(1, true);
 
       expect(dto).toBeInstanceOf(RegisterResponseDto);
+    });
+
+    it('marketingConsent가 true면 true로 매핑한다', () => {
+      const dto = RegisterResponseDto.of(1, true);
+
+      expect(dto.marketingConsent).toBe(true);
+    });
+
+    it('marketingConsent가 false면 false로 매핑한다', () => {
+      const dto = RegisterResponseDto.of(1, false);
+
+      expect(dto.marketingConsent).toBe(false);
     });
   });
 });

--- a/apps/service/src/auth/dto/response/register.response.dto.ts
+++ b/apps/service/src/auth/dto/response/register.response.dto.ts
@@ -4,9 +4,13 @@ export class RegisterResponseDto {
   @ApiProperty({ description: '생성된 사용자 ID', example: 1 })
   id: number;
 
-  static of(id: number): RegisterResponseDto {
+  @ApiProperty({ description: '마케팅 수신 동의', example: true })
+  marketingConsent: boolean;
+
+  static of(id: number, marketingConsent: boolean): RegisterResponseDto {
     const dto = new RegisterResponseDto();
     dto.id = id;
+    dto.marketingConsent = marketingConsent;
     return dto;
   }
 }

--- a/apps/service/src/auth/interface/user-write-repository.interface.ts
+++ b/apps/service/src/auth/interface/user-write-repository.interface.ts
@@ -4,6 +4,7 @@ export interface CreateUserInput {
   email: string;
   password: string;
   name: string;
+  marketingConsent: boolean;
 }
 
 export interface UpdateUserInput {

--- a/libs/shared/src/entities/user.entity.ts
+++ b/libs/shared/src/entities/user.entity.ts
@@ -17,6 +17,9 @@ export class User extends BaseTimeEntity {
   @Column({ type: 'varchar', length: 255, nullable: true })
   hashedRefreshToken: string | null;
 
+  @Column({ type: 'boolean', default: false })
+  marketingConsent: boolean;
+
   @OneToMany(() => Post, (post) => post.user)
   posts: Relation<Post[]>;
 }

--- a/libs/shared/src/migrations/1779528943000-AddMarketingConsentToUser.ts
+++ b/libs/shared/src/migrations/1779528943000-AddMarketingConsentToUser.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMarketingConsentToUser1779528943000 implements MigrationInterface {
+  name = 'AddMarketingConsentToUser1779528943000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "marketing_consent" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN "marketing_consent"`,
+    );
+  }
+}

--- a/test/back-office/admin.integration-spec.ts
+++ b/test/back-office/admin.integration-spec.ts
@@ -61,6 +61,7 @@ describe('Admin (integration)', () => {
         email: 'user@example.com',
         password: 'password123',
         name: '일반유저',
+        marketingConsent: true,
       })
       .expect(201);
     const res = await request(app.getHttpServer())

--- a/test/service/auth.integration-spec.ts
+++ b/test/service/auth.integration-spec.ts
@@ -30,6 +30,7 @@ describe('Auth (integration)', () => {
     email: 'test@example.com',
     password: 'password123',
     name: '테스트유저',
+    marketingConsent: true,
   };
 
   function registerUser(body: Record<string, unknown> = {}) {
@@ -54,12 +55,34 @@ describe('Auth (integration)', () => {
   // POST /auth/register
   // ============================================================
   describe('POST /auth/register', () => {
-    it('should register and return { id } with 201', async () => {
+    it('should register and return { id, marketingConsent } with 201', async () => {
       const res = await registerUser().expect(201);
 
       expect(res.body.id).toBeDefined();
       expect(typeof res.body.id).toBe('number');
-      expect(Object.keys(res.body)).toEqual(['id']);
+      expect(Object.keys(res.body).sort()).toEqual(['id', 'marketingConsent']);
+    });
+
+    it('marketingConsent: true로 가입하면 응답에 marketingConsent: true가 포함된다', async () => {
+      const res = await registerUser({ marketingConsent: true }).expect(201);
+
+      expect(res.body.marketingConsent).toBe(true);
+    });
+
+    it('marketingConsent: false로 가입하면 응답에 marketingConsent: false가 포함된다', async () => {
+      const res = await registerUser({
+        email: 'noconsent@example.com',
+        marketingConsent: false,
+      }).expect(201);
+
+      expect(res.body.marketingConsent).toBe(false);
+    });
+
+    it('marketingConsent가 누락되면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .post('/v1/auth/register')
+        .send({ email: 'a@b.com', password: 'password123', name: '테스트' })
+        .expect(400);
     });
 
     it('should persist user (verified via login)', async () => {
@@ -82,7 +105,11 @@ describe('Auth (integration)', () => {
     it('should return 400 when email is missing', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
-        .send({ password: 'password123', name: '테스트' })
+        .send({
+          password: 'password123',
+          name: '테스트',
+          marketingConsent: true,
+        })
         .expect(400);
     });
 
@@ -93,6 +120,7 @@ describe('Auth (integration)', () => {
           email: 'not-an-email',
           password: 'password123',
           name: '테스트',
+          marketingConsent: true,
         })
         .expect(400);
     });
@@ -100,21 +128,30 @@ describe('Auth (integration)', () => {
     it('should return 400 when password is missing', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
-        .send({ email: 'a@b.com', name: '테스트' })
+        .send({ email: 'a@b.com', name: '테스트', marketingConsent: true })
         .expect(400);
     });
 
     it('should return 400 when password is shorter than 8 characters', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
-        .send({ email: 'a@b.com', password: 'short', name: '테스트' })
+        .send({
+          email: 'a@b.com',
+          password: 'short',
+          name: '테스트',
+          marketingConsent: true,
+        })
         .expect(400);
     });
 
     it('should return 400 when name is missing', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
-        .send({ email: 'a@b.com', password: 'password123' })
+        .send({
+          email: 'a@b.com',
+          password: 'password123',
+          marketingConsent: true,
+        })
         .expect(400);
     });
 
@@ -245,7 +282,7 @@ describe('Auth (integration)', () => {
   // GET /auth/profile
   // ============================================================
   describe('GET /auth/profile', () => {
-    it('should return profile with { id, email, name, createdAt, updatedAt } and 200', async () => {
+    it('should return profile with { id, email, name, marketingConsent, createdAt, updatedAt } and 200', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -263,9 +300,38 @@ describe('Auth (integration)', () => {
         'createdAt',
         'email',
         'id',
+        'marketingConsent',
         'name',
         'updatedAt',
       ]);
+    });
+
+    it('가입 시 동의한 marketingConsent가 프로필 조회에 반영된다', async () => {
+      const tokens = await registerAndLogin({
+        email: 'consent-profile@example.com',
+        marketingConsent: true,
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/auth/profile')
+        .set('Authorization', `Bearer ${tokens.accessToken}`)
+        .expect(200);
+
+      expect(res.body.marketingConsent).toBe(true);
+    });
+
+    it('가입 시 미동의한 marketingConsent가 프로필 조회에 반영된다', async () => {
+      const tokens = await registerAndLogin({
+        email: 'noconsent-profile@example.com',
+        marketingConsent: false,
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/auth/profile')
+        .set('Authorization', `Bearer ${tokens.accessToken}`)
+        .expect(200);
+
+      expect(res.body.marketingConsent).toBe(false);
     });
 
     it('should not include password or hashedRefreshToken in response', async () => {

--- a/test/service/compression.integration-spec.ts
+++ b/test/service/compression.integration-spec.ts
@@ -30,6 +30,7 @@ describe('Compression (integration)', () => {
     email: 'compression-test@example.com',
     password: 'password123',
     name: '테스트유저',
+    marketingConsent: true,
   };
 
   async function registerAndLogin(body: Record<string, unknown> = {}) {

--- a/test/service/google-oauth.integration-spec.ts
+++ b/test/service/google-oauth.integration-spec.ts
@@ -62,7 +62,7 @@ describe('Google OAuth (integration)', () => {
   ) {
     await request(app.getHttpServer())
       .post('/v1/auth/register')
-      .send({ email, password, name })
+      .send({ email, password, name, marketingConsent: true })
       .expect(201);
   }
 

--- a/test/service/posts.integration-spec.ts
+++ b/test/service/posts.integration-spec.ts
@@ -30,6 +30,7 @@ describe('Posts (integration)', () => {
     email: 'post-test@example.com',
     password: 'password123',
     name: '테스트유저',
+    marketingConsent: true,
   };
 
   async function registerAndLogin(body: Record<string, unknown> = {}) {


### PR DESCRIPTION
## 개요
회원가입 시 마케팅 수신 동의(`marketingConsent`)를 **필수**로 받고, **회원가입 응답과 프로필 응답 모두**에 반환합니다.

## 변경 사항
- **DB**: `User` 엔티티에 `marketingConsent: boolean`(기본 false) 컬럼 + 마이그레이션 `AddMarketingConsentToUser`(`marketing_consent` NOT NULL DEFAULT false — 기존 행 백필 안전)
- **요청**: `RegisterRequestDto`에 필수 `marketingConsent`(`@IsBoolean()`)
- **응답**: `RegisterResponseDto`/`ProfileResponseDto`에 `marketingConsent` 반환
  - CQRS 준수: Command는 id(number)만 반환, 컨트롤러가 요청값을 echo해 회원가입 응답 구성
  - 프로필은 Query Handler가 엔티티에서 매핑
- **OAuth**: Google 신규 가입자는 동의 화면을 거치지 않으므로 `marketingConsent: false`로 생성
- **테스트**: 단위(핸들러/DTO) + 통합(register/profile) 추가, register를 셋업으로 재사용하는 통합 스펙 픽스처 보강

## ⚠️ 하위 호환 주의
`POST /v1/auth/register`에 **필수 필드**가 추가되어, `marketingConsent`를 보내지 않는 기존 클라이언트는 400을 받습니다(의도된 사양).

## 검증
- `pnpm format` / `pnpm lint:check` / `pnpm build:all` ✓
- 단위 테스트 **104** / 통합 테스트 **151**(service 117 + back-office 34) ✓
- verify-db-safety(D1~D6) PASS, verify-api-compat PASS(C2 필수필드 추가는 의도)
- code-reviewer: blocker/major 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 회원가입 및 프로필 조회 시 마케팅 수신 동의 여부 수집 및 관리 기능 추가

* **테스트**
  * 회원가입, 로그인, 프로필 조회 기능에 대한 통합 테스트 및 단위 테스트 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inkweon7269/nest-repository-pattern/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->