### PR TITLE
docs(agent-memory): M:N @JoinTable inverse FK CASCADE 패턴 기록

### DIFF
--- a/.claude/agent-memory/postgres-db-normalizer/MEMORY.md
+++ b/.claude/agent-memory/postgres-db-normalizer/MEMORY.md
@@ -1,2 +1,3 @@
 - [nullable union type에 type 명시 필요](feedback_nullable_varchar.md) — `string | null` 컬럼은 반드시 `type: 'varchar'` 명시, 미명시 시 TypeORM이 "Object"로 추론하여 migration:generate 실패
 - [SnakeNamingStrategy 자동 변환](patterns_naming.md) — camelCase 프로퍼티명만 선언하면 DB 컬럼은 자동 snake_case 변환, @Column({ name: ... }) 수동 지정 금지
+- [M:N JoinTable 정션 FK CASCADE](patterns_manytomany_jointable.md) — @JoinTable inverse FK는 항상 NO ACTION, CASCADE 필요 시 마이그레이션 직접 작성 + synchronize:false로 회귀 방지. 정션 컬럼명은 posts_id/tags_id

--- a/.claude/agent-memory/postgres-db-normalizer/patterns_manytomany_jointable.md
+++ b/.claude/agent-memory/postgres-db-normalizer/patterns_manytomany_jointable.md
@@ -1,0 +1,23 @@
+---
+name: patterns-manytomany-jointable
+description: M:N @JoinTable 인버스 FK는 onDelete를 데코레이터로 못 박으므로 마이그레이션+synchronize:false 조합으로 CASCADE 유지
+metadata:
+  type: feedback
+---
+
+이 프로젝트에서 M:N 관계(`@ManyToMany` + `@JoinTable`)를 추가할 때 정션 테이블 FK의 `ON DELETE CASCADE`를 양쪽에 보장하려면 주의가 필요하다.
+
+**Why:**
+- `@JoinTable`은 정션 테이블 두 FK 중 **owning 쪽(`@JoinTable`이 달린 엔티티의 컬럼, 예: `posts_id`)만** `ON DELETE CASCADE`로 생성한다. **inverse 쪽 FK(예: `tags_id`)는 항상 `ON DELETE NO ACTION`** 으로 굳어지며, TypeORM 데코레이터로 이 동작을 바꿀 방법이 없다(`@JoinTable`에 per-FK onDelete 옵션 없음 — context7 TypeORM 문서 확인).
+- inverse FK가 NO ACTION이면, hard-delete 대상 엔티티(soft-delete 없는 Tag 등)를 삭제할 때 정션 행이 남아 FK 위반으로 삭제 실패.
+- 마이그레이션에서 inverse FK를 CASCADE로 수정하면, 다음 `migration:generate`가 엔티티 메타데이터(NO ACTION 기대)와 DB(CASCADE) 차이를 감지해 **DROP+ADD로 NO ACTION 되돌리는 회귀 마이그레이션을 생성**한다 (CLAUDE.md "DB 제약은 엔티티에 선언" 규칙과 충돌).
+
+**How to apply:**
+- 정션 테이블의 inverse FK까지 CASCADE가 필요하면:
+  1. 마이그레이션에서 inverse FK를 `ON DELETE CASCADE ON UPDATE CASCADE`로 직접 작성(생성된 NO ACTION을 손으로 교체).
+  2. owning 엔티티의 `@JoinTable`에 `synchronize: false`를 추가 → TypeORM이 정션 테이블을 diff 검사에서 제외하여 회귀 마이그레이션 생성 안 됨. 마이그레이션이 정션 테이블의 단일 진실 원천이 됨.
+  3. `migration:generate ... --dr`로 "No changes in database schema" 확인하여 회귀 없음 검증.
+- 정션 컬럼 명명: SnakeNamingStrategy의 정션 컬럼명은 `<참조테이블명>_id` 형태 → `posts` + `id` = **`posts_id`**, `tags` + `id` = **`tags_id`** (단수형 `post_id`/`tag_id` 아님). `@JoinTable({ name: 'post_tags' })`처럼 테이블명만 지정하고 joinColumn/inverseJoinColumn name 인자는 주지 않는다.
+- 검증: 마이그레이션 적용 후 `migration:revert`로 down()이 up()을 완전히 역순(FK→인덱스→테이블) 복구하는지 실DB에서 확인.
+
+관련: [[patterns-snake-naming-strategy]]

--- a/test/service/tags.integration-spec.ts
+++ b/test/service/tags.integration-spec.ts
@@ -30,6 +30,7 @@ describe('Tags (integration)', () => {
     email: 'tag-test@example.com',
     password: 'password123',
     name: '테스트유저',
+    marketingConsent: true,
   };
 
   async function registerAndLogin(body: Record<string, unknown> = {}) {


### PR DESCRIPTION
## 개요

`postgres-db-normalizer` 에이전트 메모리에 M:N 정션 테이블 inverse FK CASCADE 패턴을 기록하고, 더불어 main을 깨뜨리고 있던 tags 통합 테스트 실패를 함께 복구합니다.

## 변경 사항

**1. 에이전트 메모리 (docs)**
- `patterns_manytomany_jointable.md` (신규) — M:N `@JoinTable` inverse FK 함정 + 해결 패턴
- `MEMORY.md` — 위 노트 인덱스 한 줄 추가

**2. tags 통합 테스트 복구 (fix)**
- `test/service/tags.integration-spec.ts` — `registerAndLogin` 헬퍼의 `defaultUser`에 `marketingConsent: true` 추가

## 메모리 패턴 핵심

- `@JoinTable`은 owning 쪽 FK만 `ON DELETE CASCADE`로 생성, inverse FK(`tags_id`)는 항상 `NO ACTION`으로 굳어지며 데코레이터로 변경 불가
- inverse FK까지 CASCADE 필요 시 마이그레이션 직접 작성 + `@JoinTable`에 `synchronize: false`로 회귀 마이그레이션 방지

## 테스트 실패 복구 배경

- `#67`이 register에 필수 필드 `marketingConsent`를 추가했으나 `#68`의 tags 스펙 register 페이로드가 갱신되지 않음
- 두 PR이 서로의 변경을 반영하지 않고 순차 머지되며 `POST /v1/auth/register`가 400 → tags 스펙 28건 실패, **main CI가 red 상태**였음
- `defaultUser`에 `marketingConsent` 추가로 복구. 로컬 통합 테스트 **33건 통과** 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)