### PR TITLE
refactor(service): 도메인 이벤트를 EventEmitter에서 CQRS EventBus로 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,12 +191,13 @@ Controller → CommandBus / QueryBus → Handler (검증 + 로직) → IPostRead
 - Redis 기반 멱등성 키 저장. `IdempotencyInterceptor`가 요청 헤더의 키로 중복 여부 판단
 - `IdempotencyModule`을 import하여 사용
 
-### Event-Driven (EventEmitter + Slack)
+### Event-Driven (CQRS EventBus + Slack)
 
-- `@nestjs/event-emitter` 기반 도메인 이벤트 발행 — Command Handler에서 상태 변경 후 이벤트 발행
-- `PostCreatedEvent` → `PostCreatedHandler`가 Slack 알림 전송 (`apps/service/src/posts/event/`)
-- `SlackModule` / `SlackService` (`libs/shared/src/slack/`) — Slack Bot Token으로 채널 알림 전송
-- 이벤트 핸들러는 비동기 처리되므로 메인 요청 흐름에 영향 없음
+- `@nestjs/cqrs`의 `EventBus` 기반 도메인 이벤트 발행 — Command Handler에서 상태 변경 후 `eventBus.publish(new XxxEvent(...))`. 별도 이벤트 문자열 키 없이 이벤트 클래스 자체로 라우팅
+- `PostCreatedEvent` → `PostCreatedHandler`(`@EventsHandler` + `IEventHandler<T>`)가 Slack 알림 전송 (`apps/service/src/posts/event/`)
+- `SlackModule` / `SlackService` (`libs/shared/src/slack/`) — Slack Bot Token으로 채널 알림 전송. 내부 catch로 Fail-Open (전송 실패가 핸들러로 전파되지 않음)
+- 이벤트 핸들러는 RxJS 스트림에서 비동기 처리되므로 메인 요청 흐름에 영향 없음. 핸들러 실패도 publisher(Command Handler)에 전파되지 않음
+- **이벤트 핸들러 예외는 Exception filter 미적용** — request-response cycle 밖이므로 `HttpExceptionFilter`가 잡지 못한다. EventBus 내장 `catchError`가 예외를 `UnhandledExceptionBus`(CqrsModule이 export하는 앱 전체 싱글톤)로 발행하고, `CqrsLoggingModule`의 `UnhandledEventExceptionsLogger`(`libs/shared/src/cqrs/`)가 이를 구독하여 앱 전역의 이벤트 핸들러 예외를 중앙 로깅. EventBus로 이벤트를 발행하는 앱의 AppModule에서 `CqrsLoggingModule`을 import한다 (현재 service만 — back-office는 이벤트 도입 시점에 추가). 이벤트 핸들러 안에 별도 try/catch를 추가하지 않는다 (SlackService Fail-Open + UnhandledExceptionBus 안전망으로 충분 — dead catch 방지)
 
 ### OpenTelemetry
 
@@ -210,7 +211,7 @@ Controller → CommandBus / QueryBus → Handler (검증 + 로직) → IPostRead
 외부 OTEL 백엔드 없이도 단일 PostgreSQL 쿼리가 임계값을 넘으면 Slack 채널로 알림을 보내는 인앱 후크. 코드는 `libs/shared/src/otel/` + `libs/shared/src/instrumentation.ts` + `libs/shared/src/slack/slack.service.ts`(sendSlowQueryAlert).
 
 - 데이터 흐름: pg 자동 계측 → `SlowQuerySpanProcessor` → 모듈 레벨 callback registry → `SlowQueryAlertHandler` (NestJS DI) → `SlackService.sendSlowQueryAlert` → `#prod-slow-query` / `#dev-slow-query` 채널
-- Boot-time SpanProcessor와 NestJS DI 사이 연결: 모듈 레벨 callback + buffer(BUFFER_CAP=100건) 패턴. EventEmitter는 back-office에 미등록되어 있어 사용 안 함.
+- Boot-time SpanProcessor와 NestJS DI 사이 연결: 모듈 레벨 callback + buffer(BUFFER_CAP=100건) 패턴. SpanProcessor는 NestJS DI 컨테이너 부팅 전에 생성되므로 EventBus 등 DI 기반 이벤트 시스템을 사용할 수 없음.
 - Dedup: SQL 본문 SHA-1 앞 16자를 키로 60초 TTL Redis 중복 제거 (분산 환경 모든 인스턴스 공유). `CacheService` Fail-Open이라 Redis 장애 시 dedup 효과만 사라지고 알림 자체는 계속 전송
 - 환경변수: `SLOW_QUERY_THRESHOLD_MS`(기본 5000, NaN/음수면 폴백), `SLACK_BOT_TOKEN` 미설정 시 silent skip
 - 양쪽 앱 활성화: 각 AppModule이 `OtelAlertingModule` import 필수

--- a/apps/service/src/app.module.ts
+++ b/apps/service/src/app.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {
   createDataSourceOptions,
+  CqrsLoggingModule,
   LoggingModule,
   IdempotencyModule,
   HealthModule,
@@ -30,7 +30,7 @@ const nodeEnv = process.env.NODE_ENV || 'local';
         { name: 'long', ttl: 60000, limit: 60 },
       ],
     }),
-    EventEmitterModule.forRoot(),
+    CqrsLoggingModule,
     LoggingModule,
     IdempotencyModule,
     TypeOrmModule.forRootAsync({

--- a/apps/service/src/posts/command/create-post.handler.spec.ts
+++ b/apps/service/src/posts/command/create-post.handler.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed, type Mocked } from '@suites/unit';
 import type { Type } from '@suites/types.common';
 import { BadRequestException, ConflictException } from '@nestjs/common';
+import { EventBus } from '@nestjs/cqrs';
 import { CreatePostHandler } from './create-post.handler';
 import { CreatePostCommand } from './create-post.command';
+import { PostCreatedEvent } from '@service/posts/event/post-created.event';
 import { IPostReadRepository } from '@service/posts/interface/post-read-repository.interface';
 import { IPostWriteRepository } from '@service/posts/interface/post-write-repository.interface';
 import { TagOwnershipValidator } from '@service/tags/tag-ownership.validator';
@@ -20,6 +22,7 @@ describe('CreatePostHandler', () => {
   let postReadRepository: Mocked<IPostReadRepository>;
   let postWriteRepository: Mocked<IPostWriteRepository>;
   let tagOwnershipValidator: Mocked<TagOwnershipValidator>;
+  let eventBus: Mocked<EventBus>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -33,6 +36,7 @@ describe('CreatePostHandler', () => {
       IPostWriteRepository as Type<IPostWriteRepository>,
     );
     tagOwnershipValidator = unitRef.get(TagOwnershipValidator);
+    eventBus = unitRef.get(EventBus);
   });
 
   it('중복되지 않는 제목이면 게시글을 생성하고 id를 반환한다', async () => {
@@ -54,6 +58,9 @@ describe('CreatePostHandler', () => {
       isPublished: false,
       tagIds: undefined,
     });
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      new PostCreatedEvent(1, 'New Title', 1),
+    );
   });
 
   it('동일한 제목이 이미 존재하면 ConflictException을 발생시킨다', async () => {

--- a/apps/service/src/posts/command/create-post.handler.ts
+++ b/apps/service/src/posts/command/create-post.handler.ts
@@ -1,6 +1,5 @@
 import { ConflictException } from '@nestjs/common';
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CommandHandler, EventBus, ICommandHandler } from '@nestjs/cqrs';
 import { Transactional } from 'typeorm-transactional';
 import { CreatePostCommand } from './create-post.command';
 import { PostCreatedEvent } from '@service/posts/event/post-created.event';
@@ -16,7 +15,7 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
     private readonly postReadRepository: IPostReadRepository,
     private readonly postWriteRepository: IPostWriteRepository,
     private readonly tagOwnershipValidator: TagOwnershipValidator,
-    private readonly eventEmitter: EventEmitter2,
+    private readonly eventBus: EventBus,
     private readonly cacheService: CacheService,
   ) {}
 
@@ -70,10 +69,7 @@ export class CreatePostHandler implements ICommandHandler<CreatePostCommand> {
     title: string,
     userId: number,
   ): void {
-    this.eventEmitter.emit(
-      PostCreatedEvent.event,
-      new PostCreatedEvent(postId, title, userId),
-    );
+    this.eventBus.publish(new PostCreatedEvent(postId, title, userId));
   }
 
   private async invalidateUserCache(userId: number): Promise<void> {

--- a/apps/service/src/posts/event/post-created.event.ts
+++ b/apps/service/src/posts/event/post-created.event.ts
@@ -1,6 +1,4 @@
 export class PostCreatedEvent {
-  static readonly event = 'post.created';
-
   constructor(
     public readonly postId: number,
     public readonly title: string,

--- a/apps/service/src/posts/event/post-created.handler.ts
+++ b/apps/service/src/posts/event/post-created.handler.ts
@@ -1,13 +1,11 @@
-import { Injectable } from '@nestjs/common';
-import { OnEvent } from '@nestjs/event-emitter';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 import { PostCreatedEvent } from './post-created.event';
 import { SlackService } from '@app/shared';
 
-@Injectable()
-export class PostCreatedHandler {
+@EventsHandler(PostCreatedEvent)
+export class PostCreatedHandler implements IEventHandler<PostCreatedEvent> {
   constructor(private readonly slackService: SlackService) {}
 
-  @OnEvent(PostCreatedEvent.event, { async: true })
   async handle(event: PostCreatedEvent): Promise<void> {
     await this.slackService.sendPostCreatedNotification(
       event.postId,

--- a/docs/slack-notification-prd.md
+++ b/docs/slack-notification-prd.md
@@ -1,5 +1,7 @@
 # Slack 알림 PRD: Post 생성 시 Slack 알림 전송
 
+> **[2026-06 마이그레이션 노트]** 이 문서는 최초 구현 당시 `@nestjs/event-emitter`를 선택한 기록이다. 이후 이벤트 시스템은 `@nestjs/cqrs`의 `EventBus`(`@EventsHandler`)로 마이그레이션되었고 `@nestjs/event-emitter` 의존성은 제거되었다. 당시 미선택 사유였던 "EventBus는 동기 실행이라 핸들러 실패가 전파됨"은 @nestjs/cqrs v11 기준 부정확하다 — EventBus는 RxJS 스트림으로 핸들러를 비동기 실행하고, 핸들러 예외는 내부 `catchError`가 `UnhandledExceptionBus`로 발행하므로 publisher에 전파되지 않는다. 현행 구조는 CLAUDE.md의 "Event-Driven (CQRS EventBus + Slack)" 섹션 참고.
+
 ## 0. 용어 해설
 
 이 문서에서 사용하는 주요 용어를 정리한다.

--- a/libs/shared/src/cqrs/cqrs-logging.module.ts
+++ b/libs/shared/src/cqrs/cqrs-logging.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { UnhandledEventExceptionsLogger } from './unhandled-event-exceptions.logger';
+
+/**
+ * EventBus 이벤트 핸들러의 unhandled exception을 중앙 로깅하는 모듈.
+ * EventBus로 이벤트를 발행하는 앱의 AppModule에서 import한다.
+ */
+@Module({
+  imports: [CqrsModule],
+  providers: [UnhandledEventExceptionsLogger],
+})
+export class CqrsLoggingModule {}

--- a/libs/shared/src/cqrs/unhandled-event-exceptions.logger.ts
+++ b/libs/shared/src/cqrs/unhandled-event-exceptions.logger.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { UnhandledExceptionBus } from '@nestjs/cqrs';
+import { Subject, takeUntil } from 'rxjs';
+
+/**
+ * EventBus 이벤트 핸들러의 예외는 request-response cycle 밖에서 발생하므로
+ * Exception filter가 잡을 수 없다. EventBus 내장 catchError가 예외를
+ * UnhandledExceptionBus로 발행하므로, 이를 구독하여 중앙에서 로깅한다.
+ *
+ * UnhandledExceptionBus는 CqrsModule이 export하는 앱 전체 싱글톤이므로
+ * 이 로거 하나가 앱 내 모든 이벤트 핸들러 예외를 관측한다.
+ */
+@Injectable()
+export class UnhandledEventExceptionsLogger implements OnModuleDestroy {
+  private readonly destroy$ = new Subject<void>();
+  private readonly logger = new Logger(UnhandledEventExceptionsLogger.name);
+
+  constructor(unhandledExceptionBus: UnhandledExceptionBus) {
+    unhandledExceptionBus.pipe(takeUntil(this.destroy$)).subscribe((info) => {
+      this.logger.error(
+        `Unhandled exception in event handler for ${info.cause?.constructor?.name ?? 'unknown event'}`,
+        info.exception instanceof Error
+          ? info.exception.stack
+          : String(info.exception),
+      );
+    });
+  }
+
+  onModuleDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -33,6 +33,10 @@ export type { AuthTokens } from './auth.types';
 export { AppCacheModule } from './cache/cache.module';
 export { CacheService } from './cache/cache.service';
 
+// CQRS
+export { CqrsLoggingModule } from './cqrs/cqrs-logging.module';
+export { UnhandledEventExceptionsLogger } from './cqrs/unhandled-event-exceptions.logger';
+
 // Logging
 export { LoggingModule } from './logging/logging.module';
 export { HttpExceptionFilter } from './logging/http-exception.filter';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.1.17",
     "@nestjs/cqrs": "^11.0.3",
-    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@nestjs/cqrs':
         specifier: ^11.0.3
         version: 11.0.3(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/event-emitter':
-        specifier: ^3.0.1
-        version: 3.0.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@nestjs/jwt':
         specifier: ^11.0.2
         version: 11.0.2(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))
@@ -868,12 +865,6 @@ packages:
       '@nestjs/core': ^10.0.0 || ^11.0.0
       reflect-metadata: ^0.1.13 || ^0.2.0
       rxjs: ^7.2.0
-
-  '@nestjs/event-emitter@3.0.1':
-    resolution: {integrity: sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==}
-    peerDependencies:
-      '@nestjs/common': ^10.0.0 || ^11.0.0
-      '@nestjs/core': ^10.0.0 || ^11.0.0
 
   '@nestjs/jwt@11.0.2':
     resolution: {integrity: sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==}
@@ -2921,9 +2912,6 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-
-  eventemitter2@6.4.9:
-    resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -5656,12 +5644,6 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
 
-  '@nestjs/event-emitter@3.0.1(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2))':
-    dependencies:
-      '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      eventemitter2: 6.4.9
-
   '@nestjs/jwt@11.0.2(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))':
     dependencies:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -7948,8 +7930,6 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
-
-  eventemitter2@6.4.9: {}
 
   eventemitter3@4.0.7: {}
 

--- a/test/back-office/admin-test.module.ts
+++ b/test/back-office/admin-test.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {
@@ -28,7 +27,6 @@ const nodeEnv = process.env.NODE_ENV || 'local';
         { name: 'long', ttl: 60000, limit: 60 },
       ],
     }),
-    EventEmitterModule.forRoot(),
     LoggingModule,
     IdempotencyModule,
     TypeOrmModule.forRootAsync({


### PR DESCRIPTION
> **Merge Strategy**: Create a merge commit을 사용해주세요.

## Summary

프로젝트가 이미 @nestjs/cqrs 기반(CommandBus/QueryBus)인데 도메인 이벤트만 @nestjs/event-emitter를 별도로 사용하고 있어 EventBus로 통일한다. 이 전환으로 의존성 1개(@nestjs/event-emitter)가 제거된다.

기존에 event-emitter를 선택한 근거였던 "EventBus는 동기 호출이라 핸들러 실패가 전파됨"(docs/slack-notification-prd.md)은 @nestjs/cqrs v11 기준 부정확하다. EventBus는 RxJS 스트림으로 핸들러를 비동기 실행하고, 핸들러 예외는 내부에서 잡아 UnhandledExceptionBus로 발행하므로 발행자(Command Handler)에 전파되지 않는다.

## 변경 내용

### 이벤트 발행/구독 전환
- `post-created.event.ts`: 문자열 이벤트 키(`static event`)를 제거한다. EventBus는 이벤트 클래스 자체로 라우팅한다
- `post-created.handler.ts`: `@OnEvent` 대신 `@EventsHandler(PostCreatedEvent)` + `IEventHandler<T>`로 전환한다
- `create-post.handler.ts`: `EventEmitter2` 대신 `EventBus`를 주입하고 `emitCreatedEvent`에서 `publish`를 호출한다. try 밖 위치 등 Handler Authoring Rules는 그대로 유지한다

### 이벤트 핸들러 예외의 중앙 관측 (신규)
- 이벤트 핸들러 예외는 request-response cycle 밖이라 Exception filter가 잡지 못한다. EventBus가 예외를 `UnhandledExceptionBus`(CqrsModule이 export하는 앱 전체 싱글톤)로 발행하므로, 이를 구독해 중앙 로깅하는 `UnhandledEventExceptionsLogger`를 추가한다
- 도메인 의존성이 없는 cross-cutting 코드라 `libs/shared/src/cqrs/`에 `CqrsLoggingModule`로 배치한다 (LoggingModule·OtelAlertingModule 선례). EventBus로 이벤트를 발행하는 service 앱에만 등록하고, back-office는 이벤트 도입 시점에 추가한다
- 이벤트 핸들러 안에 별도 try/catch는 추가하지 않는다. SlackService가 Fail-Open(장애 시에도 호출자에 예외를 던지지 않고 통과)이라 dead catch가 되기 때문이다

### 정리
- `app.module.ts`(service): `EventEmitterModule.forRoot()`를 제거하고 `CqrsLoggingModule`을 등록한다
- `admin-test.module.ts`: back-office 실제 AppModule에는 없던 `EventEmitterModule` 잔재를 제거한다 (테스트 모듈과 실제 모듈의 불일치 정리)
- `package.json`: `@nestjs/event-emitter` 의존성을 제거한다

### 테스트·문서
- `create-post.handler.spec.ts`: 생성 성공 시 `eventBus.publish`가 `PostCreatedEvent`로 호출되는지 단언을 추가한다 (기존에는 이벤트 발행 미검증)
- `CLAUDE.md`: Event-Driven 섹션을 EventBus 기반으로 다시 기술한다
- `docs/slack-notification-prd.md`: 문서 상단에 마이그레이션 노트를 추가하고 부정확한 선택 근거를 정정한다

## Test plan

- [x] `pnpm format` / `pnpm lint:check` 통과
- [x] `pnpm build:all` — 양쪽 앱 컴파일 성공
- [x] `pnpm test` — 단위 테스트 148건 통과
- [x] `pnpm test:e2e` — 통합 테스트 service 160건 + back-office 34건 통과
- [x] `verify-handler-structure` 스킬 — R1~R5 위반 없음
- [x] `event-emitter` 잔여 참조 0건 확인 후 패키지 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링 (Refactor)**
  * 이벤트 처리 시스템을 개선하여 더욱 안정적인 게시글 생성 알림 전송 지원
  * 핸들러 예외 처리를 중앙화하여 오류 로깅 및 추적 기능 강화
  * 문서 업데이트를 통해 시스템 동작 방식 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->