### PR TITLE
refactor(back-office): 토큰 발급 단일화 + admin auth 테스트 + 23505 헬퍼 추출

### DIFF
--- a/apps/back-office/src/auth/admin-token-issuer.service.spec.ts
+++ b/apps/back-office/src/auth/admin-token-issuer.service.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'crypto';
+import * as bcrypt from 'bcrypt';
+import { AdminTokenIssuer } from './admin-token-issuer.service';
+import { IAdminWriteRepository } from '@back-office/auth/interface/admin-write-repository.interface';
+import { Admin, AdminRole } from '@app/shared';
+
+jest.mock('bcrypt');
+
+describe('AdminTokenIssuer', () => {
+  let service: AdminTokenIssuer;
+  let adminWriteRepository: Mocked<IAdminWriteRepository>;
+  let jwtService: Mocked<JwtService>;
+  let configService: Mocked<ConfigService>;
+
+  const mockAdmin = {
+    id: 42,
+    email: 'admin@example.com',
+    password: 'hashed-password',
+    name: '관리자',
+    role: AdminRole.MANAGER,
+    hashedRefreshToken: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Admin;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const { unit, unitRef } =
+      await TestBed.solitary(AdminTokenIssuer).compile();
+
+    service = unit;
+    adminWriteRepository = unitRef.get<IAdminWriteRepository>(
+      IAdminWriteRepository as Type<IAdminWriteRepository>,
+    );
+    jwtService = unitRef.get(JwtService);
+    configService = unitRef.get(ConfigService);
+
+    jwtService.sign
+      .mockReturnValueOnce('access-token')
+      .mockReturnValueOnce('refresh-token');
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-refresh-token');
+    adminWriteRepository.update.mockResolvedValue(1);
+    configService.get.mockImplementation(
+      (key: string, defaultValue?: string) => {
+        if (key === 'JWT_ADMIN_ACCESS_EXPIRATION') return defaultValue ?? '15m';
+        if (key === 'JWT_ADMIN_REFRESH_EXPIRATION') return defaultValue ?? '7d';
+        return defaultValue;
+      },
+    );
+    configService.getOrThrow.mockImplementation((key: string) => {
+      if (key === 'JWT_ADMIN_ACCESS_SECRET') return 'test-admin-access-secret';
+      if (key === 'JWT_ADMIN_REFRESH_SECRET')
+        return 'test-admin-refresh-secret';
+      throw new Error(`Unexpected getOrThrow key: ${key}`);
+    });
+  });
+
+  it('access/refresh 토큰을 발급하고 payload에 role을 포함하며 hashedRefreshToken을 저장한다', async () => {
+    const result = await service.issueTokens(mockAdmin);
+
+    expect(result).toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+
+    expect(jwtService.sign).toHaveBeenCalledTimes(2);
+    expect(jwtService.sign).toHaveBeenNthCalledWith(
+      1,
+      { sub: 42, email: 'admin@example.com', role: AdminRole.MANAGER },
+      expect.objectContaining({
+        secret: 'test-admin-access-secret',
+        expiresIn: '15m',
+      }),
+    );
+    expect(jwtService.sign).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sub: 42,
+        email: 'admin@example.com',
+        role: AdminRole.MANAGER,
+        type: 'refresh',
+        jti: expect.any(String),
+      }),
+      expect.objectContaining({
+        secret: 'test-admin-refresh-secret',
+        expiresIn: '7d',
+      }),
+    );
+
+    const expectedDigest = createHash('sha256')
+      .update('refresh-token')
+      .digest('hex');
+    expect(bcrypt.hash).toHaveBeenCalledWith(expectedDigest, 10);
+    expect(adminWriteRepository.update).toHaveBeenCalledWith(42, {
+      hashedRefreshToken: 'hashed-refresh-token',
+    });
+  });
+
+  it('refresh 토큰의 jti는 호출마다 고유해야 한다', async () => {
+    jwtService.sign.mockReset();
+    jwtService.sign
+      .mockReturnValueOnce('a1')
+      .mockReturnValueOnce('r1')
+      .mockReturnValueOnce('a2')
+      .mockReturnValueOnce('r2');
+
+    await service.issueTokens(mockAdmin);
+    await service.issueTokens(mockAdmin);
+
+    const firstCall = jwtService.sign.mock.calls[1][0] as { jti: string };
+    const secondCall = jwtService.sign.mock.calls[3][0] as { jti: string };
+    expect(firstCall.jti).not.toEqual(secondCall.jti);
+  });
+});

--- a/apps/back-office/src/auth/admin-token-issuer.service.ts
+++ b/apps/back-office/src/auth/admin-token-issuer.service.ts
@@ -1,0 +1,60 @@
+import { createHash, randomUUID } from 'crypto';
+import { Injectable } from '@nestjs/common';
+import { JwtService, JwtSignOptions } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import { Admin, AuthTokens } from '@app/shared';
+import { IAdminWriteRepository } from '@back-office/auth/interface/admin-write-repository.interface';
+
+@Injectable()
+export class AdminTokenIssuer {
+  constructor(
+    private readonly adminWriteRepository: IAdminWriteRepository,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async issueTokens(admin: Admin): Promise<AuthTokens> {
+    const accessToken = this.generateAccessToken(admin);
+    const refreshToken = this.generateRefreshToken(admin);
+    await this.persistRefreshTokenDigest(admin.id, refreshToken);
+
+    return { accessToken, refreshToken };
+  }
+
+  private generateAccessToken(admin: Admin): string {
+    const payload = { sub: admin.id, email: admin.email, role: admin.role };
+    return this.jwtService.sign(payload, {
+      secret: this.configService.getOrThrow<string>('JWT_ADMIN_ACCESS_SECRET'),
+      expiresIn: this.configService.get<string>(
+        'JWT_ADMIN_ACCESS_EXPIRATION',
+        '15m',
+      ),
+    } as JwtSignOptions);
+  }
+
+  private generateRefreshToken(admin: Admin): string {
+    const payload = { sub: admin.id, email: admin.email, role: admin.role };
+    return this.jwtService.sign(
+      { ...payload, type: 'refresh', jti: randomUUID() },
+      {
+        secret: this.configService.getOrThrow<string>(
+          'JWT_ADMIN_REFRESH_SECRET',
+        ),
+        expiresIn: this.configService.get<string>(
+          'JWT_ADMIN_REFRESH_EXPIRATION',
+          '7d',
+        ),
+      } as JwtSignOptions,
+    );
+  }
+
+  private async persistRefreshTokenDigest(
+    adminId: number,
+    refreshToken: string,
+  ): Promise<void> {
+    const tokenDigest = createHash('sha256').update(refreshToken).digest('hex');
+    const hashedRefreshToken = await bcrypt.hash(tokenDigest, 10);
+    await this.adminWriteRepository.update(adminId, { hashedRefreshToken });
+  }
+}

--- a/apps/back-office/src/auth/admin.module.ts
+++ b/apps/back-office/src/auth/admin.module.ts
@@ -9,6 +9,7 @@ import { AdminRefreshTokenHandler } from './command/admin-refresh-token.handler'
 import { AdminLogoutHandler } from './command/admin-logout.handler';
 import { GetAdminProfileHandler } from './query/get-admin-profile.handler';
 import { adminRepositoryProviders } from './admin-repository.provider';
+import { AdminTokenIssuer } from './admin-token-issuer.service';
 import { AdminJwtStrategy } from './strategy/admin-jwt.strategy';
 import { AdminJwtAuthGuard } from './guard/admin-jwt-auth.guard';
 
@@ -28,6 +29,7 @@ const queryHandlers = [GetAdminProfileHandler];
     ...commandHandlers,
     ...queryHandlers,
     ...adminRepositoryProviders,
+    AdminTokenIssuer,
     AdminJwtStrategy,
     AdminJwtAuthGuard,
   ],

--- a/apps/back-office/src/auth/command/admin-login.handler.spec.ts
+++ b/apps/back-office/src/auth/command/admin-login.handler.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { UnauthorizedException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { AdminLoginHandler } from './admin-login.handler';
+import { AdminLoginCommand } from './admin-login.command';
+import { IAdminReadRepository } from '@back-office/auth/interface/admin-read-repository.interface';
+import { AdminTokenIssuer } from '@back-office/auth/admin-token-issuer.service';
+import { Admin, AdminRole } from '@app/shared';
+
+jest.mock('bcrypt');
+
+describe('AdminLoginHandler', () => {
+  let handler: AdminLoginHandler;
+  let adminReadRepository: Mocked<IAdminReadRepository>;
+  let tokenIssuer: Mocked<AdminTokenIssuer>;
+
+  const mockAdmin = {
+    id: 1,
+    email: 'admin@example.com',
+    password: 'hashed-password',
+    name: '관리자',
+    role: AdminRole.MANAGER,
+    hashedRefreshToken: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Admin;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const { unit, unitRef } =
+      await TestBed.solitary(AdminLoginHandler).compile();
+
+    handler = unit;
+    adminReadRepository = unitRef.get<IAdminReadRepository>(
+      IAdminReadRepository as Type<IAdminReadRepository>,
+    );
+    tokenIssuer = unitRef.get(AdminTokenIssuer);
+
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    tokenIssuer.issueTokens.mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+  });
+
+  it('유효한 이메일과 비밀번호면 AdminTokenIssuer로 위임하여 토큰 쌍을 반환한다', async () => {
+    adminReadRepository.findByEmail.mockResolvedValue(mockAdmin);
+
+    const command = new AdminLoginCommand('admin@example.com', 'password123');
+    const result = await handler.execute(command);
+
+    expect(result).toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+    expect(bcrypt.compare).toHaveBeenCalledWith(
+      'password123',
+      'hashed-password',
+    );
+    expect(tokenIssuer.issueTokens).toHaveBeenCalledWith(mockAdmin);
+  });
+
+  it('존재하지 않는 이메일이면 UnauthorizedException을 발생시킨다', async () => {
+    adminReadRepository.findByEmail.mockResolvedValue(null);
+
+    const command = new AdminLoginCommand('nobody@example.com', 'password123');
+
+    await expect(handler.execute(command)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(bcrypt.compare).not.toHaveBeenCalled();
+    expect(tokenIssuer.issueTokens).not.toHaveBeenCalled();
+  });
+
+  it('비밀번호가 틀리면 UnauthorizedException을 발생시킨다', async () => {
+    adminReadRepository.findByEmail.mockResolvedValue(mockAdmin);
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+    const command = new AdminLoginCommand('admin@example.com', 'wrongpassword');
+
+    await expect(handler.execute(command)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(tokenIssuer.issueTokens).not.toHaveBeenCalled();
+  });
+});

--- a/apps/back-office/src/auth/command/admin-login.handler.ts
+++ b/apps/back-office/src/auth/command/admin-login.handler.ts
@@ -35,7 +35,7 @@ export class AdminLoginHandler implements ICommandHandler<AdminLoginCommand> {
     const payload = { sub: admin.id, email: admin.email, role: admin.role };
 
     const accessToken = this.jwtService.sign(payload, {
-      secret: this.configService.get<string>('JWT_ADMIN_ACCESS_SECRET'),
+      secret: this.configService.getOrThrow<string>('JWT_ADMIN_ACCESS_SECRET'),
       expiresIn: this.configService.get<string>(
         'JWT_ADMIN_ACCESS_EXPIRATION',
         '15m',
@@ -45,7 +45,9 @@ export class AdminLoginHandler implements ICommandHandler<AdminLoginCommand> {
     const refreshToken = this.jwtService.sign(
       { ...payload, type: 'refresh', jti: randomUUID() },
       {
-        secret: this.configService.get<string>('JWT_ADMIN_REFRESH_SECRET'),
+        secret: this.configService.getOrThrow<string>(
+          'JWT_ADMIN_REFRESH_SECRET',
+        ),
         expiresIn: this.configService.get<string>(
           'JWT_ADMIN_REFRESH_EXPIRATION',
           '7d',

--- a/apps/back-office/src/auth/command/admin-login.handler.ts
+++ b/apps/back-office/src/auth/command/admin-login.handler.ts
@@ -1,64 +1,39 @@
-import { createHash, randomUUID } from 'crypto';
 import { UnauthorizedException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { JwtService, JwtSignOptions } from '@nestjs/jwt';
-import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
 import { AdminLoginCommand } from './admin-login.command';
 import { IAdminReadRepository } from '@back-office/auth/interface/admin-read-repository.interface';
-import { IAdminWriteRepository } from '@back-office/auth/interface/admin-write-repository.interface';
-import { AuthTokens } from '@app/shared';
+import { AdminTokenIssuer } from '@back-office/auth/admin-token-issuer.service';
+import { Admin, AuthTokens } from '@app/shared';
 
 @CommandHandler(AdminLoginCommand)
 export class AdminLoginHandler implements ICommandHandler<AdminLoginCommand> {
   constructor(
     private readonly adminReadRepository: IAdminReadRepository,
-    private readonly adminWriteRepository: IAdminWriteRepository,
-    private readonly jwtService: JwtService,
-    private readonly configService: ConfigService,
+    private readonly tokenIssuer: AdminTokenIssuer,
   ) {}
 
   async execute(command: AdminLoginCommand): Promise<AuthTokens> {
-    const admin = await this.adminReadRepository.findByEmail(command.email);
+    const admin = await this.loadAdminByEmail(command.email);
+    await this.validatePasswordMatches(command.password, admin.password);
+    return this.tokenIssuer.issueTokens(admin);
+  }
+
+  private async loadAdminByEmail(email: string): Promise<Admin> {
+    const admin = await this.adminReadRepository.findByEmail(email);
     if (!admin) {
       throw new UnauthorizedException('Invalid email or password');
     }
+    return admin;
+  }
 
-    const isPasswordValid = await bcrypt.compare(
-      command.password,
-      admin.password,
-    );
+  private async validatePasswordMatches(
+    raw: string,
+    hashed: string,
+  ): Promise<void> {
+    const isPasswordValid = await bcrypt.compare(raw, hashed);
     if (!isPasswordValid) {
       throw new UnauthorizedException('Invalid email or password');
     }
-
-    const payload = { sub: admin.id, email: admin.email, role: admin.role };
-
-    const accessToken = this.jwtService.sign(payload, {
-      secret: this.configService.getOrThrow<string>('JWT_ADMIN_ACCESS_SECRET'),
-      expiresIn: this.configService.get<string>(
-        'JWT_ADMIN_ACCESS_EXPIRATION',
-        '15m',
-      ),
-    } as JwtSignOptions);
-
-    const refreshToken = this.jwtService.sign(
-      { ...payload, type: 'refresh', jti: randomUUID() },
-      {
-        secret: this.configService.getOrThrow<string>(
-          'JWT_ADMIN_REFRESH_SECRET',
-        ),
-        expiresIn: this.configService.get<string>(
-          'JWT_ADMIN_REFRESH_EXPIRATION',
-          '7d',
-        ),
-      } as JwtSignOptions,
-    );
-
-    const tokenDigest = createHash('sha256').update(refreshToken).digest('hex');
-    const hashedRefreshToken = await bcrypt.hash(tokenDigest, 10);
-    await this.adminWriteRepository.update(admin.id, { hashedRefreshToken });
-
-    return { accessToken, refreshToken };
   }
 }

--- a/apps/back-office/src/auth/command/admin-refresh-token.handler.spec.ts
+++ b/apps/back-office/src/auth/command/admin-refresh-token.handler.spec.ts
@@ -1,0 +1,156 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'crypto';
+import * as bcrypt from 'bcrypt';
+import { AdminRefreshTokenHandler } from './admin-refresh-token.handler';
+import { AdminRefreshTokenCommand } from './admin-refresh-token.command';
+import { IAdminReadRepository } from '@back-office/auth/interface/admin-read-repository.interface';
+import { AdminTokenIssuer } from '@back-office/auth/admin-token-issuer.service';
+import { Admin, AdminRole } from '@app/shared';
+
+jest.mock('bcrypt');
+
+describe('AdminRefreshTokenHandler', () => {
+  let handler: AdminRefreshTokenHandler;
+  let adminReadRepository: Mocked<IAdminReadRepository>;
+  let jwtService: Mocked<JwtService>;
+  let configService: Mocked<ConfigService>;
+  let tokenIssuer: Mocked<AdminTokenIssuer>;
+
+  const mockAdmin = {
+    id: 1,
+    email: 'admin@example.com',
+    password: 'hashed-password',
+    name: '관리자',
+    role: AdminRole.MANAGER,
+    hashedRefreshToken: 'stored-hashed-refresh-token',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Admin;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const { unit, unitRef } = await TestBed.solitary(
+      AdminRefreshTokenHandler,
+    ).compile();
+
+    handler = unit;
+    adminReadRepository = unitRef.get<IAdminReadRepository>(
+      IAdminReadRepository as Type<IAdminReadRepository>,
+    );
+    jwtService = unitRef.get(JwtService);
+    configService = unitRef.get(ConfigService);
+    tokenIssuer = unitRef.get(AdminTokenIssuer);
+
+    jwtService.verify.mockReturnValue({
+      sub: 1,
+      email: 'admin@example.com',
+      role: AdminRole.MANAGER,
+      type: 'refresh',
+    });
+    adminReadRepository.findById.mockResolvedValue(mockAdmin);
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    tokenIssuer.issueTokens.mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+    });
+    configService.getOrThrow.mockReturnValue('test-admin-refresh-secret');
+  });
+
+  it('유효한 refresh token이면 AdminTokenIssuer로 위임하여 새 토큰 쌍을 반환한다', async () => {
+    const command = new AdminRefreshTokenCommand('valid-refresh-token');
+    const result = await handler.execute(command);
+
+    expect(result).toEqual({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+    });
+    expect(jwtService.verify).toHaveBeenCalledWith(
+      'valid-refresh-token',
+      expect.objectContaining({ secret: 'test-admin-refresh-secret' }),
+    );
+    expect(adminReadRepository.findById).toHaveBeenCalledWith(1);
+    const expectedDigest = createHash('sha256')
+      .update('valid-refresh-token')
+      .digest('hex');
+    expect(bcrypt.compare).toHaveBeenCalledWith(
+      expectedDigest,
+      'stored-hashed-refresh-token',
+    );
+    expect(tokenIssuer.issueTokens).toHaveBeenCalledWith(mockAdmin);
+  });
+
+  it('jwtService.verify 실패 시 UnauthorizedException을 발생시킨다', async () => {
+    jwtService.verify.mockImplementation(() => {
+      throw new Error('invalid token');
+    });
+
+    const command = new AdminRefreshTokenCommand('invalid-token');
+
+    await expect(handler.execute(command)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(adminReadRepository.findById).not.toHaveBeenCalled();
+    expect(tokenIssuer.issueTokens).not.toHaveBeenCalled();
+  });
+
+  it('type이 refresh가 아니면 UnauthorizedException을 발생시킨다', async () => {
+    jwtService.verify.mockReturnValue({
+      sub: 1,
+      email: 'admin@example.com',
+      role: AdminRole.MANAGER,
+    });
+
+    const command = new AdminRefreshTokenCommand(
+      'access-token-used-as-refresh',
+    );
+
+    await expect(handler.execute(command)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(adminReadRepository.findById).not.toHaveBeenCalled();
+    expect(tokenIssuer.issueTokens).not.toHaveBeenCalled();
+  });
+
+  it('관리자가 존재하지 않으면 UnauthorizedException을 발생시킨다', async () => {
+    adminReadRepository.findById.mockResolvedValue(null);
+
+    const command = new AdminRefreshTokenCommand('valid-refresh-token');
+
+    await expect(handler.execute(command)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(bcrypt.compare).not.toHaveBeenCalled();
+    expect(tokenIssuer.issueTokens).not.toHaveBeenCalled();
+  });
+
+  it('hashedRefreshToken이 null이면 UnauthorizedException을 발생시킨다', async () => {
+    adminReadRepository.findById.mockResolvedValue({
+      ...mockAdmin,
+      hashedRefreshToken: null,
+    } as Admin);
+
+    const command = new AdminRefreshTokenCommand('valid-refresh-token');
+
+    await expect(handler.execute(command)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(bcrypt.compare).not.toHaveBeenCalled();
+    expect(tokenIssuer.issueTokens).not.toHaveBeenCalled();
+  });
+
+  it('bcrypt.compare가 false면 UnauthorizedException을 발생시킨다', async () => {
+    (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+    const command = new AdminRefreshTokenCommand('old-refresh-token');
+
+    await expect(handler.execute(command)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(tokenIssuer.issueTokens).not.toHaveBeenCalled();
+  });
+});

--- a/apps/back-office/src/auth/command/admin-refresh-token.handler.ts
+++ b/apps/back-office/src/auth/command/admin-refresh-token.handler.ts
@@ -28,7 +28,9 @@ export class AdminRefreshTokenHandler implements ICommandHandler<AdminRefreshTok
     };
     try {
       payload = this.jwtService.verify(command.refreshToken, {
-        secret: this.configService.get<string>('JWT_ADMIN_REFRESH_SECRET'),
+        secret: this.configService.getOrThrow<string>(
+          'JWT_ADMIN_REFRESH_SECRET',
+        ),
       });
     } catch {
       throw new UnauthorizedException('Invalid or expired refresh token');
@@ -61,7 +63,7 @@ export class AdminRefreshTokenHandler implements ICommandHandler<AdminRefreshTok
     };
 
     const accessToken = this.jwtService.sign(newPayload, {
-      secret: this.configService.get<string>('JWT_ADMIN_ACCESS_SECRET'),
+      secret: this.configService.getOrThrow<string>('JWT_ADMIN_ACCESS_SECRET'),
       expiresIn: this.configService.get<string>(
         'JWT_ADMIN_ACCESS_EXPIRATION',
         '15m',
@@ -71,7 +73,9 @@ export class AdminRefreshTokenHandler implements ICommandHandler<AdminRefreshTok
     const refreshToken = this.jwtService.sign(
       { ...newPayload, type: 'refresh', jti: randomUUID() },
       {
-        secret: this.configService.get<string>('JWT_ADMIN_REFRESH_SECRET'),
+        secret: this.configService.getOrThrow<string>(
+          'JWT_ADMIN_REFRESH_SECRET',
+        ),
         expiresIn: this.configService.get<string>(
           'JWT_ADMIN_REFRESH_EXPIRATION',
           '7d',

--- a/apps/back-office/src/auth/command/admin-refresh-token.handler.ts
+++ b/apps/back-office/src/auth/command/admin-refresh-token.handler.ts
@@ -1,33 +1,45 @@
-import { createHash, randomUUID } from 'crypto';
+import { createHash } from 'crypto';
 import { UnauthorizedException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { JwtService, JwtSignOptions } from '@nestjs/jwt';
+import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
 import { AdminRefreshTokenCommand } from './admin-refresh-token.command';
 import { IAdminReadRepository } from '@back-office/auth/interface/admin-read-repository.interface';
-import { IAdminWriteRepository } from '@back-office/auth/interface/admin-write-repository.interface';
-import { AdminRole } from '@app/shared';
-import { AuthTokens } from '@app/shared';
+import { AdminTokenIssuer } from '@back-office/auth/admin-token-issuer.service';
+import { Admin, AdminRole, AuthTokens } from '@app/shared';
+
+interface AdminRefreshTokenPayload {
+  sub: number;
+  email: string;
+  role?: AdminRole;
+  type?: string;
+}
 
 @CommandHandler(AdminRefreshTokenCommand)
 export class AdminRefreshTokenHandler implements ICommandHandler<AdminRefreshTokenCommand> {
   constructor(
     private readonly adminReadRepository: IAdminReadRepository,
-    private readonly adminWriteRepository: IAdminWriteRepository,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
+    private readonly tokenIssuer: AdminTokenIssuer,
   ) {}
 
   async execute(command: AdminRefreshTokenCommand): Promise<AuthTokens> {
-    let payload: {
-      sub: number;
-      email: string;
-      role?: AdminRole;
-      type?: string;
-    };
+    const payload = this.decodeRefreshPayloadOrUnauthorized(
+      command.refreshToken,
+    );
+    const admin = await this.loadAdminByIdOrUnauthorized(payload.sub);
+    await this.validateRefreshTokenMatches(command.refreshToken, admin);
+    return this.tokenIssuer.issueTokens(admin);
+  }
+
+  private decodeRefreshPayloadOrUnauthorized(
+    refreshToken: string,
+  ): AdminRefreshTokenPayload {
+    let payload: AdminRefreshTokenPayload;
     try {
-      payload = this.jwtService.verify(command.refreshToken, {
+      payload = this.jwtService.verify(refreshToken, {
         secret: this.configService.getOrThrow<string>(
           'JWT_ADMIN_REFRESH_SECRET',
         ),
@@ -40,14 +52,26 @@ export class AdminRefreshTokenHandler implements ICommandHandler<AdminRefreshTok
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
 
-    const admin = await this.adminReadRepository.findById(payload.sub);
-    if (!admin || !admin.hashedRefreshToken) {
+    return payload;
+  }
+
+  private async loadAdminByIdOrUnauthorized(adminId: number): Promise<Admin> {
+    const admin = await this.adminReadRepository.findById(adminId);
+    if (!admin) {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+    return admin;
+  }
+
+  private async validateRefreshTokenMatches(
+    refreshToken: string,
+    admin: Admin,
+  ): Promise<void> {
+    if (!admin.hashedRefreshToken) {
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
 
-    const tokenDigest = createHash('sha256')
-      .update(command.refreshToken)
-      .digest('hex');
+    const tokenDigest = createHash('sha256').update(refreshToken).digest('hex');
     const isRefreshTokenValid = await bcrypt.compare(
       tokenDigest,
       admin.hashedRefreshToken,
@@ -55,40 +79,5 @@ export class AdminRefreshTokenHandler implements ICommandHandler<AdminRefreshTok
     if (!isRefreshTokenValid) {
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
-
-    const newPayload = {
-      sub: admin.id,
-      email: admin.email,
-      role: admin.role,
-    };
-
-    const accessToken = this.jwtService.sign(newPayload, {
-      secret: this.configService.getOrThrow<string>('JWT_ADMIN_ACCESS_SECRET'),
-      expiresIn: this.configService.get<string>(
-        'JWT_ADMIN_ACCESS_EXPIRATION',
-        '15m',
-      ),
-    } as JwtSignOptions);
-
-    const refreshToken = this.jwtService.sign(
-      { ...newPayload, type: 'refresh', jti: randomUUID() },
-      {
-        secret: this.configService.getOrThrow<string>(
-          'JWT_ADMIN_REFRESH_SECRET',
-        ),
-        expiresIn: this.configService.get<string>(
-          'JWT_ADMIN_REFRESH_EXPIRATION',
-          '7d',
-        ),
-      } as JwtSignOptions,
-    );
-
-    const newTokenDigest = createHash('sha256')
-      .update(refreshToken)
-      .digest('hex');
-    const hashedRefreshToken = await bcrypt.hash(newTokenDigest, 10);
-    await this.adminWriteRepository.update(admin.id, { hashedRefreshToken });
-
-    return { accessToken, refreshToken };
   }
 }

--- a/apps/back-office/src/auth/command/admin-register.handler.spec.ts
+++ b/apps/back-office/src/auth/command/admin-register.handler.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import type { Type } from '@suites/types.common';
+import { ConflictException } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { AdminRegisterHandler } from './admin-register.handler';
+import { AdminRegisterCommand } from './admin-register.command';
+import { IAdminReadRepository } from '@back-office/auth/interface/admin-read-repository.interface';
+import { IAdminWriteRepository } from '@back-office/auth/interface/admin-write-repository.interface';
+import { Admin, AdminRole } from '@app/shared';
+
+jest.mock('bcrypt');
+
+describe('AdminRegisterHandler', () => {
+  let handler: AdminRegisterHandler;
+  let adminReadRepository: Mocked<IAdminReadRepository>;
+  let adminWriteRepository: Mocked<IAdminWriteRepository>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const { unit, unitRef } =
+      await TestBed.solitary(AdminRegisterHandler).compile();
+
+    handler = unit;
+    adminReadRepository = unitRef.get<IAdminReadRepository>(
+      IAdminReadRepository as Type<IAdminReadRepository>,
+    );
+    adminWriteRepository = unitRef.get<IAdminWriteRepository>(
+      IAdminWriteRepository as Type<IAdminWriteRepository>,
+    );
+
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+  });
+
+  it('중복되지 않는 이메일이면 관리자를 생성하고 id를 반환한다', async () => {
+    adminReadRepository.findByEmail.mockResolvedValue(null);
+    adminWriteRepository.create.mockResolvedValue({ id: 1 } as Admin);
+
+    const command = new AdminRegisterCommand(
+      'admin@example.com',
+      'password123',
+      '관리자',
+      AdminRole.MANAGER,
+    );
+    const result = await handler.execute(command);
+
+    expect(result).toBe(1);
+    expect(adminReadRepository.findByEmail).toHaveBeenCalledWith(
+      'admin@example.com',
+    );
+    expect(bcrypt.hash).toHaveBeenCalledWith('password123', 10);
+    expect(adminWriteRepository.create).toHaveBeenCalledWith({
+      email: 'admin@example.com',
+      password: 'hashed-password',
+      name: '관리자',
+      role: AdminRole.MANAGER,
+    });
+  });
+
+  it('role이 SUPER면 create input에 그대로 전달된다', async () => {
+    adminReadRepository.findByEmail.mockResolvedValue(null);
+    adminWriteRepository.create.mockResolvedValue({ id: 1 } as Admin);
+
+    const command = new AdminRegisterCommand(
+      'super@example.com',
+      'password123',
+      '슈퍼관리자',
+      AdminRole.SUPER,
+    );
+    await handler.execute(command);
+
+    expect(adminWriteRepository.create).toHaveBeenCalledWith({
+      email: 'super@example.com',
+      password: 'hashed-password',
+      name: '슈퍼관리자',
+      role: AdminRole.SUPER,
+    });
+  });
+
+  it('동일한 이메일이 이미 존재하면 ConflictException을 발생시킨다', async () => {
+    adminReadRepository.findByEmail.mockResolvedValue({ id: 1 } as Admin);
+
+    const command = new AdminRegisterCommand(
+      'admin@example.com',
+      'password123',
+      '관리자',
+      AdminRole.MANAGER,
+    );
+
+    await expect(handler.execute(command)).rejects.toThrow(ConflictException);
+    expect(adminWriteRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('DB unique constraint 위반 시(23505) ConflictException을 발생시킨다', async () => {
+    adminReadRepository.findByEmail.mockResolvedValue(null);
+
+    const dbError = new QueryFailedError('INSERT', [], new Error());
+    Object.assign(dbError, { driverError: { code: '23505' } });
+    adminWriteRepository.create.mockRejectedValue(dbError);
+
+    const command = new AdminRegisterCommand(
+      'admin@example.com',
+      'password123',
+      '관리자',
+      AdminRole.MANAGER,
+    );
+
+    await expect(handler.execute(command)).rejects.toThrow(ConflictException);
+  });
+});

--- a/apps/back-office/src/auth/command/admin-register.handler.ts
+++ b/apps/back-office/src/auth/command/admin-register.handler.ts
@@ -1,6 +1,6 @@
 import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { QueryFailedError } from 'typeorm';
+import { isUniqueViolation } from '@app/shared';
 import * as bcrypt from 'bcrypt';
 import { AdminRegisterCommand } from './admin-register.command';
 import { IAdminReadRepository } from '@back-office/auth/interface/admin-read-repository.interface';
@@ -32,10 +32,7 @@ export class AdminRegisterHandler implements ICommandHandler<AdminRegisterComman
       });
       return admin.id;
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException(
           `Admin with email '${command.email}' already exists`,
         );

--- a/apps/service/src/auth/command/google-login.handler.ts
+++ b/apps/service/src/auth/command/google-login.handler.ts
@@ -5,7 +5,6 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { QueryFailedError } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 import * as bcrypt from 'bcrypt';
 import { GoogleLoginCommand } from './google-login.command';
@@ -18,7 +17,7 @@ import {
 } from '@service/auth/interface/oauth-account-write-repository.interface';
 import { AuthTokenIssuer } from '@service/auth/auth-token-issuer.service';
 import type { GoogleProfilePayload } from '@service/auth/strategy/google-profile.type';
-import { AuthTokens, OAuthAccount, User } from '@app/shared';
+import { AuthTokens, OAuthAccount, User, isUniqueViolation } from '@app/shared';
 
 @CommandHandler(GoogleLoginCommand)
 export class GoogleLoginHandler implements ICommandHandler<
@@ -104,10 +103,7 @@ export class GoogleLoginHandler implements ICommandHandler<
         marketingConsent: false,
       });
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException(
           `이미 가입된 이메일입니다: '${profile.email}'`,
         );
@@ -122,10 +118,7 @@ export class GoogleLoginHandler implements ICommandHandler<
     try {
       await this.oauthWriteRepository.create(input);
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException('이미 연결된 Google 계정입니다');
       }
       throw error;

--- a/apps/service/src/auth/command/link-google-account.handler.ts
+++ b/apps/service/src/auth/command/link-google-account.handler.ts
@@ -1,6 +1,6 @@
 import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { QueryFailedError } from 'typeorm';
+import { isUniqueViolation } from '@app/shared';
 import { LinkGoogleAccountCommand } from './link-google-account.command';
 import { IOAuthAccountReadRepository } from '@service/auth/interface/oauth-account-read-repository.interface';
 import {
@@ -71,10 +71,7 @@ export class LinkGoogleAccountHandler implements ICommandHandler<
     try {
       await this.oauthWriteRepository.create(input);
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException('이미 Google 계정이 연결되어 있습니다');
       }
       throw error;

--- a/apps/service/src/auth/command/register.handler.ts
+++ b/apps/service/src/auth/command/register.handler.ts
@@ -1,6 +1,6 @@
 import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { QueryFailedError } from 'typeorm';
+import { isUniqueViolation } from '@app/shared';
 import * as bcrypt from 'bcrypt';
 import { RegisterCommand } from './register.command';
 import { IUserReadRepository } from '@service/auth/interface/user-read-repository.interface';
@@ -39,10 +39,7 @@ export class RegisterHandler implements ICommandHandler<RegisterCommand> {
       const user = await this.userWriteRepository.create(input);
       return user.id;
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException(
           `User with email '${input.email}' already exists`,
         );

--- a/apps/service/src/posts/command/create-post.handler.ts
+++ b/apps/service/src/posts/command/create-post.handler.ts
@@ -1,7 +1,6 @@
 import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { QueryFailedError } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 import { CreatePostCommand } from './create-post.command';
 import { PostCreatedEvent } from '@service/posts/event/post-created.event';
@@ -9,7 +8,7 @@ import { IPostReadRepository } from '@service/posts/interface/post-read-reposito
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
 import type { CreatePostInput } from '@service/posts/interface/post-write-repository.interface';
 import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
-import { CacheService, Post } from '@app/shared';
+import { CacheService, Post, isUniqueViolation } from '@app/shared';
 
 @CommandHandler(CreatePostCommand)
 export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
@@ -57,10 +56,7 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
     try {
       return await this.postWriteRepository.create(input);
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException(
           `Post with title '${input.title}' already exists`,
         );

--- a/apps/service/src/tags/command/create-tag.handler.ts
+++ b/apps/service/src/tags/command/create-tag.handler.ts
@@ -1,13 +1,12 @@
 import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { QueryFailedError } from 'typeorm';
 import { CreateTagCommand } from './create-tag.command';
 import { ITagReadRepository } from '@service/tags/interface/tag-read-repository.interface';
 import {
   CreateTagInput,
   ITagWriteRepository,
 } from '@service/tags/interface/tag-write-repository.interface';
-import { CacheService, Tag } from '@app/shared';
+import { CacheService, Tag, isUniqueViolation } from '@app/shared';
 
 @CommandHandler(CreateTagCommand)
 export class CreateTagHandler implements ICommandHandler<CreateTagCommand> {
@@ -44,10 +43,7 @@ export class CreateTagHandler implements ICommandHandler<CreateTagCommand> {
     try {
       return await this.tagWriteRepository.create(input);
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException(
           `Tag with name '${input.name}' already exists`,
         );

--- a/apps/service/src/tags/command/update-tag.handler.ts
+++ b/apps/service/src/tags/command/update-tag.handler.ts
@@ -1,9 +1,8 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { ConflictException, NotFoundException } from '@nestjs/common';
-import { QueryFailedError } from 'typeorm';
 import { UpdateTagCommand } from './update-tag.command';
 import { ITagWriteRepository } from '@service/tags/interface/tag-write-repository.interface';
-import { CacheService } from '@app/shared';
+import { CacheService, isUniqueViolation } from '@app/shared';
 
 @CommandHandler(UpdateTagCommand)
 export class UpdateTagHandler implements ICommandHandler<UpdateTagCommand> {
@@ -29,10 +28,7 @@ export class UpdateTagHandler implements ICommandHandler<UpdateTagCommand> {
         name: command.name,
       });
     } catch (error) {
-      if (
-        error instanceof QueryFailedError &&
-        (error.driverError as { code?: string })?.code === '23505'
-      ) {
+      if (isUniqueViolation(error)) {
         throw new ConflictException(
           `Tag with name '${command.name}' already exists`,
         );

--- a/libs/shared/src/database/postgres-error.util.ts
+++ b/libs/shared/src/database/postgres-error.util.ts
@@ -1,0 +1,15 @@
+import { QueryFailedError } from 'typeorm';
+
+/**
+ * PostgreSQL unique_violation (SQLSTATE 23505) 여부를 판별하는 타입가드.
+ *
+ * Repository write 직후 catch 블록에서 동시성 race로 발생한 unique 제약 위반을
+ * `ConflictException`으로 변환할 때 일관되게 사용한다. `driverError`의 unsafe
+ * 캐스팅을 이 한 곳으로 모아, 호출 지점에서는 메시지/제어 흐름만 책임지게 한다.
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof QueryFailedError &&
+    (error.driverError as { code?: string })?.code === '23505'
+  );
+}

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -11,6 +11,7 @@ export { AdminRole } from './enum/admin-role.enum';
 
 // Database
 export { createDataSourceOptions } from './database/typeorm.config';
+export { isUniqueViolation } from './database/postgres-error.util';
 
 // Common - Base Repository
 export { BaseRepository } from './common/base.repository';


### PR DESCRIPTION
## 개요

프로젝트 전반 점검에서 도출된 개선 항목 4가지를 각각 별도 커밋으로 처리합니다. 모두 동작/스키마 변경 없는 품질·일관성 개선이며, 한 가지(getOrThrow)는 latent bug 수정입니다.

## 커밋 단위 변경

**1. `fix(back-office)` — JWT 시크릿 getOrThrow (`523ef3c`)**
- `admin-login`/`admin-refresh-token`이 `JWT_ADMIN_*_SECRET`을 `configService.get`으로 로드 → env 누락 시 조용히 `undefined`가 되어 토큰 서명 런타임에야 실패하던 것을 `getOrThrow`로 교체.
- CLAUDE.md *"JWT secret은 반드시 getOrThrow"* 규칙 및 서비스측 `AuthTokenIssuer`와 정합.

**2. `refactor(back-office)` — AdminTokenIssuer 추출 (`b2e92b3`)**
- login/refresh 핸들러에 인라인 복붙돼 있던 access/refresh 발급 + digest 해싱 + `hashedRefreshToken` 저장을 `AdminTokenIssuer` 도메인 서비스로 단일화 (서비스측 `AuthTokenIssuer`와 대칭 구조).
- `AdminLoginHandler`/`AdminRefreshTokenHandler`의 `execute()`를 호출 전용으로 정리(검증 단계 private 메서드 분리).

**3. `test(back-office)` — admin auth 단위 테스트 (`22cf5c1`)**
- 분기 로직이 있으나 단위 테스트가 없던 `admin-login`/`admin-register`/`admin-refresh-token` + `AdminTokenIssuer`에 Suites(`TestBed.solitary`) 단위 테스트 **15건** 추가.

**4. `refactor(shared)` — isUniqueViolation 헬퍼 (`a9910d1`)**
- 8개 핸들러에 복붙된 `QueryFailedError instanceof` + `(error.driverError as {code?})?.code === '23505'` 패턴(unsafe 캐스팅 8회)을 `libs/shared`의 `isUniqueViolation` 타입가드로 통합. 호출 지점은 각자의 `ConflictException` 메시지만 유지.

## 검증

- `pnpm lint:check` ✅
- `pnpm build:all` ✅ (service + back-office)
- `pnpm test` ✅ 42 스위트 / 147건 (신규 15건 포함)
- `pnpm test:e2e` ✅ service 160건 + back-office 34건

## 비고

점검에서 함께 거론됐던 항목 중 **오탐으로 확인되어 제외**: `CreatePostHandler @Transactional`(실제로는 posts+post_tags 다중 write라 정당), logout 핸들러 `@Transactional` 누락(단일 write라 불필요). back-office 핸들러 구조 규칙(R1~R3)은 `apps/service/**`에만 적용되므로 위반이 아닌 일관성 개선으로 다룸.

🤖 Generated with [Claude Code](https://claude.com/claude-code)