### PR TITLE
feat: 게시물 태그 기능 추가 (사용자별 태그 CRUD + 게시물 M:N 연동)

### DIFF
--- a/apps/service/src/app.module.ts
+++ b/apps/service/src/app.module.ts
@@ -12,6 +12,7 @@ import {
   OtelAlertingModule,
 } from '@app/shared';
 import { PostsModule } from './posts/posts.module';
+import { TagsModule } from './tags/tags.module';
 import { AuthModule } from './auth/auth.module';
 
 const nodeEnv = process.env.NODE_ENV || 'local';
@@ -40,6 +41,7 @@ const nodeEnv = process.env.NODE_ENV || 'local';
       }),
     }),
     PostsModule,
+    TagsModule,
     AuthModule,
     HealthModule,
     OtelAlertingModule,

--- a/apps/service/src/posts/command/create-post.command.ts
+++ b/apps/service/src/posts/command/create-post.command.ts
@@ -4,5 +4,6 @@ export class CreatePostCommand {
     public readonly title: string,
     public readonly content: string,
     public readonly isPublished?: boolean,
+    public readonly tagIds?: number[],
   ) {}
 }

--- a/apps/service/src/posts/command/create-post.handler.spec.ts
+++ b/apps/service/src/posts/command/create-post.handler.spec.ts
@@ -1,16 +1,18 @@
 import { TestBed, type Mocked } from '@suites/unit';
 import type { Type } from '@suites/types.common';
-import { ConflictException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { CreatePostHandler } from './create-post.handler';
 import { CreatePostCommand } from './create-post.command';
 import { IPostReadRepository } from '@service/posts/interface/post-read-repository.interface';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
-import { Post } from '@app/shared';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { Post, Tag } from '@app/shared';
 
 describe('CreatePostHandler', () => {
   let handler: CreatePostHandler;
   let postReadRepository: Mocked<IPostReadRepository>;
   let postWriteRepository: Mocked<IPostWriteRepository>;
+  let tagReadRepository: Mocked<ITagReadRepository>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -22,6 +24,9 @@ describe('CreatePostHandler', () => {
     );
     postWriteRepository = unitRef.get<IPostWriteRepository>(
       IPostWriteRepository as Type<IPostWriteRepository>,
+    );
+    tagReadRepository = unitRef.get<ITagReadRepository>(
+      ITagReadRepository as Type<ITagReadRepository>,
     );
   });
 
@@ -42,6 +47,7 @@ describe('CreatePostHandler', () => {
       title: 'New Title',
       content: 'Content',
       isPublished: false,
+      tagIds: undefined,
     });
   });
 
@@ -53,6 +59,53 @@ describe('CreatePostHandler', () => {
     const command = new CreatePostCommand(1, 'Duplicate Title', 'Content');
 
     await expect(handler.execute(command)).rejects.toThrow(ConflictException);
+    expect(postWriteRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('소유한 태그가 모두 검증되면 tagIds와 함께 게시글을 생성한다', async () => {
+    postReadRepository.findByUserIdAndTitle.mockResolvedValue(null);
+    tagReadRepository.findByIdsAndUserId.mockResolvedValue([
+      { id: 1 } as Tag,
+      { id: 2 } as Tag,
+    ]);
+    postWriteRepository.create.mockResolvedValue({ id: 10 } as Post);
+
+    const command = new CreatePostCommand(
+      1,
+      'Tagged',
+      'Content',
+      false,
+      [1, 2],
+    );
+    const result = await handler.execute(command);
+
+    expect(result).toBe(10);
+    expect(tagReadRepository.findByIdsAndUserId).toHaveBeenCalledWith(
+      [1, 2],
+      1,
+    );
+    expect(postWriteRepository.create).toHaveBeenCalledWith({
+      userId: 1,
+      title: 'Tagged',
+      content: 'Content',
+      isPublished: false,
+      tagIds: [1, 2],
+    });
+  });
+
+  it('요청한 태그 중 소유하지 않은 것이 있으면 BadRequestException을 발생시킨다', async () => {
+    postReadRepository.findByUserIdAndTitle.mockResolvedValue(null);
+    tagReadRepository.findByIdsAndUserId.mockResolvedValue([{ id: 1 } as Tag]);
+
+    const command = new CreatePostCommand(
+      1,
+      'Tagged',
+      'Content',
+      false,
+      [1, 2],
+    );
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
     expect(postWriteRepository.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/service/src/posts/command/create-post.handler.spec.ts
+++ b/apps/service/src/posts/command/create-post.handler.spec.ts
@@ -8,6 +8,13 @@ import { IPostWriteRepository } from '@service/posts/interface/post-write-reposi
 import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
 import { Post } from '@app/shared';
 
+// 단위 테스트는 실 DataSource를 부트스트랩하지 않으므로 `@Transactional()`을
+// 트랜잭션 컨텍스트 초기화 없이 통과시키도록 no-op으로 치환한다. 트랜잭션 의미는
+// 통합 테스트에서 검증한다.
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => () => undefined,
+}));
+
 describe('CreatePostHandler', () => {
   let handler: CreatePostHandler;
   let postReadRepository: Mocked<IPostReadRepository>;

--- a/apps/service/src/posts/command/create-post.handler.spec.ts
+++ b/apps/service/src/posts/command/create-post.handler.spec.ts
@@ -5,14 +5,14 @@ import { CreatePostHandler } from './create-post.handler';
 import { CreatePostCommand } from './create-post.command';
 import { IPostReadRepository } from '@service/posts/interface/post-read-repository.interface';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
-import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
-import { Post, Tag } from '@app/shared';
+import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
+import { Post } from '@app/shared';
 
 describe('CreatePostHandler', () => {
   let handler: CreatePostHandler;
   let postReadRepository: Mocked<IPostReadRepository>;
   let postWriteRepository: Mocked<IPostWriteRepository>;
-  let tagReadRepository: Mocked<ITagReadRepository>;
+  let tagOwnershipValidator: Mocked<TagOwnershipValidator>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -25,9 +25,7 @@ describe('CreatePostHandler', () => {
     postWriteRepository = unitRef.get<IPostWriteRepository>(
       IPostWriteRepository as Type<IPostWriteRepository>,
     );
-    tagReadRepository = unitRef.get<ITagReadRepository>(
-      ITagReadRepository as Type<ITagReadRepository>,
-    );
+    tagOwnershipValidator = unitRef.get(TagOwnershipValidator);
   });
 
   it('중복되지 않는 제목이면 게시글을 생성하고 id를 반환한다', async () => {
@@ -64,10 +62,7 @@ describe('CreatePostHandler', () => {
 
   it('소유한 태그가 모두 검증되면 tagIds와 함께 게시글을 생성한다', async () => {
     postReadRepository.findByUserIdAndTitle.mockResolvedValue(null);
-    tagReadRepository.findByIdsAndUserId.mockResolvedValue([
-      { id: 1 } as Tag,
-      { id: 2 } as Tag,
-    ]);
+    tagOwnershipValidator.validateOwnedByUser.mockResolvedValue(undefined);
     postWriteRepository.create.mockResolvedValue({ id: 10 } as Post);
 
     const command = new CreatePostCommand(
@@ -80,9 +75,9 @@ describe('CreatePostHandler', () => {
     const result = await handler.execute(command);
 
     expect(result).toBe(10);
-    expect(tagReadRepository.findByIdsAndUserId).toHaveBeenCalledWith(
-      [1, 2],
+    expect(tagOwnershipValidator.validateOwnedByUser).toHaveBeenCalledWith(
       1,
+      [1, 2],
     );
     expect(postWriteRepository.create).toHaveBeenCalledWith({
       userId: 1,
@@ -95,7 +90,11 @@ describe('CreatePostHandler', () => {
 
   it('요청한 태그 중 소유하지 않은 것이 있으면 BadRequestException을 발생시킨다', async () => {
     postReadRepository.findByUserIdAndTitle.mockResolvedValue(null);
-    tagReadRepository.findByIdsAndUserId.mockResolvedValue([{ id: 1 } as Tag]);
+    tagOwnershipValidator.validateOwnedByUser.mockRejectedValue(
+      new BadRequestException(
+        'One or more tags do not exist or are not owned by the user',
+      ),
+    );
 
     const command = new CreatePostCommand(
       1,

--- a/apps/service/src/posts/command/create-post.handler.ts
+++ b/apps/service/src/posts/command/create-post.handler.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { QueryFailedError } from 'typeorm';
@@ -9,7 +9,7 @@ import {
   CreatePostInput,
   IPostWriteRepository,
 } from '@service/posts/interface/post-write-repository.interface';
-import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
 import { CacheService, Post } from '@app/shared';
 
 @CommandHandler(CreatePostCommand)
@@ -17,14 +17,17 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
   constructor(
     private readonly postReadRepository: IPostReadRepository,
     private readonly postWriteRepository: IPostWriteRepository,
-    private readonly tagReadRepository: ITagReadRepository,
+    private readonly tagOwnershipValidator: TagOwnershipValidator,
     private readonly eventEmitter: EventEmitter2,
     private readonly cacheService: CacheService,
   ) {}
 
   async execute(command: CreatePostCommand): Promise<number> {
     await this.validateTitleNotDuplicated(command.userId, command.title);
-    await this.validateTagsOwnedByUser(command.userId, command.tagIds);
+    await this.tagOwnershipValidator.validateOwnedByUser(
+      command.userId,
+      command.tagIds,
+    );
     const post = await this.persistPostOrConflict({
       userId: command.userId,
       title: command.title,
@@ -47,26 +50,6 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
     );
     if (existing) {
       throw new ConflictException(`Post with title '${title}' already exists`);
-    }
-  }
-
-  private async validateTagsOwnedByUser(
-    userId: number,
-    tagIds?: number[],
-  ): Promise<void> {
-    if (!tagIds?.length) {
-      return;
-    }
-
-    const uniqueIds = [...new Set(tagIds)];
-    const tags = await this.tagReadRepository.findByIdsAndUserId(
-      uniqueIds,
-      userId,
-    );
-    if (tags.length !== uniqueIds.length) {
-      throw new BadRequestException(
-        'One or more tags do not exist or are not owned by the user',
-      );
     }
   }
 

--- a/apps/service/src/posts/command/create-post.handler.ts
+++ b/apps/service/src/posts/command/create-post.handler.ts
@@ -2,13 +2,12 @@ import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { QueryFailedError } from 'typeorm';
+import { Transactional } from 'typeorm-transactional';
 import { CreatePostCommand } from './create-post.command';
 import { PostCreatedEvent } from '@service/posts/event/post-created.event';
 import { IPostReadRepository } from '@service/posts/interface/post-read-repository.interface';
-import {
-  CreatePostInput,
-  IPostWriteRepository,
-} from '@service/posts/interface/post-write-repository.interface';
+import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
+import type { CreatePostInput } from '@service/posts/interface/post-write-repository.interface';
 import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
 import { CacheService, Post } from '@app/shared';
 
@@ -53,6 +52,7 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
     }
   }
 
+  @Transactional()
   private async persistPostOrConflict(input: CreatePostInput): Promise<Post> {
     try {
       return await this.postWriteRepository.create(input);

--- a/apps/service/src/posts/command/create-post.handler.ts
+++ b/apps/service/src/posts/command/create-post.handler.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { QueryFailedError } from 'typeorm';
@@ -9,6 +9,7 @@ import {
   CreatePostInput,
   IPostWriteRepository,
 } from '@service/posts/interface/post-write-repository.interface';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
 import { CacheService, Post } from '@app/shared';
 
 @CommandHandler(CreatePostCommand)
@@ -16,17 +17,20 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
   constructor(
     private readonly postReadRepository: IPostReadRepository,
     private readonly postWriteRepository: IPostWriteRepository,
+    private readonly tagReadRepository: ITagReadRepository,
     private readonly eventEmitter: EventEmitter2,
     private readonly cacheService: CacheService,
   ) {}
 
   async execute(command: CreatePostCommand): Promise<number> {
     await this.validateTitleNotDuplicated(command.userId, command.title);
+    await this.validateTagsOwnedByUser(command.userId, command.tagIds);
     const post = await this.persistPostOrConflict({
       userId: command.userId,
       title: command.title,
       content: command.content,
       isPublished: command.isPublished,
+      tagIds: command.tagIds,
     });
     this.emitCreatedEvent(post.id, command.title, command.userId);
     await this.invalidateUserCache(command.userId);
@@ -43,6 +47,26 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
     );
     if (existing) {
       throw new ConflictException(`Post with title '${title}' already exists`);
+    }
+  }
+
+  private async validateTagsOwnedByUser(
+    userId: number,
+    tagIds?: number[],
+  ): Promise<void> {
+    if (!tagIds?.length) {
+      return;
+    }
+
+    const uniqueIds = [...new Set(tagIds)];
+    const tags = await this.tagReadRepository.findByIdsAndUserId(
+      uniqueIds,
+      userId,
+    );
+    if (tags.length !== uniqueIds.length) {
+      throw new BadRequestException(
+        'One or more tags do not exist or are not owned by the user',
+      );
     }
   }
 

--- a/apps/service/src/posts/command/update-post.command.ts
+++ b/apps/service/src/posts/command/update-post.command.ts
@@ -5,5 +5,6 @@ export class UpdatePostCommand {
     public readonly title: string,
     public readonly content: string,
     public readonly isPublished: boolean,
+    public readonly tagIds?: number[],
   ) {}
 }

--- a/apps/service/src/posts/command/update-post.handler.spec.ts
+++ b/apps/service/src/posts/command/update-post.handler.spec.ts
@@ -6,6 +6,13 @@ import { UpdatePostCommand } from './update-post.command';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
 import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
 
+// 단위 테스트는 실 DataSource를 부트스트랩하지 않으므로 `@Transactional()`을
+// 트랜잭션 컨텍스트 초기화 없이 통과시키도록 no-op으로 치환한다. 트랜잭션 의미는
+// 통합 테스트에서 검증한다.
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => () => undefined,
+}));
+
 describe('UpdatePostHandler', () => {
   let handler: UpdatePostHandler;
   let postWriteRepository: Mocked<IPostWriteRepository>;

--- a/apps/service/src/posts/command/update-post.handler.spec.ts
+++ b/apps/service/src/posts/command/update-post.handler.spec.ts
@@ -4,13 +4,12 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { UpdatePostHandler } from './update-post.handler';
 import { UpdatePostCommand } from './update-post.command';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
-import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
-import { Tag } from '@app/shared';
+import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
 
 describe('UpdatePostHandler', () => {
   let handler: UpdatePostHandler;
   let postWriteRepository: Mocked<IPostWriteRepository>;
-  let tagReadRepository: Mocked<ITagReadRepository>;
+  let tagOwnershipValidator: Mocked<TagOwnershipValidator>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -20,9 +19,7 @@ describe('UpdatePostHandler', () => {
     postWriteRepository = unitRef.get<IPostWriteRepository>(
       IPostWriteRepository as Type<IPostWriteRepository>,
     );
-    tagReadRepository = unitRef.get<ITagReadRepository>(
-      ITagReadRepository as Type<ITagReadRepository>,
-    );
+    tagOwnershipValidator = unitRef.get(TagOwnershipValidator);
   });
 
   it('존재하는 본인의 게시글을 수정하면 void를 반환한다', async () => {
@@ -47,10 +44,7 @@ describe('UpdatePostHandler', () => {
   });
 
   it('소유한 태그가 검증되면 tagIds와 함께 수정한다', async () => {
-    tagReadRepository.findByIdsAndUserId.mockResolvedValue([
-      { id: 1 } as Tag,
-      { id: 2 } as Tag,
-    ]);
+    tagOwnershipValidator.validateOwnedByUser.mockResolvedValue(undefined);
     postWriteRepository.update.mockResolvedValue(1);
 
     const command = new UpdatePostCommand(
@@ -63,9 +57,9 @@ describe('UpdatePostHandler', () => {
     );
     await handler.execute(command);
 
-    expect(tagReadRepository.findByIdsAndUserId).toHaveBeenCalledWith(
-      [1, 2],
+    expect(tagOwnershipValidator.validateOwnedByUser).toHaveBeenCalledWith(
       1,
+      [1, 2],
     );
     expect(postWriteRepository.update).toHaveBeenCalledWith(1, 1, {
       title: 'Updated Title',
@@ -76,7 +70,11 @@ describe('UpdatePostHandler', () => {
   });
 
   it('요청한 태그 중 소유하지 않은 것이 있으면 BadRequestException을 발생시킨다', async () => {
-    tagReadRepository.findByIdsAndUserId.mockResolvedValue([{ id: 1 } as Tag]);
+    tagOwnershipValidator.validateOwnedByUser.mockRejectedValue(
+      new BadRequestException(
+        'One or more tags do not exist or are not owned by the user',
+      ),
+    );
 
     const command = new UpdatePostCommand(
       1,

--- a/apps/service/src/posts/command/update-post.handler.spec.ts
+++ b/apps/service/src/posts/command/update-post.handler.spec.ts
@@ -1,13 +1,16 @@
 import { TestBed, type Mocked } from '@suites/unit';
 import type { Type } from '@suites/types.common';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { UpdatePostHandler } from './update-post.handler';
 import { UpdatePostCommand } from './update-post.command';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { Tag } from '@app/shared';
 
 describe('UpdatePostHandler', () => {
   let handler: UpdatePostHandler;
   let postWriteRepository: Mocked<IPostWriteRepository>;
+  let tagReadRepository: Mocked<ITagReadRepository>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -16,6 +19,9 @@ describe('UpdatePostHandler', () => {
     handler = unit;
     postWriteRepository = unitRef.get<IPostWriteRepository>(
       IPostWriteRepository as Type<IPostWriteRepository>,
+    );
+    tagReadRepository = unitRef.get<ITagReadRepository>(
+      ITagReadRepository as Type<ITagReadRepository>,
     );
   });
 
@@ -36,7 +42,53 @@ describe('UpdatePostHandler', () => {
       title: 'Updated Title',
       content: 'Content',
       isPublished: false,
+      tagIds: undefined,
     });
+  });
+
+  it('소유한 태그가 검증되면 tagIds와 함께 수정한다', async () => {
+    tagReadRepository.findByIdsAndUserId.mockResolvedValue([
+      { id: 1 } as Tag,
+      { id: 2 } as Tag,
+    ]);
+    postWriteRepository.update.mockResolvedValue(1);
+
+    const command = new UpdatePostCommand(
+      1,
+      1,
+      'Updated Title',
+      'Content',
+      false,
+      [1, 2],
+    );
+    await handler.execute(command);
+
+    expect(tagReadRepository.findByIdsAndUserId).toHaveBeenCalledWith(
+      [1, 2],
+      1,
+    );
+    expect(postWriteRepository.update).toHaveBeenCalledWith(1, 1, {
+      title: 'Updated Title',
+      content: 'Content',
+      isPublished: false,
+      tagIds: [1, 2],
+    });
+  });
+
+  it('요청한 태그 중 소유하지 않은 것이 있으면 BadRequestException을 발생시킨다', async () => {
+    tagReadRepository.findByIdsAndUserId.mockResolvedValue([{ id: 1 } as Tag]);
+
+    const command = new UpdatePostCommand(
+      1,
+      1,
+      'Updated Title',
+      'Content',
+      false,
+      [1, 2],
+    );
+
+    await expect(handler.execute(command)).rejects.toThrow(BadRequestException);
+    expect(postWriteRepository.update).not.toHaveBeenCalled();
   });
 
   it('affected가 0이면 NotFoundException을 발생시킨다', async () => {

--- a/apps/service/src/posts/command/update-post.handler.ts
+++ b/apps/service/src/posts/command/update-post.handler.ts
@@ -1,17 +1,45 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { UpdatePostCommand } from './update-post.command';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
 import { CacheService } from '@app/shared';
 
 @CommandHandler(UpdatePostCommand)
 export class UpdatePostHandler implements ICommandHandler<UpdatePostCommand> {
   constructor(
     private readonly postWriteRepository: IPostWriteRepository,
+    private readonly tagReadRepository: ITagReadRepository,
     private readonly cacheService: CacheService,
   ) {}
 
   async execute(command: UpdatePostCommand): Promise<void> {
+    await this.validateTagsOwnedByUser(command.userId, command.tagIds);
+    await this.updatePostOrThrow(command);
+    await this.invalidatePostCache(command.userId, command.id);
+  }
+
+  private async validateTagsOwnedByUser(
+    userId: number,
+    tagIds?: number[],
+  ): Promise<void> {
+    if (!tagIds?.length) {
+      return;
+    }
+
+    const uniqueIds = [...new Set(tagIds)];
+    const tags = await this.tagReadRepository.findByIdsAndUserId(
+      uniqueIds,
+      userId,
+    );
+    if (tags.length !== uniqueIds.length) {
+      throw new BadRequestException(
+        'One or more tags do not exist or are not owned by the user',
+      );
+    }
+  }
+
+  private async updatePostOrThrow(command: UpdatePostCommand): Promise<void> {
     const affected = await this.postWriteRepository.update(
       command.id,
       command.userId,
@@ -19,13 +47,19 @@ export class UpdatePostHandler implements ICommandHandler<UpdatePostCommand> {
         title: command.title,
         content: command.content,
         isPublished: command.isPublished,
+        tagIds: command.tagIds,
       },
     );
     if (affected === 0) {
       throw new NotFoundException(`Post with ID ${command.id} not found`);
     }
+  }
 
-    await this.cacheService.del(`post:${command.userId}:${command.id}`);
-    await this.cacheService.delByPattern(`posts:${command.userId}:*`);
+  private async invalidatePostCache(
+    userId: number,
+    postId: number,
+  ): Promise<void> {
+    await this.cacheService.del(`post:${userId}:${postId}`);
+    await this.cacheService.delByPattern(`posts:${userId}:*`);
   }
 }

--- a/apps/service/src/posts/command/update-post.handler.ts
+++ b/apps/service/src/posts/command/update-post.handler.ts
@@ -1,5 +1,6 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { NotFoundException } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
 import { UpdatePostCommand } from './update-post.command';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
 import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
@@ -22,6 +23,7 @@ export class UpdatePostHandler implements ICommandHandler<UpdatePostCommand> {
     await this.invalidatePostCache(command.userId, command.id);
   }
 
+  @Transactional()
   private async updatePostOrThrow(command: UpdatePostCommand): Promise<void> {
     const affected = await this.postWriteRepository.update(
       command.id,

--- a/apps/service/src/posts/command/update-post.handler.ts
+++ b/apps/service/src/posts/command/update-post.handler.ts
@@ -1,42 +1,25 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { UpdatePostCommand } from './update-post.command';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
-import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
 import { CacheService } from '@app/shared';
 
 @CommandHandler(UpdatePostCommand)
 export class UpdatePostHandler implements ICommandHandler<UpdatePostCommand> {
   constructor(
     private readonly postWriteRepository: IPostWriteRepository,
-    private readonly tagReadRepository: ITagReadRepository,
+    private readonly tagOwnershipValidator: TagOwnershipValidator,
     private readonly cacheService: CacheService,
   ) {}
 
   async execute(command: UpdatePostCommand): Promise<void> {
-    await this.validateTagsOwnedByUser(command.userId, command.tagIds);
+    await this.tagOwnershipValidator.validateOwnedByUser(
+      command.userId,
+      command.tagIds,
+    );
     await this.updatePostOrThrow(command);
     await this.invalidatePostCache(command.userId, command.id);
-  }
-
-  private async validateTagsOwnedByUser(
-    userId: number,
-    tagIds?: number[],
-  ): Promise<void> {
-    if (!tagIds?.length) {
-      return;
-    }
-
-    const uniqueIds = [...new Set(tagIds)];
-    const tags = await this.tagReadRepository.findByIdsAndUserId(
-      uniqueIds,
-      userId,
-    );
-    if (tags.length !== uniqueIds.length) {
-      throw new BadRequestException(
-        'One or more tags do not exist or are not owned by the user',
-      );
-    }
   }
 
   private async updatePostOrThrow(command: UpdatePostCommand): Promise<void> {

--- a/apps/service/src/posts/dto/request/create-post.request.dto.ts
+++ b/apps/service/src/posts/dto/request/create-post.request.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class CreatePostRequestDto {
   @ApiProperty({ description: '게시글 제목', example: 'First Post' })
@@ -16,4 +23,14 @@ export class CreatePostRequestDto {
   @IsBoolean()
   @IsOptional()
   isPublished?: boolean;
+
+  @ApiPropertyOptional({
+    description: '연결할 태그 ID 목록',
+    type: [Number],
+    example: [1, 2],
+  })
+  @IsArray()
+  @IsInt({ each: true })
+  @IsOptional()
+  tagIds?: number[];
 }

--- a/apps/service/src/posts/dto/request/find-posts.request.dto.ts
+++ b/apps/service/src/posts/dto/request/find-posts.request.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import { IsBoolean, IsInt, IsOptional } from 'class-validator';
 import { PaginationRequestDto } from '@app/shared';
 
@@ -15,7 +15,10 @@ export class PostsPaginationRequestDto extends PaginationRequestDto {
   isPublished?: boolean;
 
   @ApiPropertyOptional({ description: '태그 ID 필터', example: 1 })
-  @Type(() => Number)
+  @Transform(({ value }: { value: unknown }) => {
+    if (value === undefined || value === null || value === '') return undefined;
+    return Number(value);
+  })
   @IsInt()
   @IsOptional()
   tagId?: number;

--- a/apps/service/src/posts/dto/request/find-posts.request.dto.ts
+++ b/apps/service/src/posts/dto/request/find-posts.request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsInt, IsOptional } from 'class-validator';
 import { PaginationRequestDto } from '@app/shared';
 
 export class PostsPaginationRequestDto extends PaginationRequestDto {
@@ -13,4 +13,10 @@ export class PostsPaginationRequestDto extends PaginationRequestDto {
   @IsBoolean()
   @IsOptional()
   isPublished?: boolean;
+
+  @ApiPropertyOptional({ description: '태그 ID 필터', example: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @IsOptional()
+  tagId?: number;
 }

--- a/apps/service/src/posts/dto/request/update-post.request.dto.ts
+++ b/apps/service/src/posts/dto/request/update-post.request.dto.ts
@@ -1,5 +1,12 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class UpdatePostRequestDto {
   @ApiProperty({ description: '게시글 제목', example: 'Updated Title' })
@@ -18,4 +25,14 @@ export class UpdatePostRequestDto {
   @ApiProperty({ description: '공개 여부' })
   @IsBoolean()
   isPublished: boolean;
+
+  @ApiPropertyOptional({
+    description: '연결할 태그 ID 목록 (제공 시 기존 태그를 이 목록으로 대체)',
+    type: [Number],
+    example: [1, 2],
+  })
+  @IsArray()
+  @IsInt({ each: true })
+  @IsOptional()
+  tagIds?: number[];
 }

--- a/apps/service/src/posts/dto/response/post.response.dto.ts
+++ b/apps/service/src/posts/dto/response/post.response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Post } from '@app/shared';
+import { TagResponseDto } from '@service/tags/dto/response/tag.response.dto';
 
 export class PostResponseDto {
   @ApiProperty({ description: '게시글 ID', example: 1 })
@@ -23,6 +24,9 @@ export class PostResponseDto {
   @ApiProperty({ description: '수정일시' })
   updatedAt: Date;
 
+  @ApiProperty({ description: '연결된 태그 목록', type: [TagResponseDto] })
+  tags: TagResponseDto[];
+
   static of(post: Post): PostResponseDto {
     const dto = new PostResponseDto();
     dto.id = post.id;
@@ -32,6 +36,7 @@ export class PostResponseDto {
     dto.isPublished = post.isPublished;
     dto.createdAt = post.createdAt;
     dto.updatedAt = post.updatedAt;
+    dto.tags = (post.tags ?? []).map((tag) => TagResponseDto.of(tag));
     return dto;
   }
 }

--- a/apps/service/src/posts/interface/post-read-repository.interface.ts
+++ b/apps/service/src/posts/interface/post-read-repository.interface.ts
@@ -3,6 +3,7 @@ import { Post } from '@app/shared';
 export type PostFilter = {
   userId?: number;
   isPublished?: boolean;
+  tagId?: number;
 };
 
 export abstract class IPostReadRepository {

--- a/apps/service/src/posts/interface/post-write-repository.interface.ts
+++ b/apps/service/src/posts/interface/post-write-repository.interface.ts
@@ -5,12 +5,14 @@ export interface CreatePostInput {
   title: string;
   content: string;
   isPublished?: boolean;
+  tagIds?: number[];
 }
 
 export interface UpdatePostInput {
   title?: string;
   content?: string;
   isPublished?: boolean;
+  tagIds?: number[];
 }
 
 export abstract class IPostWriteRepository {

--- a/apps/service/src/posts/post.repository.ts
+++ b/apps/service/src/posts/post.repository.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, FindOptionsWhere, IsNull } from 'typeorm';
+import { DataSource, IsNull } from 'typeorm';
+import { Transactional } from 'typeorm-transactional';
 import { BaseRepository } from '@app/shared';
 import {
   IPostReadRepository,
   PostFilter,
 } from './interface/post-read-repository.interface';
-import {
+import { IPostWriteRepository } from './interface/post-write-repository.interface';
+import type {
   CreatePostInput,
-  IPostWriteRepository,
   UpdatePostInput,
 } from './interface/post-write-repository.interface';
 import { Post } from '@app/shared';
@@ -26,7 +27,10 @@ export class PostRepository
   }
 
   async findById(id: number): Promise<Post | null> {
-    return this.postRepository.findOneBy({ id });
+    return this.postRepository.findOne({
+      where: { id },
+      relations: { tags: true },
+    });
   }
 
   async findByUserIdAndTitle(
@@ -41,39 +45,116 @@ export class PostRepository
     limit: number,
     filter: PostFilter = {},
   ): Promise<[Post[], number]> {
-    const where: FindOptionsWhere<Post> = {};
+    const qb = this.postRepository
+      .createQueryBuilder('post')
+      .leftJoinAndSelect('post.tags', 'tag');
 
     if (filter.userId !== undefined) {
-      where.userId = filter.userId;
+      qb.andWhere('post.userId = :userId', { userId: filter.userId });
     }
 
     if (filter.isPublished !== undefined) {
-      where.isPublished = filter.isPublished;
+      qb.andWhere('post.isPublished = :isPublished', {
+        isPublished: filter.isPublished,
+      });
     }
 
-    return this.postRepository.findAndCount({
-      where,
-      skip: (page - 1) * limit,
-      take: limit,
-      order: { id: 'DESC' },
-    });
+    if (filter.tagId !== undefined) {
+      qb.andWhere(
+        (sub) => {
+          const subQuery = sub
+            .subQuery()
+            .select('filterPost.id')
+            .from(Post, 'filterPost')
+            .innerJoin('filterPost.tags', 'filterTag')
+            .where('filterTag.id = :tagId')
+            .getQuery();
+          return `post.id IN ${subQuery}`;
+        },
+        { tagId: filter.tagId },
+      );
+    }
+
+    return qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .orderBy('post.id', 'DESC')
+      .getManyAndCount();
   }
 
+  @Transactional()
   async create(input: CreatePostInput): Promise<Post> {
-    const post = this.postRepository.create(input);
-    return this.postRepository.save(post);
+    const { tagIds, ...scalars } = input;
+    const post = this.postRepository.create(scalars);
+    const saved = await this.postRepository.save(post);
+
+    if (tagIds?.length) {
+      await this.postRepository
+        .createQueryBuilder()
+        .relation(Post, 'tags')
+        .of(saved.id)
+        .add(tagIds);
+    }
+
+    const reloaded = await this.postRepository.findOne({
+      where: { id: saved.id },
+      relations: { tags: true },
+    });
+    return reloaded ?? saved;
   }
 
+  @Transactional()
   async update(
     id: number,
     userId: number,
     input: UpdatePostInput,
   ): Promise<number> {
-    const result = await this.postRepository.update(
-      { id, userId, deletedAt: IsNull() },
-      input,
-    );
+    const { tagIds, ...scalars } = input;
+
+    const affected = await this.updateScalars(id, userId, scalars);
+    if (affected === 0 || tagIds === undefined) {
+      return affected;
+    }
+
+    await this.replaceTags(id, userId, tagIds);
+    return affected;
+  }
+
+  private async updateScalars(
+    id: number,
+    userId: number,
+    scalars: Omit<UpdatePostInput, 'tagIds'>,
+  ): Promise<number> {
+    const criteria = { id, userId, deletedAt: IsNull() };
+
+    if (Object.keys(scalars).length === 0) {
+      const count = await this.postRepository.countBy(criteria);
+      return count;
+    }
+
+    const result = await this.postRepository.update(criteria, scalars);
     return result.affected ?? 0;
+  }
+
+  private async replaceTags(
+    id: number,
+    userId: number,
+    tagIds: number[],
+  ): Promise<void> {
+    const existing = await this.postRepository.findOne({
+      where: { id, userId, deletedAt: IsNull() },
+      relations: { tags: true },
+    });
+    if (!existing) {
+      return;
+    }
+
+    const currentTagIds = (existing.tags ?? []).map((tag) => tag.id);
+    await this.postRepository
+      .createQueryBuilder()
+      .relation(Post, 'tags')
+      .of(id)
+      .addAndRemove(tagIds, currentTagIds);
   }
 
   async delete(id: number, userId: number): Promise<number> {

--- a/apps/service/src/posts/post.repository.ts
+++ b/apps/service/src/posts/post.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource, IsNull } from 'typeorm';
-import { Transactional } from 'typeorm-transactional';
 import { BaseRepository } from '@app/shared';
 import {
   IPostReadRepository,
@@ -82,7 +81,6 @@ export class PostRepository
       .getManyAndCount();
   }
 
-  @Transactional()
   async create(input: CreatePostInput): Promise<Post> {
     const { tagIds, ...scalars } = input;
     const post = this.postRepository.create(scalars);
@@ -97,14 +95,9 @@ export class PostRepository
         .add(normalizedTagIds);
     }
 
-    const reloaded = await this.postRepository.findOne({
-      where: { id: saved.id },
-      relations: { tags: true },
-    });
-    return reloaded ?? saved;
+    return saved;
   }
 
-  @Transactional()
   async update(
     id: number,
     userId: number,

--- a/apps/service/src/posts/post.repository.ts
+++ b/apps/service/src/posts/post.repository.ts
@@ -88,12 +88,13 @@ export class PostRepository
     const post = this.postRepository.create(scalars);
     const saved = await this.postRepository.save(post);
 
-    if (tagIds?.length) {
+    const normalizedTagIds = tagIds ? [...new Set(tagIds)] : [];
+    if (normalizedTagIds.length) {
       await this.postRepository
         .createQueryBuilder()
         .relation(Post, 'tags')
         .of(saved.id)
-        .add(tagIds);
+        .add(normalizedTagIds);
     }
 
     const reloaded = await this.postRepository.findOne({
@@ -150,11 +151,12 @@ export class PostRepository
     }
 
     const currentTagIds = (existing.tags ?? []).map((tag) => tag.id);
+    const normalizedTagIds = [...new Set(tagIds)];
     await this.postRepository
       .createQueryBuilder()
       .relation(Post, 'tags')
       .of(id)
-      .addAndRemove(tagIds, currentTagIds);
+      .addAndRemove(normalizedTagIds, currentTagIds);
   }
 
   async delete(id: number, userId: number): Promise<number> {

--- a/apps/service/src/posts/posts.controller.ts
+++ b/apps/service/src/posts/posts.controller.ts
@@ -65,6 +65,7 @@ export class PostsController {
       new FindAllPostsPaginatedQuery(dto.page, dto.limit, {
         userId: user.id,
         isPublished: dto.isPublished,
+        tagId: dto.tagId,
       }),
     );
   }
@@ -98,7 +99,13 @@ export class PostsController {
     @Body() dto: CreatePostRequestDto,
   ): Promise<CreatePostResponseDto> {
     const id = await this.commandBus.execute<CreatePostCommand, number>(
-      new CreatePostCommand(user.id, dto.title, dto.content, dto.isPublished),
+      new CreatePostCommand(
+        user.id,
+        dto.title,
+        dto.content,
+        dto.isPublished,
+        dto.tagIds,
+      ),
     );
     return CreatePostResponseDto.of(id);
   }
@@ -122,6 +129,7 @@ export class PostsController {
         dto.title,
         dto.content,
         dto.isPublished,
+        dto.tagIds,
       ),
     );
   }

--- a/apps/service/src/posts/posts.module.ts
+++ b/apps/service/src/posts/posts.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { AuthModule } from '@service/auth/auth.module';
+import { TagsModule } from '@service/tags/tags.module';
 import { PostsController } from './posts.controller';
 import { CreatePostHandler } from './command/create-post.handler';
 import { UpdatePostHandler } from './command/update-post.handler';
@@ -23,7 +24,7 @@ const queryHandlers = [GetPostByIdHandler, FindAllPostsPaginatedHandler];
 const eventHandlers = [PostCreatedHandler];
 
 @Module({
-  imports: [CqrsModule, AuthModule, SlackModule, AppCacheModule],
+  imports: [CqrsModule, AuthModule, TagsModule, SlackModule, AppCacheModule],
   controllers: [PostsController],
   providers: [
     ...commandHandlers,

--- a/apps/service/src/posts/query/find-all-posts-paginated.handler.ts
+++ b/apps/service/src/posts/query/find-all-posts-paginated.handler.ts
@@ -17,8 +17,8 @@ export class FindAllPostsPaginatedHandler implements IQueryHandler<FindAllPostsP
   async execute(
     query: FindAllPostsPaginatedQuery,
   ): Promise<PaginatedResponseDto<PostResponseDto>> {
-    const { userId, isPublished } = query.filter;
-    const cacheKey = `posts:${userId}:${query.page}:${query.limit}:${isPublished ?? 'all'}`;
+    const { userId, isPublished, tagId } = query.filter;
+    const cacheKey = `posts:${userId}:${query.page}:${query.limit}:${isPublished ?? 'all'}:${tagId ?? 'all'}`;
     const cached =
       await this.cacheService.get<PaginatedResponseDto<PostResponseDto>>(
         cacheKey,

--- a/apps/service/src/tags/command/create-tag.command.ts
+++ b/apps/service/src/tags/command/create-tag.command.ts
@@ -1,0 +1,6 @@
+export class CreateTagCommand {
+  constructor(
+    public readonly userId: number,
+    public readonly name: string,
+  ) {}
+}

--- a/apps/service/src/tags/command/create-tag.handler.spec.ts
+++ b/apps/service/src/tags/command/create-tag.handler.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { ConflictException } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+import { CreateTagHandler } from './create-tag.handler';
+import { CreateTagCommand } from './create-tag.command';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
+import { CacheService, Tag } from '@app/shared';
+
+describe('CreateTagHandler', () => {
+  let handler: CreateTagHandler;
+  let tagReadRepository: Mocked<ITagReadRepository>;
+  let tagWriteRepository: Mocked<ITagWriteRepository>;
+  let cacheService: Mocked<CacheService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(CreateTagHandler).compile();
+
+    handler = unit;
+    tagReadRepository = unitRef.get<ITagReadRepository>(
+      ITagReadRepository as Type<ITagReadRepository>,
+    );
+    tagWriteRepository = unitRef.get<ITagWriteRepository>(
+      ITagWriteRepository as Type<ITagWriteRepository>,
+    );
+    cacheService = unitRef.get(CacheService);
+  });
+
+  it('중복되지 않는 이름이면 태그를 생성하고 id를 반환한다', async () => {
+    tagReadRepository.findByUserIdAndName.mockResolvedValue(null);
+    tagWriteRepository.create.mockResolvedValue({ id: 1 } as Tag);
+
+    const command = new CreateTagCommand(1, 'nestjs');
+    const result = await handler.execute(command);
+
+    expect(result).toBe(1);
+    expect(tagReadRepository.findByUserIdAndName).toHaveBeenCalledWith(
+      1,
+      'nestjs',
+    );
+    expect(tagWriteRepository.create).toHaveBeenCalledWith({
+      userId: 1,
+      name: 'nestjs',
+    });
+    expect(cacheService.delByPattern).toHaveBeenCalledWith('tags:1:*');
+  });
+
+  it('동일한 이름이 이미 존재하면 ConflictException을 발생시키고 create를 호출하지 않는다', async () => {
+    tagReadRepository.findByUserIdAndName.mockResolvedValue({ id: 1 } as Tag);
+
+    const command = new CreateTagCommand(1, 'nestjs');
+
+    await expect(handler.execute(command)).rejects.toThrow(ConflictException);
+    expect(tagWriteRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('create에서 23505 QueryFailedError가 발생하면 ConflictException으로 변환한다', async () => {
+    tagReadRepository.findByUserIdAndName.mockResolvedValue(null);
+    tagWriteRepository.create.mockRejectedValue(
+      new QueryFailedError('insert', [], {
+        code: '23505',
+      } as unknown as Error),
+    );
+
+    const command = new CreateTagCommand(1, 'nestjs');
+
+    await expect(handler.execute(command)).rejects.toThrow(ConflictException);
+  });
+});

--- a/apps/service/src/tags/command/create-tag.handler.ts
+++ b/apps/service/src/tags/command/create-tag.handler.ts
@@ -1,0 +1,62 @@
+import { ConflictException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { QueryFailedError } from 'typeorm';
+import { CreateTagCommand } from './create-tag.command';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import {
+  CreateTagInput,
+  ITagWriteRepository,
+} from '@service/tags/interface/tag-write-repository.interface';
+import { CacheService, Tag } from '@app/shared';
+
+@CommandHandler(CreateTagCommand)
+export class CreateTagHandler implements ICommandHandler<CreateTagCommand> {
+  constructor(
+    private readonly tagReadRepository: ITagReadRepository,
+    private readonly tagWriteRepository: ITagWriteRepository,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(command: CreateTagCommand): Promise<number> {
+    await this.validateNameNotDuplicated(command.userId, command.name);
+    const tag = await this.persistTagOrConflict({
+      userId: command.userId,
+      name: command.name,
+    });
+    await this.invalidateUserCache(command.userId);
+    return tag.id;
+  }
+
+  private async validateNameNotDuplicated(
+    userId: number,
+    name: string,
+  ): Promise<void> {
+    const existing = await this.tagReadRepository.findByUserIdAndName(
+      userId,
+      name,
+    );
+    if (existing) {
+      throw new ConflictException(`Tag with name '${name}' already exists`);
+    }
+  }
+
+  private async persistTagOrConflict(input: CreateTagInput): Promise<Tag> {
+    try {
+      return await this.tagWriteRepository.create(input);
+    } catch (error) {
+      if (
+        error instanceof QueryFailedError &&
+        (error.driverError as { code?: string })?.code === '23505'
+      ) {
+        throw new ConflictException(
+          `Tag with name '${input.name}' already exists`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async invalidateUserCache(userId: number): Promise<void> {
+    await this.cacheService.delByPattern(`tags:${userId}:*`);
+  }
+}

--- a/apps/service/src/tags/command/delete-tag.command.ts
+++ b/apps/service/src/tags/command/delete-tag.command.ts
@@ -1,0 +1,6 @@
+export class DeleteTagCommand {
+  constructor(
+    public readonly userId: number,
+    public readonly id: number,
+  ) {}
+}

--- a/apps/service/src/tags/command/delete-tag.handler.spec.ts
+++ b/apps/service/src/tags/command/delete-tag.handler.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { NotFoundException } from '@nestjs/common';
+import { DeleteTagHandler } from './delete-tag.handler';
+import { DeleteTagCommand } from './delete-tag.command';
+import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
+import { CacheService } from '@app/shared';
+
+describe('DeleteTagHandler', () => {
+  let handler: DeleteTagHandler;
+  let tagWriteRepository: Mocked<ITagWriteRepository>;
+  let cacheService: Mocked<CacheService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(DeleteTagHandler).compile();
+
+    handler = unit;
+    tagWriteRepository = unitRef.get<ITagWriteRepository>(
+      ITagWriteRepository as Type<ITagWriteRepository>,
+    );
+    cacheService = unitRef.get(CacheService);
+  });
+
+  it('존재하는 본인의 태그를 삭제하면 void를 반환하고 캐시를 무효화한다', async () => {
+    tagWriteRepository.delete.mockResolvedValue(1);
+
+    const command = new DeleteTagCommand(1, 5);
+    const result = await handler.execute(command);
+
+    expect(result).toBeUndefined();
+    expect(tagWriteRepository.delete).toHaveBeenCalledWith(5, 1);
+    expect(cacheService.del).toHaveBeenCalledWith('tag:1:5');
+    expect(cacheService.delByPattern).toHaveBeenCalledWith('tags:1:*');
+    expect(cacheService.delByPattern).toHaveBeenCalledWith('posts:1:*');
+    expect(cacheService.delByPattern).toHaveBeenCalledWith('post:1:*');
+  });
+
+  it('affected가 0이면 NotFoundException을 발생시킨다', async () => {
+    tagWriteRepository.delete.mockResolvedValue(0);
+
+    const command = new DeleteTagCommand(1, 999);
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+    expect(cacheService.del).not.toHaveBeenCalled();
+  });
+});

--- a/apps/service/src/tags/command/delete-tag.handler.ts
+++ b/apps/service/src/tags/command/delete-tag.handler.ts
@@ -1,0 +1,32 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { NotFoundException } from '@nestjs/common';
+import { DeleteTagCommand } from './delete-tag.command';
+import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
+import { CacheService } from '@app/shared';
+
+@CommandHandler(DeleteTagCommand)
+export class DeleteTagHandler implements ICommandHandler<DeleteTagCommand> {
+  constructor(
+    private readonly tagWriteRepository: ITagWriteRepository,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(command: DeleteTagCommand): Promise<void> {
+    const affected = await this.tagWriteRepository.delete(
+      command.id,
+      command.userId,
+    );
+    if (affected === 0) {
+      throw new NotFoundException(`Tag with ID ${command.id} not found`);
+    }
+
+    await this.invalidateCaches(command.userId, command.id);
+  }
+
+  private async invalidateCaches(userId: number, id: number): Promise<void> {
+    await this.cacheService.del(`tag:${userId}:${id}`);
+    await this.cacheService.delByPattern(`tags:${userId}:*`);
+    await this.cacheService.delByPattern(`posts:${userId}:*`);
+    await this.cacheService.delByPattern(`post:${userId}:*`);
+  }
+}

--- a/apps/service/src/tags/command/delete-tag.handler.ts
+++ b/apps/service/src/tags/command/delete-tag.handler.ts
@@ -20,10 +20,10 @@ export class DeleteTagHandler implements ICommandHandler<DeleteTagCommand> {
       throw new NotFoundException(`Tag with ID ${command.id} not found`);
     }
 
-    await this.invalidateCaches(command.userId, command.id);
+    await this.invalidateTagCaches(command.userId, command.id);
   }
 
-  private async invalidateCaches(userId: number, id: number): Promise<void> {
+  private async invalidateTagCaches(userId: number, id: number): Promise<void> {
     await this.cacheService.del(`tag:${userId}:${id}`);
     await this.cacheService.delByPattern(`tags:${userId}:*`);
     await this.cacheService.delByPattern(`posts:${userId}:*`);

--- a/apps/service/src/tags/command/update-tag.command.ts
+++ b/apps/service/src/tags/command/update-tag.command.ts
@@ -1,0 +1,7 @@
+export class UpdateTagCommand {
+  constructor(
+    public readonly userId: number,
+    public readonly id: number,
+    public readonly name: string,
+  ) {}
+}

--- a/apps/service/src/tags/command/update-tag.handler.spec.ts
+++ b/apps/service/src/tags/command/update-tag.handler.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { NotFoundException } from '@nestjs/common';
+import { UpdateTagHandler } from './update-tag.handler';
+import { UpdateTagCommand } from './update-tag.command';
+import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
+import { CacheService } from '@app/shared';
+
+describe('UpdateTagHandler', () => {
+  let handler: UpdateTagHandler;
+  let tagWriteRepository: Mocked<ITagWriteRepository>;
+  let cacheService: Mocked<CacheService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(UpdateTagHandler).compile();
+
+    handler = unit;
+    tagWriteRepository = unitRef.get<ITagWriteRepository>(
+      ITagWriteRepository as Type<ITagWriteRepository>,
+    );
+    cacheService = unitRef.get(CacheService);
+  });
+
+  it('존재하는 본인의 태그를 수정하면 void를 반환하고 캐시를 무효화한다', async () => {
+    tagWriteRepository.update.mockResolvedValue(1);
+
+    const command = new UpdateTagCommand(1, 5, 'typescript');
+    const result = await handler.execute(command);
+
+    expect(result).toBeUndefined();
+    expect(tagWriteRepository.update).toHaveBeenCalledWith(5, 1, {
+      name: 'typescript',
+    });
+    expect(cacheService.del).toHaveBeenCalledWith('tag:1:5');
+    expect(cacheService.delByPattern).toHaveBeenCalledWith('tags:1:*');
+    expect(cacheService.delByPattern).toHaveBeenCalledWith('posts:1:*');
+    expect(cacheService.delByPattern).toHaveBeenCalledWith('post:1:*');
+  });
+
+  it('affected가 0이면 NotFoundException을 발생시킨다', async () => {
+    tagWriteRepository.update.mockResolvedValue(0);
+
+    const command = new UpdateTagCommand(1, 999, 'typescript');
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+    expect(cacheService.del).not.toHaveBeenCalled();
+  });
+});

--- a/apps/service/src/tags/command/update-tag.handler.spec.ts
+++ b/apps/service/src/tags/command/update-tag.handler.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, type Mocked } from '@suites/unit';
 import type { Type } from '@suites/types.common';
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
 import { UpdateTagHandler } from './update-tag.handler';
 import { UpdateTagCommand } from './update-tag.command';
 import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
@@ -44,6 +45,19 @@ describe('UpdateTagHandler', () => {
     const command = new UpdateTagCommand(1, 999, 'typescript');
 
     await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+    expect(cacheService.del).not.toHaveBeenCalled();
+  });
+
+  it('update에서 23505 QueryFailedError가 발생하면 ConflictException으로 변환한다', async () => {
+    tagWriteRepository.update.mockRejectedValue(
+      new QueryFailedError('update', [], {
+        code: '23505',
+      } as unknown as Error),
+    );
+
+    const command = new UpdateTagCommand(1, 5, 'duplicate');
+
+    await expect(handler.execute(command)).rejects.toThrow(ConflictException);
     expect(cacheService.del).not.toHaveBeenCalled();
   });
 });

--- a/apps/service/src/tags/command/update-tag.handler.ts
+++ b/apps/service/src/tags/command/update-tag.handler.ts
@@ -1,0 +1,33 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { NotFoundException } from '@nestjs/common';
+import { UpdateTagCommand } from './update-tag.command';
+import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
+import { CacheService } from '@app/shared';
+
+@CommandHandler(UpdateTagCommand)
+export class UpdateTagHandler implements ICommandHandler<UpdateTagCommand> {
+  constructor(
+    private readonly tagWriteRepository: ITagWriteRepository,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(command: UpdateTagCommand): Promise<void> {
+    const affected = await this.tagWriteRepository.update(
+      command.id,
+      command.userId,
+      { name: command.name },
+    );
+    if (affected === 0) {
+      throw new NotFoundException(`Tag with ID ${command.id} not found`);
+    }
+
+    await this.invalidateCaches(command.userId, command.id);
+  }
+
+  private async invalidateCaches(userId: number, id: number): Promise<void> {
+    await this.cacheService.del(`tag:${userId}:${id}`);
+    await this.cacheService.delByPattern(`tags:${userId}:*`);
+    await this.cacheService.delByPattern(`posts:${userId}:*`);
+    await this.cacheService.delByPattern(`post:${userId}:*`);
+  }
+}

--- a/apps/service/src/tags/command/update-tag.handler.ts
+++ b/apps/service/src/tags/command/update-tag.handler.ts
@@ -1,5 +1,6 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
 import { UpdateTagCommand } from './update-tag.command';
 import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
 import { CacheService } from '@app/shared';
@@ -12,16 +13,32 @@ export class UpdateTagHandler implements ICommandHandler<UpdateTagCommand> {
   ) {}
 
   async execute(command: UpdateTagCommand): Promise<void> {
-    const affected = await this.tagWriteRepository.update(
-      command.id,
-      command.userId,
-      { name: command.name },
-    );
+    const affected = await this.updateNameOrConflict(command);
     if (affected === 0) {
       throw new NotFoundException(`Tag with ID ${command.id} not found`);
     }
 
     await this.invalidateTagCaches(command.userId, command.id);
+  }
+
+  private async updateNameOrConflict(
+    command: UpdateTagCommand,
+  ): Promise<number> {
+    try {
+      return await this.tagWriteRepository.update(command.id, command.userId, {
+        name: command.name,
+      });
+    } catch (error) {
+      if (
+        error instanceof QueryFailedError &&
+        (error.driverError as { code?: string })?.code === '23505'
+      ) {
+        throw new ConflictException(
+          `Tag with name '${command.name}' already exists`,
+        );
+      }
+      throw error;
+    }
   }
 
   private async invalidateTagCaches(userId: number, id: number): Promise<void> {

--- a/apps/service/src/tags/command/update-tag.handler.ts
+++ b/apps/service/src/tags/command/update-tag.handler.ts
@@ -21,10 +21,10 @@ export class UpdateTagHandler implements ICommandHandler<UpdateTagCommand> {
       throw new NotFoundException(`Tag with ID ${command.id} not found`);
     }
 
-    await this.invalidateCaches(command.userId, command.id);
+    await this.invalidateTagCaches(command.userId, command.id);
   }
 
-  private async invalidateCaches(userId: number, id: number): Promise<void> {
+  private async invalidateTagCaches(userId: number, id: number): Promise<void> {
     await this.cacheService.del(`tag:${userId}:${id}`);
     await this.cacheService.delByPattern(`tags:${userId}:*`);
     await this.cacheService.delByPattern(`posts:${userId}:*`);

--- a/apps/service/src/tags/dto/request/create-tag.request.dto.ts
+++ b/apps/service/src/tags/dto/request/create-tag.request.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateTagRequestDto {
+  @ApiProperty({ description: '태그 이름', example: 'nestjs', maxLength: 50 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name: string;
+}

--- a/apps/service/src/tags/dto/request/find-tags.request.dto.ts
+++ b/apps/service/src/tags/dto/request/find-tags.request.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationRequestDto } from '@app/shared';
+
+export class TagsPaginationRequestDto extends PaginationRequestDto {}

--- a/apps/service/src/tags/dto/request/update-tag.request.dto.ts
+++ b/apps/service/src/tags/dto/request/update-tag.request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class UpdateTagRequestDto {
+  @ApiProperty({
+    description: '태그 이름',
+    example: 'typescript',
+    maxLength: 50,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name: string;
+}

--- a/apps/service/src/tags/dto/response/create-tag.response.dto.spec.ts
+++ b/apps/service/src/tags/dto/response/create-tag.response.dto.spec.ts
@@ -1,0 +1,17 @@
+import { CreateTagResponseDto } from './create-tag.response.dto';
+
+describe('CreateTagResponseDto', () => {
+  describe('of', () => {
+    it('id를 DTO로 매핑한다', () => {
+      const dto = CreateTagResponseDto.of(42);
+
+      expect(dto.id).toBe(42);
+    });
+
+    it('CreateTagResponseDto 인스턴스를 반환한다', () => {
+      const dto = CreateTagResponseDto.of(1);
+
+      expect(dto).toBeInstanceOf(CreateTagResponseDto);
+    });
+  });
+});

--- a/apps/service/src/tags/dto/response/create-tag.response.dto.ts
+++ b/apps/service/src/tags/dto/response/create-tag.response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateTagResponseDto {
+  @ApiProperty({ description: '생성된 태그 ID', example: 1 })
+  id: number;
+
+  static of(id: number): CreateTagResponseDto {
+    const dto = new CreateTagResponseDto();
+    dto.id = id;
+    return dto;
+  }
+}

--- a/apps/service/src/tags/dto/response/tag.response.dto.spec.ts
+++ b/apps/service/src/tags/dto/response/tag.response.dto.spec.ts
@@ -1,0 +1,43 @@
+import { TagResponseDto } from './tag.response.dto';
+import { Tag } from '@app/shared';
+
+describe('TagResponseDto', () => {
+  const now = new Date();
+
+  const createTag = (overrides: Partial<Tag> = {}): Tag => {
+    const tag = new Tag();
+    tag.id = 1;
+    tag.userId = 1;
+    tag.name = 'nestjs';
+    tag.createdAt = now;
+    tag.updatedAt = now;
+    Object.assign(tag, overrides);
+    return tag;
+  };
+
+  describe('of', () => {
+    it('Tag 엔티티의 모든 필드를 DTO로 매핑한다', () => {
+      const tag = createTag();
+
+      const dto = TagResponseDto.of(tag);
+
+      expect(dto.id).toBe(tag.id);
+      expect(dto.userId).toBe(tag.userId);
+      expect(dto.name).toBe(tag.name);
+      expect(dto.createdAt).toBe(tag.createdAt);
+      expect(dto.updatedAt).toBe(tag.updatedAt);
+    });
+
+    it('TagResponseDto 인스턴스를 반환한다', () => {
+      const dto = TagResponseDto.of(createTag());
+
+      expect(dto).toBeInstanceOf(TagResponseDto);
+    });
+
+    it('userId를 올바르게 매핑한다', () => {
+      const dto = TagResponseDto.of(createTag({ userId: 42 }));
+
+      expect(dto.userId).toBe(42);
+    });
+  });
+});

--- a/apps/service/src/tags/dto/response/tag.response.dto.ts
+++ b/apps/service/src/tags/dto/response/tag.response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Tag } from '@app/shared';
+
+export class TagResponseDto {
+  @ApiProperty({ description: '태그 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '소유자 ID', example: 1 })
+  userId: number;
+
+  @ApiProperty({ description: '태그 이름', example: 'nestjs' })
+  name: string;
+
+  @ApiProperty({ description: '생성일시' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '수정일시' })
+  updatedAt: Date;
+
+  static of(tag: Tag): TagResponseDto {
+    const dto = new TagResponseDto();
+    dto.id = tag.id;
+    dto.userId = tag.userId;
+    dto.name = tag.name;
+    dto.createdAt = tag.createdAt;
+    dto.updatedAt = tag.updatedAt;
+    return dto;
+  }
+}

--- a/apps/service/src/tags/interface/tag-read-repository.interface.ts
+++ b/apps/service/src/tags/interface/tag-read-repository.interface.ts
@@ -1,0 +1,17 @@
+import { Tag } from '@app/shared';
+
+export type TagFilter = { userId?: number };
+
+export abstract class ITagReadRepository {
+  abstract findById(id: number): Promise<Tag | null>;
+  abstract findByUserIdAndName(
+    userId: number,
+    name: string,
+  ): Promise<Tag | null>;
+  abstract findByIdsAndUserId(ids: number[], userId: number): Promise<Tag[]>;
+  abstract findAllPaginated(
+    page: number,
+    limit: number,
+    filter?: TagFilter,
+  ): Promise<[Tag[], number]>;
+}

--- a/apps/service/src/tags/interface/tag-write-repository.interface.ts
+++ b/apps/service/src/tags/interface/tag-write-repository.interface.ts
@@ -1,0 +1,20 @@
+import { Tag } from '@app/shared';
+
+export interface CreateTagInput {
+  userId: number;
+  name: string;
+}
+
+export interface UpdateTagInput {
+  name?: string;
+}
+
+export abstract class ITagWriteRepository {
+  abstract create(input: CreateTagInput): Promise<Tag>;
+  abstract update(
+    id: number,
+    userId: number,
+    input: UpdateTagInput,
+  ): Promise<number>;
+  abstract delete(id: number, userId: number): Promise<number>;
+}

--- a/apps/service/src/tags/query/find-all-tags-paginated.handler.spec.ts
+++ b/apps/service/src/tags/query/find-all-tags-paginated.handler.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { FindAllTagsPaginatedHandler } from './find-all-tags-paginated.handler';
+import { FindAllTagsPaginatedQuery } from './find-all-tags-paginated.query';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { TagResponseDto } from '@service/tags/dto/response/tag.response.dto';
+import { CacheService, PaginatedResponseDto, Tag } from '@app/shared';
+
+describe('FindAllTagsPaginatedHandler', () => {
+  let handler: FindAllTagsPaginatedHandler;
+  let tagReadRepository: Mocked<ITagReadRepository>;
+  let cacheService: Mocked<CacheService>;
+
+  const now = new Date();
+  const mockTags: Tag[] = [
+    {
+      id: 2,
+      userId: 1,
+      name: 'typescript',
+      createdAt: now,
+      updatedAt: now,
+    } as Tag,
+    {
+      id: 1,
+      userId: 1,
+      name: 'nestjs',
+      createdAt: now,
+      updatedAt: now,
+    } as Tag,
+  ];
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(
+      FindAllTagsPaginatedHandler,
+    ).compile();
+
+    handler = unit;
+    tagReadRepository = unitRef.get<ITagReadRepository>(
+      ITagReadRepository as Type<ITagReadRepository>,
+    );
+    cacheService = unitRef.get(CacheService);
+  });
+
+  it('캐시 히트 시 저장소를 조회하지 않고 캐시된 값을 반환한다', async () => {
+    const cached = PaginatedResponseDto.of(
+      mockTags.map((tag) => TagResponseDto.of(tag)),
+      2,
+      1,
+      10,
+    );
+    cacheService.get.mockResolvedValue(cached);
+
+    const result = await handler.execute(
+      new FindAllTagsPaginatedQuery(1, 10, { userId: 1 }),
+    );
+
+    expect(result).toBe(cached);
+    expect(tagReadRepository.findAllPaginated).not.toHaveBeenCalled();
+    expect(cacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('캐시 미스 시 태그 목록을 페이지네이션하여 PaginatedResponseDto로 반환하고 캐시에 저장한다', async () => {
+    cacheService.get.mockResolvedValue(null);
+    tagReadRepository.findAllPaginated.mockResolvedValue([mockTags, 5]);
+
+    const query = new FindAllTagsPaginatedQuery(1, 2, { userId: 1 });
+    const result = await handler.execute(query);
+
+    expect(tagReadRepository.findAllPaginated).toHaveBeenCalledWith(1, 2, {
+      userId: 1,
+    });
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toBeInstanceOf(TagResponseDto);
+    expect(result.items[0].id).toBe(2);
+    expect(result.items[1].id).toBe(1);
+    expect(result.meta).toEqual({
+      page: 1,
+      limit: 2,
+      totalElements: 5,
+      totalPages: 3,
+      isFirst: true,
+      isLast: false,
+    });
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'tags:1:1:2',
+      expect.any(PaginatedResponseDto),
+      expect.any(Number),
+    );
+  });
+
+  it('빈 목록이면 빈 items와 올바른 메타 정보를 반환한다', async () => {
+    cacheService.get.mockResolvedValue(null);
+    tagReadRepository.findAllPaginated.mockResolvedValue([[], 0]);
+
+    const query = new FindAllTagsPaginatedQuery(1, 10, { userId: 1 });
+    const result = await handler.execute(query);
+
+    expect(result.items).toHaveLength(0);
+    expect(result.meta.totalElements).toBe(0);
+    expect(result.meta.totalPages).toBe(0);
+    expect(result.meta.isFirst).toBe(true);
+    expect(result.meta.isLast).toBe(true);
+  });
+});

--- a/apps/service/src/tags/query/find-all-tags-paginated.handler.ts
+++ b/apps/service/src/tags/query/find-all-tags-paginated.handler.ts
@@ -1,0 +1,45 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { FindAllTagsPaginatedQuery } from './find-all-tags-paginated.query';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { TagResponseDto } from '@service/tags/dto/response/tag.response.dto';
+import { PaginatedResponseDto } from '@app/shared';
+import { CacheService } from '@app/shared';
+
+const TAGS_LIST_CACHE_TTL = 180; // 3분
+
+@QueryHandler(FindAllTagsPaginatedQuery)
+export class FindAllTagsPaginatedHandler implements IQueryHandler<FindAllTagsPaginatedQuery> {
+  constructor(
+    private readonly tagReadRepository: ITagReadRepository,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(
+    query: FindAllTagsPaginatedQuery,
+  ): Promise<PaginatedResponseDto<TagResponseDto>> {
+    const { userId } = query.filter;
+    const cacheKey = `tags:${userId}:${query.page}:${query.limit}`;
+    const cached =
+      await this.cacheService.get<PaginatedResponseDto<TagResponseDto>>(
+        cacheKey,
+      );
+    if (cached) return cached;
+
+    const [tags, totalElements] = await this.tagReadRepository.findAllPaginated(
+      query.page,
+      query.limit,
+      query.filter,
+    );
+
+    const items = tags.map((tag) => TagResponseDto.of(tag));
+    const result = PaginatedResponseDto.of(
+      items,
+      totalElements,
+      query.page,
+      query.limit,
+    );
+
+    await this.cacheService.set(cacheKey, result, TAGS_LIST_CACHE_TTL);
+    return result;
+  }
+}

--- a/apps/service/src/tags/query/find-all-tags-paginated.query.ts
+++ b/apps/service/src/tags/query/find-all-tags-paginated.query.ts
@@ -1,0 +1,12 @@
+import { PaginatedQuery } from '@app/shared';
+import { TagFilter } from '@service/tags/interface/tag-read-repository.interface';
+
+export class FindAllTagsPaginatedQuery extends PaginatedQuery {
+  constructor(
+    page: number,
+    limit: number,
+    public readonly filter: TagFilter = {},
+  ) {
+    super(page, limit);
+  }
+}

--- a/apps/service/src/tags/query/get-tag-by-id.handler.spec.ts
+++ b/apps/service/src/tags/query/get-tag-by-id.handler.spec.ts
@@ -1,0 +1,80 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { NotFoundException } from '@nestjs/common';
+import { GetTagByIdHandler } from './get-tag-by-id.handler';
+import { GetTagByIdQuery } from './get-tag-by-id.query';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { TagResponseDto } from '@service/tags/dto/response/tag.response.dto';
+import { CacheService, Tag } from '@app/shared';
+
+describe('GetTagByIdHandler', () => {
+  let handler: GetTagByIdHandler;
+  let tagReadRepository: Mocked<ITagReadRepository>;
+  let cacheService: Mocked<CacheService>;
+
+  const now = new Date();
+  const mockTag: Tag = {
+    id: 1,
+    userId: 1,
+    name: 'nestjs',
+    createdAt: now,
+    updatedAt: now,
+  } as Tag;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(GetTagByIdHandler).compile();
+
+    handler = unit;
+    tagReadRepository = unitRef.get<ITagReadRepository>(
+      ITagReadRepository as Type<ITagReadRepository>,
+    );
+    cacheService = unitRef.get(CacheService);
+  });
+
+  it('캐시 히트 시 저장소를 조회하지 않고 캐시된 값을 반환한다', async () => {
+    const cached = TagResponseDto.of(mockTag);
+    cacheService.get.mockResolvedValue(cached);
+
+    const result = await handler.execute(new GetTagByIdQuery(1, 1));
+
+    expect(result).toBe(cached);
+    expect(tagReadRepository.findById).not.toHaveBeenCalled();
+    expect(cacheService.set).not.toHaveBeenCalled();
+  });
+
+  it('캐시 미스 시 저장소를 조회해 TagResponseDto로 변환하고 캐시에 저장한다', async () => {
+    cacheService.get.mockResolvedValue(null);
+    tagReadRepository.findById.mockResolvedValue(mockTag);
+
+    const result = await handler.execute(new GetTagByIdQuery(1, 1));
+
+    expect(result).toBeInstanceOf(TagResponseDto);
+    expect(result.id).toBe(1);
+    expect(result.name).toBe('nestjs');
+    expect(tagReadRepository.findById).toHaveBeenCalledWith(1);
+    expect(cacheService.set).toHaveBeenCalledWith(
+      'tag:1:1',
+      expect.any(TagResponseDto),
+      expect.any(Number),
+    );
+  });
+
+  it('존재하지 않는 태그를 조회하면 NotFoundException을 발생시킨다', async () => {
+    cacheService.get.mockResolvedValue(null);
+    tagReadRepository.findById.mockResolvedValue(null);
+
+    await expect(handler.execute(new GetTagByIdQuery(1, 999))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('다른 사용자의 태그를 조회하면 NotFoundException을 발생시킨다', async () => {
+    cacheService.get.mockResolvedValue(null);
+    tagReadRepository.findById.mockResolvedValue(mockTag);
+
+    await expect(handler.execute(new GetTagByIdQuery(2, 1))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});

--- a/apps/service/src/tags/query/get-tag-by-id.handler.ts
+++ b/apps/service/src/tags/query/get-tag-by-id.handler.ts
@@ -1,0 +1,31 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { NotFoundException } from '@nestjs/common';
+import { GetTagByIdQuery } from './get-tag-by-id.query';
+import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
+import { TagResponseDto } from '@service/tags/dto/response/tag.response.dto';
+import { CacheService } from '@app/shared';
+
+const TAG_CACHE_TTL = 300; // 5분
+
+@QueryHandler(GetTagByIdQuery)
+export class GetTagByIdHandler implements IQueryHandler<GetTagByIdQuery> {
+  constructor(
+    private readonly tagReadRepository: ITagReadRepository,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(query: GetTagByIdQuery): Promise<TagResponseDto> {
+    const cacheKey = `tag:${query.userId}:${query.id}`;
+    const cached = await this.cacheService.get<TagResponseDto>(cacheKey);
+    if (cached) return cached;
+
+    const tag = await this.tagReadRepository.findById(query.id);
+    if (!tag || tag.userId !== query.userId) {
+      throw new NotFoundException(`Tag with ID ${query.id} not found`);
+    }
+
+    const result = TagResponseDto.of(tag);
+    await this.cacheService.set(cacheKey, result, TAG_CACHE_TTL);
+    return result;
+  }
+}

--- a/apps/service/src/tags/query/get-tag-by-id.query.ts
+++ b/apps/service/src/tags/query/get-tag-by-id.query.ts
@@ -1,0 +1,6 @@
+export class GetTagByIdQuery {
+  constructor(
+    public readonly userId: number,
+    public readonly id: number,
+  ) {}
+}

--- a/apps/service/src/tags/tag-ownership.validator.spec.ts
+++ b/apps/service/src/tags/tag-ownership.validator.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { BadRequestException } from '@nestjs/common';
+import { TagOwnershipValidator } from './tag-ownership.validator';
+import { ITagReadRepository } from './interface/tag-read-repository.interface';
+import { Tag } from '@app/shared';
+
+describe('TagOwnershipValidator', () => {
+  let validator: TagOwnershipValidator;
+  let tagReadRepository: Mocked<ITagReadRepository>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(
+      TagOwnershipValidator,
+    ).compile();
+
+    validator = unit;
+    tagReadRepository = unitRef.get<ITagReadRepository>(
+      ITagReadRepository as Type<ITagReadRepository>,
+    );
+  });
+
+  it('tagIds가 undefined이면 조회 없이 통과한다', async () => {
+    await expect(
+      validator.validateOwnedByUser(1, undefined),
+    ).resolves.toBeUndefined();
+    expect(tagReadRepository.findByIdsAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('tagIds가 빈 배열이면 조회 없이 통과한다', async () => {
+    await expect(validator.validateOwnedByUser(1, [])).resolves.toBeUndefined();
+    expect(tagReadRepository.findByIdsAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('모든 태그가 사용자 소유면 통과하며 중복 id는 제거하여 조회한다', async () => {
+    tagReadRepository.findByIdsAndUserId.mockResolvedValue([
+      { id: 1 } as Tag,
+      { id: 2 } as Tag,
+    ]);
+
+    await expect(
+      validator.validateOwnedByUser(1, [1, 2, 1]),
+    ).resolves.toBeUndefined();
+    expect(tagReadRepository.findByIdsAndUserId).toHaveBeenCalledWith(
+      [1, 2],
+      1,
+    );
+  });
+
+  it('소유하지 않거나 존재하지 않는 태그가 있으면 BadRequestException을 발생시킨다', async () => {
+    tagReadRepository.findByIdsAndUserId.mockResolvedValue([{ id: 1 } as Tag]);
+
+    await expect(validator.validateOwnedByUser(1, [1, 2])).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/apps/service/src/tags/tag-ownership.validator.ts
+++ b/apps/service/src/tags/tag-ownership.validator.ts
@@ -1,0 +1,28 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ITagReadRepository } from './interface/tag-read-repository.interface';
+
+/**
+ * 게시글에 연결하려는 태그가 모두 해당 사용자의 소유인지 검증하는 도메인 서비스.
+ * Create/Update Post 핸들러가 공유한다.
+ */
+@Injectable()
+export class TagOwnershipValidator {
+  constructor(private readonly tagReadRepository: ITagReadRepository) {}
+
+  async validateOwnedByUser(userId: number, tagIds?: number[]): Promise<void> {
+    if (!tagIds?.length) {
+      return;
+    }
+
+    const uniqueIds = [...new Set(tagIds)];
+    const tags = await this.tagReadRepository.findByIdsAndUserId(
+      uniqueIds,
+      userId,
+    );
+    if (tags.length !== uniqueIds.length) {
+      throw new BadRequestException(
+        'One or more tags do not exist or are not owned by the user',
+      );
+    }
+  }
+}

--- a/apps/service/src/tags/tag-repository.provider.ts
+++ b/apps/service/src/tags/tag-repository.provider.ts
@@ -1,0 +1,10 @@
+import { Provider } from '@nestjs/common';
+import { ITagReadRepository } from './interface/tag-read-repository.interface';
+import { ITagWriteRepository } from './interface/tag-write-repository.interface';
+import { TagRepository } from './tag.repository';
+
+export const tagRepositoryProviders: Provider[] = [
+  TagRepository,
+  { provide: ITagReadRepository, useExisting: TagRepository },
+  { provide: ITagWriteRepository, useExisting: TagRepository },
+];

--- a/apps/service/src/tags/tag.repository.ts
+++ b/apps/service/src/tags/tag.repository.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, FindOptionsWhere, In } from 'typeorm';
+import { BaseRepository, Tag } from '@app/shared';
+import {
+  ITagReadRepository,
+  TagFilter,
+} from './interface/tag-read-repository.interface';
+import {
+  CreateTagInput,
+  ITagWriteRepository,
+  UpdateTagInput,
+} from './interface/tag-write-repository.interface';
+
+@Injectable()
+export class TagRepository
+  extends BaseRepository
+  implements ITagReadRepository, ITagWriteRepository
+{
+  constructor(dataSource: DataSource) {
+    super(dataSource);
+  }
+
+  private get tagRepository() {
+    return this.getRepository(Tag);
+  }
+
+  async findById(id: number): Promise<Tag | null> {
+    return this.tagRepository.findOneBy({ id });
+  }
+
+  async findByUserIdAndName(userId: number, name: string): Promise<Tag | null> {
+    return this.tagRepository.findOneBy({ userId, name });
+  }
+
+  async findByIdsAndUserId(ids: number[], userId: number): Promise<Tag[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    return this.tagRepository.findBy({ id: In(ids), userId });
+  }
+
+  async findAllPaginated(
+    page: number,
+    limit: number,
+    filter: TagFilter = {},
+  ): Promise<[Tag[], number]> {
+    const where: FindOptionsWhere<Tag> = {};
+
+    if (filter.userId !== undefined) {
+      where.userId = filter.userId;
+    }
+
+    return this.tagRepository.findAndCount({
+      where,
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { id: 'DESC' },
+    });
+  }
+
+  async create(input: CreateTagInput): Promise<Tag> {
+    const tag = this.tagRepository.create(input);
+    return this.tagRepository.save(tag);
+  }
+
+  async update(
+    id: number,
+    userId: number,
+    input: UpdateTagInput,
+  ): Promise<number> {
+    const result = await this.tagRepository.update({ id, userId }, input);
+    return result.affected ?? 0;
+  }
+
+  async delete(id: number, userId: number): Promise<number> {
+    const result = await this.tagRepository.delete({ id, userId });
+    return result.affected ?? 0;
+  }
+}

--- a/apps/service/src/tags/tags.controller.ts
+++ b/apps/service/src/tags/tags.controller.ts
@@ -1,0 +1,130 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiHeader,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { Idempotent } from '@app/shared';
+import { PaginatedResponseDto } from '@app/shared';
+import { JwtAuthGuard } from '@service/auth/guard/jwt-auth.guard';
+import { CurrentUser } from '@service/auth/decorator/current-user.decorator';
+import { AuthUser } from '@service/auth/decorator/auth-user.type';
+import { CreateTagCommand } from './command/create-tag.command';
+import { UpdateTagCommand } from './command/update-tag.command';
+import { DeleteTagCommand } from './command/delete-tag.command';
+import { GetTagByIdQuery } from './query/get-tag-by-id.query';
+import { FindAllTagsPaginatedQuery } from './query/find-all-tags-paginated.query';
+import { CreateTagRequestDto } from './dto/request/create-tag.request.dto';
+import { UpdateTagRequestDto } from './dto/request/update-tag.request.dto';
+import { TagsPaginationRequestDto } from './dto/request/find-tags.request.dto';
+import { TagResponseDto } from './dto/response/tag.response.dto';
+import { CreateTagResponseDto } from './dto/response/create-tag.response.dto';
+
+@ApiTags('Tags')
+@ApiBearerAuth()
+@ApiUnauthorizedResponse({ description: '인증되지 않은 요청' })
+@UseGuards(JwtAuthGuard)
+@Controller('tags')
+export class TagsController {
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: '태그 페이지네이션 조회' })
+  @ApiOkResponse({ type: PaginatedResponseDto })
+  async findAllPaginated(
+    @CurrentUser() user: AuthUser,
+    @Query() dto: TagsPaginationRequestDto,
+  ): Promise<PaginatedResponseDto<TagResponseDto>> {
+    return this.queryBus.execute(
+      new FindAllTagsPaginatedQuery(dto.page, dto.limit, {
+        userId: user.id,
+      }),
+    );
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'ID로 태그 조회' })
+  @ApiOkResponse({ type: TagResponseDto })
+  @ApiNotFoundResponse({ description: '태그를 찾을 수 없음' })
+  async getTagById(
+    @CurrentUser() user: AuthUser,
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<TagResponseDto> {
+    return this.queryBus.execute(new GetTagByIdQuery(user.id, id));
+  }
+
+  @Post()
+  @Idempotent()
+  @ApiHeader({
+    name: 'Idempotency-Key',
+    required: true,
+    description: 'UUID v4 형식의 멱등성 키',
+  })
+  @ApiOperation({ summary: '태그 생성' })
+  @ApiCreatedResponse({ type: CreateTagResponseDto })
+  @ApiBadRequestResponse({ description: '잘못된 요청' })
+  @ApiConflictResponse({
+    description:
+      '중복된 태그 이름 또는 동일 Idempotency-Key로 동시 요청 처리 중',
+  })
+  async createTag(
+    @CurrentUser() user: AuthUser,
+    @Body() dto: CreateTagRequestDto,
+  ): Promise<CreateTagResponseDto> {
+    const id = await this.commandBus.execute<CreateTagCommand, number>(
+      new CreateTagCommand(user.id, dto.name),
+    );
+    return CreateTagResponseDto.of(id);
+  }
+
+  @Patch(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: '태그 수정' })
+  @ApiNoContentResponse({ description: '수정 성공' })
+  @ApiNotFoundResponse({ description: '태그를 찾을 수 없음' })
+  @ApiBadRequestResponse({ description: '잘못된 요청' })
+  async updateTag(
+    @CurrentUser() user: AuthUser,
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateTagRequestDto,
+  ): Promise<void> {
+    await this.commandBus.execute(new UpdateTagCommand(user.id, id, dto.name));
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: '태그 삭제' })
+  @ApiNoContentResponse({ description: '삭제 성공' })
+  @ApiNotFoundResponse({ description: '태그를 찾을 수 없음' })
+  async deleteTag(
+    @CurrentUser() user: AuthUser,
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<void> {
+    await this.commandBus.execute(new DeleteTagCommand(user.id, id));
+  }
+}

--- a/apps/service/src/tags/tags.module.ts
+++ b/apps/service/src/tags/tags.module.ts
@@ -9,7 +9,7 @@ import { DeleteTagHandler } from './command/delete-tag.handler';
 import { GetTagByIdHandler } from './query/get-tag-by-id.handler';
 import { FindAllTagsPaginatedHandler } from './query/find-all-tags-paginated.handler';
 import { tagRepositoryProviders } from './tag-repository.provider';
-import { ITagReadRepository } from './interface/tag-read-repository.interface';
+import { TagOwnershipValidator } from './tag-ownership.validator';
 
 const commandHandlers = [CreateTagHandler, UpdateTagHandler, DeleteTagHandler];
 
@@ -18,7 +18,12 @@ const queryHandlers = [GetTagByIdHandler, FindAllTagsPaginatedHandler];
 @Module({
   imports: [CqrsModule, AuthModule, AppCacheModule],
   controllers: [TagsController],
-  providers: [...commandHandlers, ...queryHandlers, ...tagRepositoryProviders],
-  exports: [ITagReadRepository],
+  providers: [
+    ...commandHandlers,
+    ...queryHandlers,
+    ...tagRepositoryProviders,
+    TagOwnershipValidator,
+  ],
+  exports: [TagOwnershipValidator],
 })
 export class TagsModule {}

--- a/apps/service/src/tags/tags.module.ts
+++ b/apps/service/src/tags/tags.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { AuthModule } from '@service/auth/auth.module';
+import { AppCacheModule } from '@app/shared';
+import { TagsController } from './tags.controller';
+import { CreateTagHandler } from './command/create-tag.handler';
+import { UpdateTagHandler } from './command/update-tag.handler';
+import { DeleteTagHandler } from './command/delete-tag.handler';
+import { GetTagByIdHandler } from './query/get-tag-by-id.handler';
+import { FindAllTagsPaginatedHandler } from './query/find-all-tags-paginated.handler';
+import { tagRepositoryProviders } from './tag-repository.provider';
+import { ITagReadRepository } from './interface/tag-read-repository.interface';
+
+const commandHandlers = [CreateTagHandler, UpdateTagHandler, DeleteTagHandler];
+
+const queryHandlers = [GetTagByIdHandler, FindAllTagsPaginatedHandler];
+
+@Module({
+  imports: [CqrsModule, AuthModule, AppCacheModule],
+  controllers: [TagsController],
+  providers: [...commandHandlers, ...queryHandlers, ...tagRepositoryProviders],
+  exports: [ITagReadRepository],
+})
+export class TagsModule {}

--- a/libs/shared/src/database/typeorm.config.ts
+++ b/libs/shared/src/database/typeorm.config.ts
@@ -4,8 +4,9 @@ import { User } from '../entities/user.entity';
 import { Post } from '../entities/post.entity';
 import { Admin } from '../entities/admin.entity';
 import { OAuthAccount } from '../entities/oauth-account.entity';
+import { Tag } from '../entities/tag.entity';
 
-const entities = [User, Post, Admin, OAuthAccount];
+const entities = [User, Post, Admin, OAuthAccount, Tag];
 
 export function createDataSourceOptions(
   env: Record<string, string | undefined>,

--- a/libs/shared/src/entities/post.entity.ts
+++ b/libs/shared/src/entities/post.entity.ts
@@ -4,10 +4,13 @@ import {
   Entity,
   Index,
   JoinColumn,
+  JoinTable,
+  ManyToMany,
   ManyToOne,
 } from 'typeorm';
 import type { Relation } from 'typeorm';
 import { User } from './user.entity';
+import { Tag } from './tag.entity';
 import { BaseTimeEntity } from './base.entity';
 
 @Entity('posts')
@@ -31,6 +34,10 @@ export class Post extends BaseTimeEntity {
 
   @Column({ default: false })
   isPublished: boolean;
+
+  @ManyToMany(() => Tag, (tag) => tag.posts)
+  @JoinTable({ name: 'post_tags', synchronize: false })
+  tags: Relation<Tag[]>;
 
   @DeleteDateColumn()
   deletedAt: Date | null;

--- a/libs/shared/src/entities/tag.entity.ts
+++ b/libs/shared/src/entities/tag.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToMany,
+  ManyToOne,
+} from 'typeorm';
+import type { Relation } from 'typeorm';
+import { User } from './user.entity';
+import { Post } from './post.entity';
+import { BaseTimeEntity } from './base.entity';
+
+@Entity('tags')
+@Index('UQ_tags_user_id_name', ['userId', 'name'], { unique: true })
+export class Tag extends BaseTimeEntity {
+  @Column()
+  userId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  user: Relation<User>;
+
+  @Column({ length: 50 })
+  name: string;
+
+  @ManyToMany(() => Post, (post) => post.tags)
+  posts: Relation<Post[]>;
+}

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -2,6 +2,7 @@
 export { BaseTimeEntity } from './entities/base.entity';
 export { User } from './entities/user.entity';
 export { Post } from './entities/post.entity';
+export { Tag } from './entities/tag.entity';
 export { Admin } from './entities/admin.entity';
 export { OAuthAccount } from './entities/oauth-account.entity';
 

--- a/libs/shared/src/migrations/1779529302473-CreateTagAndPostTagTables.ts
+++ b/libs/shared/src/migrations/1779529302473-CreateTagAndPostTagTables.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTagAndPostTagTables1779529302473 implements MigrationInterface {
+  name = 'CreateTagAndPostTagTables1779529302473';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "tags" ("id" SERIAL NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "user_id" integer NOT NULL, "name" character varying(50) NOT NULL, CONSTRAINT "PK_e7dc17249a1148a1970748eda99" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_tags_user_id_name" ON "tags" ("user_id", "name") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "post_tags" ("posts_id" integer NOT NULL, "tags_id" integer NOT NULL, CONSTRAINT "PK_297a2aa2d29337748de4b075e55" PRIMARY KEY ("posts_id", "tags_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_493a35163a3681947bc2519f7c" ON "post_tags" ("posts_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0e926b96ace9d137603da0a102" ON "post_tags" ("tags_id") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tags" ADD CONSTRAINT "FK_74603743868d1e4f4fc2c0225b6" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post_tags" ADD CONSTRAINT "FK_493a35163a3681947bc2519f7c5" FOREIGN KEY ("posts_id") REFERENCES "posts"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post_tags" ADD CONSTRAINT "FK_0e926b96ace9d137603da0a1025" FOREIGN KEY ("tags_id") REFERENCES "tags"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "post_tags" DROP CONSTRAINT "FK_0e926b96ace9d137603da0a1025"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post_tags" DROP CONSTRAINT "FK_493a35163a3681947bc2519f7c5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tags" DROP CONSTRAINT "FK_74603743868d1e4f4fc2c0225b6"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0e926b96ace9d137603da0a102"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_493a35163a3681947bc2519f7c"`,
+    );
+    await queryRunner.query(`DROP TABLE "post_tags"`);
+    await queryRunner.query(`DROP INDEX "public"."UQ_tags_user_id_name"`);
+    await queryRunner.query(`DROP TABLE "tags"`);
+  }
+}

--- a/test/service/posts.integration-spec.ts
+++ b/test/service/posts.integration-spec.ts
@@ -768,4 +768,244 @@ describe('Posts (integration)', () => {
       expect(getRes.body.title).toBe('Keep');
     });
   });
+
+  // ============================================================
+  // Posts ↔ Tags (M:N integration)
+  // ============================================================
+  describe('Posts <-> Tags', () => {
+    let token: string;
+
+    function createTag(t: string, name: string) {
+      return request(app.getHttpServer())
+        .post('/v1/tags')
+        .set('Authorization', `Bearer ${t}`)
+        .set('Idempotency-Key', crypto.randomUUID())
+        .send({ name });
+    }
+
+    async function createTagAndGetId(t: string, name: string): Promise<number> {
+      const res = await createTag(t, name).expect(201);
+      return res.body.id as number;
+    }
+
+    beforeEach(async () => {
+      const tokens = await registerAndLogin();
+      token = tokens.accessToken;
+    });
+
+    it('소유한 tagIds로 게시글을 생성하면 GET 시 tags가 채워진다', async () => {
+      const tagId1 = await createTagAndGetId(token, 'nestjs');
+      const tagId2 = await createTagAndGetId(token, 'typescript');
+
+      const getRes = await createAndGet(token, {
+        title: 'Tagged Post',
+        tagIds: [tagId1, tagId2],
+      });
+
+      expect(getRes.body.tags).toHaveLength(2);
+      const names = (getRes.body.tags as Array<{ name: string }>)
+        .map((t) => t.name)
+        .sort();
+      expect(names).toEqual(['nestjs', 'typescript']);
+    });
+
+    it('tagIds가 없으면 tags는 빈 배열이다', async () => {
+      const getRes = await createAndGet(token, { title: 'No Tags' });
+
+      expect(getRes.body.tags).toEqual([]);
+    });
+
+    it('소유하지 않은 tagId로 게시글을 생성하면 400을 반환한다', async () => {
+      const ownTagId = await createTagAndGetId(token, 'mine');
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+      const otherTagId = await createTagAndGetId(tokens2.accessToken, 'theirs');
+
+      await createPost(token, {
+        title: 'Steal Tag',
+        tagIds: [ownTagId, otherTagId],
+      }).expect(400);
+    });
+
+    it('존재하지 않는 tagId로 게시글을 생성하면 400을 반환한다', async () => {
+      await createPost(token, {
+        title: 'Ghost Tag',
+        tagIds: [99999],
+      }).expect(400);
+    });
+
+    it('소유하지 않은 tagId로 게시글을 수정하면 400을 반환한다', async () => {
+      const createRes = await createPost(token, { title: 'Editable' }).expect(
+        201,
+      );
+      const postId = createRes.body.id as number;
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+      const otherTagId = await createTagAndGetId(tokens2.accessToken, 'theirs');
+
+      await request(app.getHttpServer())
+        .patch(`/v1/posts/${postId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          title: 'Editable',
+          content: 'Default Content',
+          isPublished: false,
+          tagIds: [otherTagId],
+        })
+        .expect(400);
+    });
+
+    it('tagIds를 교체하면 게시글의 tags가 변경된다', async () => {
+      const tagId1 = await createTagAndGetId(token, 'first');
+      const tagId2 = await createTagAndGetId(token, 'second');
+
+      const createRes = await createPost(token, {
+        title: 'Replace Tags',
+        tagIds: [tagId1],
+      }).expect(201);
+      const postId = createRes.body.id as number;
+
+      await request(app.getHttpServer())
+        .patch(`/v1/posts/${postId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          title: 'Replace Tags',
+          content: 'Default Content',
+          isPublished: false,
+          tagIds: [tagId2],
+        })
+        .expect(204);
+
+      const getRes = await request(app.getHttpServer())
+        .get(`/v1/posts/${postId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(getRes.body.tags).toHaveLength(1);
+      expect(getRes.body.tags[0].name).toBe('second');
+    });
+
+    it('tagIds: []로 수정하면 게시글의 tags가 비워진다', async () => {
+      const tagId1 = await createTagAndGetId(token, 'first');
+
+      const createRes = await createPost(token, {
+        title: 'Clear Tags',
+        tagIds: [tagId1],
+      }).expect(201);
+      const postId = createRes.body.id as number;
+
+      await request(app.getHttpServer())
+        .patch(`/v1/posts/${postId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          title: 'Clear Tags',
+          content: 'Default Content',
+          isPublished: false,
+          tagIds: [],
+        })
+        .expect(204);
+
+      const getRes = await request(app.getHttpServer())
+        .get(`/v1/posts/${postId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(getRes.body.tags).toEqual([]);
+    });
+
+    it('GET /posts?tagId=X는 해당 태그를 가진 게시글만 반환하고 각 게시글은 전체 태그를 보여준다', async () => {
+      const tagId1 = await createTagAndGetId(token, 'target');
+      const tagId2 = await createTagAndGetId(token, 'extra');
+
+      await createPost(token, {
+        title: 'Has Target',
+        tagIds: [tagId1, tagId2],
+      }).expect(201);
+      await createPost(token, {
+        title: 'No Target',
+        tagIds: [tagId2],
+      }).expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get(`/v1/posts?tagId=${tagId1}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].title).toBe('Has Target');
+      expect(res.body.meta.totalElements).toBe(1);
+
+      const names = (res.body.items[0].tags as Array<{ name: string }>)
+        .map((t) => t.name)
+        .sort();
+      expect(names).toEqual(['extra', 'target']);
+    });
+
+    it('동일 page/limit으로 서로 다른 tagId를 연속 조회해도 캐시가 충돌하지 않는다', async () => {
+      const tagIdA = await createTagAndGetId(token, 'alpha');
+      const tagIdB = await createTagAndGetId(token, 'beta');
+
+      await createPost(token, {
+        title: 'Only Alpha',
+        tagIds: [tagIdA],
+      }).expect(201);
+      await createPost(token, {
+        title: 'Only Beta',
+        tagIds: [tagIdB],
+      }).expect(201);
+
+      // tagId=A를 먼저 조회하여 캐시에 적재한다.
+      const resA = await request(app.getHttpServer())
+        .get(`/v1/posts?page=1&limit=10&tagId=${tagIdA}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(resA.body.items).toHaveLength(1);
+      expect(resA.body.items[0].title).toBe('Only Alpha');
+
+      // 같은 page/limit으로 tagId=B 조회 — 캐시 키에 tagId가 누락되면 A 결과가 반환된다.
+      const resB = await request(app.getHttpServer())
+        .get(`/v1/posts?page=1&limit=10&tagId=${tagIdB}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(resB.body.items).toHaveLength(1);
+      expect(resB.body.items[0].title).toBe('Only Beta');
+
+      // 필터 없는 조회는 두 게시글 모두 반환한다 (tagId='all' 키).
+      const resAll = await request(app.getHttpServer())
+        .get(`/v1/posts?page=1&limit=10`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(resAll.body.meta.totalElements).toBe(2);
+    });
+
+    it('태그를 삭제하면 해당 태그를 참조하던 게시글에서 제거된다 (FK CASCADE)', async () => {
+      const tagId1 = await createTagAndGetId(token, 'to-delete');
+      const tagId2 = await createTagAndGetId(token, 'to-keep');
+
+      const createRes = await createPost(token, {
+        title: 'Cascade Post',
+        tagIds: [tagId1, tagId2],
+      }).expect(201);
+      const postId = createRes.body.id as number;
+
+      await request(app.getHttpServer())
+        .delete(`/v1/tags/${tagId1}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204);
+
+      const getRes = await request(app.getHttpServer())
+        .get(`/v1/posts/${postId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(getRes.body.tags).toHaveLength(1);
+      expect(getRes.body.tags[0].name).toBe('to-keep');
+    });
+  });
 });

--- a/test/service/tags.integration-spec.ts
+++ b/test/service/tags.integration-spec.ts
@@ -1,0 +1,463 @@
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import {
+  createIntegrationApp,
+  useTransactionRollback,
+  TransactionHelper,
+} from '../setup/integration-helper';
+import { AppModule } from '../../apps/service/src/app.module';
+
+describe('Tags (integration)', () => {
+  let app: INestApplication<App>;
+  let txHelper: TransactionHelper;
+
+  beforeAll(async () => {
+    app = await createIntegrationApp(AppModule);
+    txHelper = useTransactionRollback(app);
+  });
+
+  beforeEach(() => txHelper.start());
+  afterEach(() => txHelper.rollback());
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  // ── 헬퍼 ─────────────────────────────────
+
+  const defaultUser = {
+    email: 'tag-test@example.com',
+    password: 'password123',
+    name: '테스트유저',
+  };
+
+  async function registerAndLogin(body: Record<string, unknown> = {}) {
+    const user = { ...defaultUser, ...body };
+    await request(app.getHttpServer())
+      .post('/v1/auth/register')
+      .send(user)
+      .expect(201);
+    const loginRes = await request(app.getHttpServer())
+      .post('/v1/auth/login')
+      .send({ email: user.email, password: user.password })
+      .expect(200);
+    return loginRes.body as { accessToken: string; refreshToken: string };
+  }
+
+  function createTag(token: string, body: Record<string, unknown> = {}) {
+    return request(app.getHttpServer())
+      .post('/v1/tags')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Idempotency-Key', crypto.randomUUID())
+      .send({ name: 'default-tag', ...body });
+  }
+
+  // ============================================================
+  // 인증 없이 요청 시 401
+  // ============================================================
+  describe('Authentication required', () => {
+    it('토큰 없이 GET /tags 호출 시 401을 반환한다', () => {
+      return request(app.getHttpServer()).get('/v1/tags').expect(401);
+    });
+
+    it('토큰 없이 GET /tags/:id 호출 시 401을 반환한다', () => {
+      return request(app.getHttpServer()).get('/v1/tags/1').expect(401);
+    });
+
+    it('토큰 없이 POST /tags 호출 시 401을 반환한다', () => {
+      return request(app.getHttpServer())
+        .post('/v1/tags')
+        .send({ name: 'nestjs' })
+        .expect(401);
+    });
+
+    it('토큰 없이 PATCH /tags/:id 호출 시 401을 반환한다', () => {
+      return request(app.getHttpServer())
+        .patch('/v1/tags/1')
+        .send({ name: 'nestjs' })
+        .expect(401);
+    });
+
+    it('토큰 없이 DELETE /tags/:id 호출 시 401을 반환한다', () => {
+      return request(app.getHttpServer()).delete('/v1/tags/1').expect(401);
+    });
+  });
+
+  // ============================================================
+  // POST /tags
+  // ============================================================
+  describe('POST /tags', () => {
+    let token: string;
+
+    beforeEach(async () => {
+      const tokens = await registerAndLogin();
+      token = tokens.accessToken;
+    });
+
+    it('태그를 생성하고 { id }를 반환한다', async () => {
+      const res = await createTag(token, { name: 'nestjs' }).expect(201);
+
+      expect(res.body.id).toBeDefined();
+      expect(typeof res.body.id).toBe('number');
+      expect(Object.keys(res.body)).toEqual(['id']);
+    });
+
+    it('생성한 태그는 GET으로 조회된다', async () => {
+      const createRes = await createTag(token, { name: 'nestjs' }).expect(201);
+      const id = createRes.body.id as number;
+
+      const getRes = await request(app.getHttpServer())
+        .get(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(getRes.body.id).toBe(id);
+      expect(getRes.body.name).toBe('nestjs');
+      expect(typeof getRes.body.userId).toBe('number');
+      expect(getRes.body.createdAt).toBeDefined();
+      expect(getRes.body.updatedAt).toBeDefined();
+    });
+
+    it('같은 사용자가 중복된 이름으로 생성하면 409를 반환한다', async () => {
+      await createTag(token, { name: 'duplicate' }).expect(201);
+
+      const res = await createTag(token, { name: 'duplicate' }).expect(409);
+
+      expect(res.body.message).toContain('duplicate');
+    });
+
+    it('다른 사용자는 동일한 이름의 태그를 생성할 수 있다 (사용자별 격리)', async () => {
+      await createTag(token, { name: 'shared' }).expect(201);
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+
+      await createTag(tokens2.accessToken, { name: 'shared' }).expect(201);
+    });
+
+    it('이름이 빈 문자열이면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .post('/v1/tags')
+        .set('Authorization', `Bearer ${token}`)
+        .set('Idempotency-Key', crypto.randomUUID())
+        .send({ name: '' })
+        .expect(400);
+    });
+
+    it('이름 필드가 누락되면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .post('/v1/tags')
+        .set('Authorization', `Bearer ${token}`)
+        .set('Idempotency-Key', crypto.randomUUID())
+        .send({})
+        .expect(400);
+    });
+
+    it('이름이 51자이면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .post('/v1/tags')
+        .set('Authorization', `Bearer ${token}`)
+        .set('Idempotency-Key', crypto.randomUUID())
+        .send({ name: 'a'.repeat(51) })
+        .expect(400);
+    });
+
+    it('이름이 50자이면 201을 반환한다 (최대 길이 허용)', async () => {
+      const maxName = 'a'.repeat(50);
+      const createRes = await createTag(token, { name: maxName }).expect(201);
+
+      const getRes = await request(app.getHttpServer())
+        .get(`/v1/tags/${createRes.body.id as number}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(getRes.body.name).toBe(maxName);
+    });
+
+    it('허용되지 않은 속성이 포함되면 400을 반환한다 (forbidNonWhitelisted)', () => {
+      return request(app.getHttpServer())
+        .post('/v1/tags')
+        .set('Authorization', `Bearer ${token}`)
+        .set('Idempotency-Key', crypto.randomUUID())
+        .send({ name: 'nestjs', hacked: true })
+        .expect(400);
+    });
+  });
+
+  // ============================================================
+  // GET /tags (pagination)
+  // ============================================================
+  describe('GET /tags', () => {
+    let token: string;
+
+    beforeEach(async () => {
+      const tokens = await registerAndLogin();
+      token = tokens.accessToken;
+    });
+
+    it('기본 page=1, limit=10으로 페이지네이션 응답을 반환한다', async () => {
+      await createTag(token, { name: 'tag-a' }).expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/tags')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body).toHaveProperty('items');
+      expect(res.body).toHaveProperty('meta');
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.meta.page).toBe(1);
+      expect(res.body.meta.limit).toBe(10);
+      expect(res.body.meta.totalElements).toBe(1);
+      expect(res.body.meta.totalPages).toBe(1);
+      expect(res.body.meta.isFirst).toBe(true);
+      expect(res.body.meta.isLast).toBe(true);
+    });
+
+    it('태그가 없으면 빈 items를 반환한다', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/v1/tags')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.items).toEqual([]);
+      expect(res.body.meta.totalElements).toBe(0);
+      expect(res.body.meta.totalPages).toBe(0);
+    });
+
+    it('custom page와 limit으로 페이지네이션한다', async () => {
+      for (let i = 0; i < 5; i++) {
+        await createTag(token, { name: `tag-${i + 1}` }).expect(201);
+      }
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/tags?page=2&limit=2')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.items).toHaveLength(2);
+      expect(res.body.meta.page).toBe(2);
+      expect(res.body.meta.limit).toBe(2);
+      expect(res.body.meta.totalElements).toBe(5);
+      expect(res.body.meta.totalPages).toBe(3);
+      expect(res.body.meta.isFirst).toBe(false);
+      expect(res.body.meta.isLast).toBe(false);
+    });
+
+    it('인증된 사용자가 생성한 태그만 반환한다 (사용자 격리)', async () => {
+      await createTag(token, { name: 'my-tag' }).expect(201);
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+      await createTag(tokens2.accessToken, { name: 'other-tag' }).expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/tags')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].name).toBe('my-tag');
+      expect(res.body.meta.totalElements).toBe(1);
+    });
+
+    it('다른 사용자의 태그는 보이지 않는다', async () => {
+      await createTag(token, { name: 'user1-tag' }).expect(201);
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/v1/tags')
+        .set('Authorization', `Bearer ${tokens2.accessToken}`)
+        .expect(200);
+
+      expect(res.body.items).toHaveLength(0);
+      expect(res.body.meta.totalElements).toBe(0);
+    });
+  });
+
+  // ============================================================
+  // GET /tags/:id
+  // ============================================================
+  describe('GET /tags/:id', () => {
+    let token: string;
+
+    beforeEach(async () => {
+      const tokens = await registerAndLogin();
+      token = tokens.accessToken;
+    });
+
+    it('존재하지 않는 태그를 조회하면 404를 반환한다', () => {
+      return request(app.getHttpServer())
+        .get('/v1/tags/99999')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+
+    it('다른 사용자의 태그를 조회하면 404를 반환한다', async () => {
+      const createRes = await createTag(token, { name: 'private' }).expect(201);
+      const id = createRes.body.id as number;
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${tokens2.accessToken}`)
+        .expect(404);
+    });
+
+    it('숫자가 아닌 id면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .get('/v1/tags/abc')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(400);
+    });
+  });
+
+  // ============================================================
+  // PATCH /tags/:id
+  // ============================================================
+  describe('PATCH /tags/:id', () => {
+    let token: string;
+
+    beforeEach(async () => {
+      const tokens = await registerAndLogin();
+      token = tokens.accessToken;
+    });
+
+    it('태그 이름을 수정하고 204를 반환하며 GET에 반영된다', async () => {
+      const createRes = await createTag(token, { name: 'before' }).expect(201);
+      const id = createRes.body.id as number;
+
+      await request(app.getHttpServer())
+        .patch(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'after' })
+        .expect(204);
+
+      const getRes = await request(app.getHttpServer())
+        .get(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(getRes.body.name).toBe('after');
+    });
+
+    it('존재하지 않는 태그를 수정하면 404를 반환한다', () => {
+      return request(app.getHttpServer())
+        .patch('/v1/tags/99999')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'whatever' })
+        .expect(404);
+    });
+
+    it('다른 사용자의 태그를 수정하면 404를 반환한다', async () => {
+      const createRes = await createTag(token, { name: 'mine' }).expect(201);
+      const id = createRes.body.id as number;
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+
+      await request(app.getHttpServer())
+        .patch(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${tokens2.accessToken}`)
+        .send({ name: 'hijacked' })
+        .expect(404);
+    });
+
+    it('이름이 빈 문자열이면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .patch('/v1/tags/1')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: '' })
+        .expect(400);
+    });
+
+    it('이름이 51자이면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .patch('/v1/tags/1')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'a'.repeat(51) })
+        .expect(400);
+    });
+
+    it('숫자가 아닌 id면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .patch('/v1/tags/abc')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'valid' })
+        .expect(400);
+    });
+  });
+
+  // ============================================================
+  // DELETE /tags/:id
+  // ============================================================
+  describe('DELETE /tags/:id', () => {
+    let token: string;
+
+    beforeEach(async () => {
+      const tokens = await registerAndLogin();
+      token = tokens.accessToken;
+    });
+
+    it('태그를 삭제하고 204를 반환하며 이후 GET은 404가 된다', async () => {
+      const createRes = await createTag(token, { name: 'delete-me' }).expect(
+        201,
+      );
+      const id = createRes.body.id as number;
+
+      await request(app.getHttpServer())
+        .delete(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204);
+
+      await request(app.getHttpServer())
+        .get(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+
+    it('존재하지 않는 태그를 삭제하면 404를 반환한다', () => {
+      return request(app.getHttpServer())
+        .delete('/v1/tags/99999')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+
+    it('다른 사용자의 태그를 삭제하면 404를 반환한다', async () => {
+      const createRes = await createTag(token, { name: 'mine' }).expect(201);
+      const id = createRes.body.id as number;
+
+      const tokens2 = await registerAndLogin({
+        email: 'other@example.com',
+        name: '다른유저',
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${tokens2.accessToken}`)
+        .expect(404);
+    });
+
+    it('숫자가 아닌 id면 400을 반환한다', () => {
+      return request(app.getHttpServer())
+        .delete('/v1/tags/abc')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(400);
+    });
+  });
+});

--- a/test/service/tags.integration-spec.ts
+++ b/test/service/tags.integration-spec.ts
@@ -378,6 +378,18 @@ describe('Tags (integration)', () => {
         .expect(404);
     });
 
+    it('이미 존재하는 이름으로 수정하면 409를 반환한다', async () => {
+      await createTag(token, { name: 'existing' }).expect(201);
+      const createRes = await createTag(token, { name: 'target' }).expect(201);
+      const id = createRes.body.id as number;
+
+      await request(app.getHttpServer())
+        .patch(`/v1/tags/${id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'existing' })
+        .expect(409);
+    });
+
     it('이름이 빈 문자열이면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .patch('/v1/tags/1')


### PR DESCRIPTION
## 개요
게시물에 태그 기능을 추가합니다. 태그는 **사용자별로 독립 관리**되며 **자체 CRUD**가 가능하고, 게시물과 **M:N**으로 연동됩니다.

`hotfix/post-tags` (base: `origin/main`) — origin/dev가 stale하여 main 기준으로 작업.

## 변경 사항

### DB 스키마
- `Tag` 엔티티: 사용자별 `(userId, name)` 유니크, 하드 삭제(soft delete 없음), `userId` FK `ON DELETE CASCADE`
- `post_tags` M:N 조인 테이블: 양쪽 FK `ON DELETE CASCADE`, 조인 컬럼 `posts_id`/`tags_id` (TypeORM `@JoinTable` 기본 명명)
- 마이그레이션 `1779529302473-CreateTagAndPostTagTables` — 실제 로컬 Postgres 적용+롤백 검증 완료
- `@JoinTable({ synchronize: false })`로 `migration:generate` 회귀 방지

### Tag CRUD 모듈 (`apps/service/src/tags/`)
- 기존 Posts 모듈과 동일한 Repository Pattern(ISP, `useExisting`) + CQRS 구조
- `POST/GET/GET :id/PATCH/DELETE /v1/tags` — 생성 201, 수정/삭제 204, 멱등성 키 적용
- 사용자 격리: 모든 조회/수정/삭제가 `userId` 스코프, 캐시 키에 `userId` 포함

### 게시물 연동
- 생성/수정 시 `tagIds`로 태그 연결 — `ITagReadRepository.findByIdsAndUserId`로 **소유권 검증**(미소유/미존재 시 400)
- `PostResponseDto.tags`로 응답에 태그 포함
- `GET /v1/posts?tagId=X` 필터 (관계 조인 기반 — 조인 컬럼명 하드코딩 없음)

## 코드 리뷰 반영
- 🔴 **캐시 정합 버그 수정**: 목록 캐시 키에 `tagId` 포함 (서로 다른 태그 필터 쿼리 충돌 방지)
- 🟡 **다중 write 원자성**: `PostRepository.create`/`update`에 `@Transactional()` 적용
- 🟡 **회귀 테스트 추가**: 동일 page/limit으로 서로 다른 `tagId` 연속 조회 시 캐시 미충돌 검증

## 검증
- `pnpm build:all` ✅ / `pnpm lint:check` ✅
- 단위 테스트 **122** ✅ (Tag 핸들러/DTO +19)
- 통합 테스트 service **154** ✅ / back-office **34** ✅
- verify 스킬 전부 PASS: handler-structure / db-safety / restful-api / api-compat
- code-reviewer fresh review 반영 완료

## 멀티 에이전트 작업
워크트리 격리 + 멀티 에이전트 파이프라인으로 진행: postgres-db-normalizer(스키마) → nestjs-expert ×2 병렬(Tag 모듈 / Post 연동) → tdd-test-writer(테스트) → code-reviewer(검토).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 태그 생성, 조회, 수정, 삭제 API 추가 (인증 필요)
  * 게시글 작성/수정 시 태그 지정(tagIds) 가능 및 각 게시글에 연결된 태그 표시
  * 게시글 목록을 태그로 필터링하는 기능 추가

* **버그 수정 / 동작 개선**
  * 타사용 태그 또는 존재하지 않는 태그 사용 시 요청이 거부되어 무결성 보장(400)
  * 태그 삭제 시 관련 게시글의 태그 연관관계가 제거됨 (연쇄 동작)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inkweon7269/nest-repository-pattern/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->