### PR TITLE
test: 공유 인프라 4종과 PostCreatedHandler에 단위 테스트 추가

### DIFF
--- a/apps/service/src/posts/event/post-created.handler.spec.ts
+++ b/apps/service/src/posts/event/post-created.handler.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed, type Mocked } from '@suites/unit';
+import { PostCreatedHandler } from './post-created.handler';
+import { PostCreatedEvent } from './post-created.event';
+import { SlackService } from '@app/shared';
+
+describe('PostCreatedHandler', () => {
+  let handler: PostCreatedHandler;
+  let slackService: Mocked<SlackService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(PostCreatedHandler).compile();
+
+    handler = unit;
+    slackService = unitRef.get(SlackService);
+  });
+
+  it('이벤트의 postId, title, userId를 그대로 Slack 알림으로 전달한다', async () => {
+    await handler.handle(new PostCreatedEvent(10, 'New Post', 1));
+
+    expect(slackService.sendPostCreatedNotification).toHaveBeenCalledWith(
+      10,
+      'New Post',
+      1,
+    );
+  });
+});

--- a/docs/shared-infra-unit-tests-prd.md
+++ b/docs/shared-infra-unit-tests-prd.md
@@ -1,0 +1,118 @@
+# 공유 인프라 단위 테스트 PRD
+
+`libs/shared`의 로직 보유 인프라 코드 4종과 `apps/service`의 유일한 spec 부재 핸들러 1종에 단위 테스트를 추가한다. 프로덕션 코드 동작 변경은 없는 **테스트 전용 작업**이다.
+
+## 1. 배경
+
+프로젝트 전수 점검(2026-06) 결과, 핸들러 25개 중 24개가 단위 spec을 갖춘 것과 대조적으로 공유 인프라 레이어는 단위 테스트가 전무했다. 이 프로젝트의 테스트 철학(Classical School — "로직은 단위 테스트, 연결은 통합 테스트")에 비춰, 아래 파일들은 실제 조건 분기를 보유하므로 단위 테스트 대상이다.
+
+| 대상 | 분기 로직 | 미검증 리스크 |
+| --- | --- | --- |
+| `libs/shared/src/idempotency/idempotency.interceptor.ts` | 헤더 검증, SET NX 선점, PROCESSING 마커 409, 캐시 히트 재생, 손상 JSON 복구, 에러 시 키 해제 — **분기 최다** | 멱등성 보장이 깨져도 잡을 테스트 없음 |
+| `libs/shared/src/database/postgres-error.util.ts` | 23505 타입가드 (3개 이상 핸들러의 동시성 안전망) | 오판 시 unique 위반이 500으로 노출 |
+| `libs/shared/src/cache/cache.service.ts` | Fail-Open swallow, 손상 캐시 self-healing(del), SCAN 커서 루프 | swallow가 깨지면 Redis 장애가 서비스 장애로 전파 |
+| `libs/shared/src/slack/slack.service.ts` | 토큰 미설정 silent skip, 텍스트 escape, 1000자 truncation, 트리플 백틱 무력화, 옵셔널 라인 조립 | 알림 포맷/Fail-Open 회귀를 감지 못함 |
+| `apps/service/src/posts/event/post-created.handler.ts` | (pass-through에 가까움 — §6 참고) | 이벤트→Slack 파라미터 매핑은 통합 테스트의 사각지대 |
+
+## 2. 목표
+
+- 위 5개 파일에 대해 **현재 동작을 그대로 고정(codify)** 하는 단위 테스트를 추가한다.
+- 프로덕션 코드는 수정하지 않는다. 테스트 작성 중 결함을 발견하면 수정하지 않고 본 문서 §7에 기록 후 별도 작업으로 넘긴다.
+- 기존 단위 테스트 인프라(`@swc/jest`, 루트 jest 설정, colocated `*.spec.ts`)를 그대로 사용한다 — 새 패키지·설정 변경 없음.
+
+## 3. 테스트 설계
+
+### 3.1 IdempotencyInterceptor (`idempotency.interceptor.spec.ts`)
+
+DI가 string token(`REDIS_CLIENT`) + `PinoLogger`(nestjs-pino)라 **수동 인스턴스화 + 수동 mock 주입**으로 작성한다 (Suites `TestBed.solitary`는 Handler 패턴 전용 컨벤션 — §5 참고). `ExecutionContext`/`CallHandler`는 최소 stub으로 구성한다.
+
+| # | 시나리오 | 기대 동작 |
+| --- | --- | --- |
+| 1 | `Idempotency-Key` 헤더 없음 | `BadRequestException` |
+| 2 | 헤더가 UUID v4 형식 아님 | `BadRequestException` |
+| 3 | `request.user` 없음 (비인증) | `UnauthorizedException` |
+| 4 | SET NX 성공 → handler 정상 완료 | 키 `idempotency:{userId}:{key}`로 SET NX(EX 60) 후, 응답을 `PX` 24h로 캐시 저장 |
+| 5 | SET NX 성공 → handler 에러 | `redis.del` 호출(키 해제) + 원본 에러 rethrow |
+| 6 | SET NX 실패 + GET = `__PROCESSING__` | `ConflictException`(409) |
+| 7 | SET NX 실패 + GET = 유효 JSON | handler 미실행, 캐시된 `statusCode`로 `response.status` 설정 + `body` 반환 |
+| 8 | SET NX 실패 + GET = 손상 JSON | `redis.del` 후 `ConflictException` — **현재 구현 기준** (§7-1의 로그-동작 불일치 참조) |
+| 9 | SET NX 실패 + GET = null (두 명령 사이 만료) | `ConflictException`(409) |
+| 10 | 헤더가 string[]로 전달 | 첫 요소 사용 |
+
+### 3.2 isUniqueViolation (`postgres-error.util.spec.ts`)
+
+순수 함수 — mock 없이 plain jest로 작성한다. `QueryFailedError`는 `new QueryFailedError(query, parameters, driverError)`로 직접 생성한다.
+
+| # | 입력 | 기대 |
+| --- | --- | --- |
+| 1 | `QueryFailedError` + `driverError.code === '23505'` | `true` |
+| 2 | `QueryFailedError` + 다른 코드(`23503` 등) | `false` |
+| 3 | `QueryFailedError` + `driverError`에 `code` 없음 | `false` |
+| 4 | 일반 `Error` | `false` |
+| 5 | `null` / `undefined` / 문자열 | `false` |
+
+### 3.3 CacheService (`cache.service.spec.ts`)
+
+수동 인스턴스화 + ioredis mock(`get`/`set`/`del`/`scan`만 가진 객체) 주입.
+
+| # | 시나리오 | 기대 동작 |
+| --- | --- | --- |
+| 1 | `get` — 키 존재 | JSON 파싱된 값 반환 |
+| 2 | `get` — 키 없음(null) | `undefined` |
+| 3 | `get` — `redis.get` 예외 | `undefined` 반환 (Fail-Open, rethrow 없음) |
+| 4 | `get` — 손상 JSON | `undefined` 반환 + 해당 키 `del` 시도 (self-healing) |
+| 5 | `get` — 손상 JSON + `del`도 실패 | 그래도 `undefined` 반환 (이중 swallow) |
+| 6 | `set` — 정상 | `JSON.stringify` 값 + `EX {ttl}`로 호출 |
+| 7 | `set` — 예외 | rethrow 없음 |
+| 8 | `del` — 예외 | rethrow 없음 |
+| 9 | `delByPattern` — 커서 2회 순회 | SCAN 루프가 cursor `'0'`까지 반복, 발견 키 전부 `del(...keys)` |
+| 10 | `delByPattern` — 매칭 키 없음 | `del` 미호출 |
+| 11 | `delByPattern` — 예외 | rethrow 없음 |
+
+### 3.4 SlackService (`slack.service.spec.ts`)
+
+`jest.mock('@slack/web-api')`로 `WebClient`를 모킹하고, `ConfigService`는 케이스별 stub(`{ get: () => token | undefined }`)을 생성자에 주입한다 — 생성자에서 토큰 분기가 일어나므로 케이스마다 새로 인스턴스화해야 한다.
+
+| # | 시나리오 | 기대 동작 |
+| --- | --- | --- |
+| 1 | `SLACK_BOT_TOKEN` 미설정 | `WebClient` 미생성, `postMessage` 미호출, 예외 없음 (silent skip) |
+| 2 | `sendPostCreatedNotification` | `&`/`<`/`>`가 `&amp;`/`&lt;`/`&gt;`로 escape된 제목 포함, `POST_CREATED` 채널로 전송 |
+| 3 | `sendSlowQueryAlert` — 1000자 초과 SQL | 1000자에서 잘리고 `... (truncated)` 접미 |
+| 4 | `sendSlowQueryAlert` — SQL에 ``` 포함 | zero-width space 삽입으로 코드 블록 무력화 |
+| 5 | `sendSlowQueryAlert` — HTTP 컨텍스트/userId 존재 | `HTTP`/`UserId` 라인 포함 |
+| 6 | `sendSlowQueryAlert` — 비-HTTP 컨텍스트 | `HTTP`/`UserId` 라인 생략 |
+| 7 | `postMessage` 예외 | 호출자로 전파되지 않음 (Fail-Open) |
+
+### 3.5 PostCreatedHandler (`post-created.handler.spec.ts`)
+
+핸들러이므로 컨벤션대로 Suites `TestBed.solitary(PostCreatedHandler)` 사용, `unitRef.get(SlackService)`로 mock 회수.
+
+| # | 시나리오 | 기대 동작 |
+| --- | --- | --- |
+| 1 | `handle(event)` | `sendPostCreatedNotification(postId, title, userId)` 인자 순서·값 일치 |
+
+## 4. 수용 기준 (Acceptance Criteria)
+
+- [x] 신규 spec 5개가 소스 파일 옆에 colocate되어 추가된다 (기존 컨벤션과 동일).
+- [x] `describe`는 영문 클래스/함수명, `it` 문장은 한국어 행위·결과 진술 (전체 spec 일관 규칙 준수).
+- [x] 프로덕션 코드(`apps/`, `libs/` 비-spec 파일) diff가 0이다.
+- [x] `pnpm format` → `pnpm lint:check` → `pnpm build:all` → `pnpm test` → `pnpm test:e2e` 전부 통과한다.
+- [x] 테스트 중 발견된 결함·불일치는 §7에 기록된다 (코드 수정 금지).
+
+## 5. 비기능 요구사항 / 컨벤션 결정
+
+- **mock 도구 선택 기준**: Handler(`PostCreatedHandler`)는 프로젝트 컨벤션대로 Suites `TestBed.solitary`. 인프라 클래스 3종은 수동 인스턴스화를 사용한다 — 근거: (1) `REDIS_CLIENT` string token·`WebClient` 내부 생성 등 Suites 자동 mock의 이점이 없는 구조, (2) `SlackService`는 생성자에서 분기하므로 케이스별 재인스턴스화가 필요, (3) 순수 클래스 직접 생성이 테스트 의도를 더 명확히 드러냄 (Classical School).
+- **RxJS 처리**: 인터셉터 테스트는 `intercept()`가 반환한 Observable을 `firstValueFrom`으로 변환해 assert한다. `CallHandler.handle()`은 `of(body)` / `throwError(() => err)` stub.
+- **로거 노이즈**: `CacheService`/`SlackService`는 내부 `new Logger()`를 사용하므로 테스트 출력 오염 시에만 `jest.spyOn(Logger.prototype, ...)`으로 침묵 처리 (필수 아님).
+- **신규 패키지·jest 설정 변경 금지.**
+
+## 6. 범위 외 (Out of scope)
+
+- **프로덕션 코드 수정 일체** — §7 발견 사항 수정 포함 (별도 PR).
+- 통합 테스트 추가 (idempotency 키 검증의 E2E 시나리오 등은 별도 작업).
+- `logging/`(interceptor·filter), `otel/`, `health/` 등 나머지 인프라 — 1차 점검에서 우선순위 낮음으로 분류된 항목.
+- 커버리지 설정(`collectCoverageFrom`) 변경 — 별도 작업(개선 권장 2번)으로 진행.
+
+## 7. 작업 중 발견 사항 (코드 수정 없이 기록만)
+
+1. **IdempotencyInterceptor 로그-동작 불일치** (`idempotency.interceptor.ts:88-96`): 손상된 캐시 엔트리를 만나면 `'Corrupted cache entry, reprocessing'`을 로깅하고 키를 삭제한 뒤 — 재처리(reprocess)가 아니라 **`ConflictException`(409)을 던진다**. 클라이언트가 재시도하면 그때 재처리되므로 동작 자체는 안전하지만, 로그 문구가 오해를 유발한다. 테스트는 현재 동작(409)을 고정한다. 후속 작업에서 로그 문구 수정 권장.

--- a/docs/shared-infra-unit-tests-todo.md
+++ b/docs/shared-infra-unit-tests-todo.md
@@ -1,0 +1,100 @@
+# 공유 인프라 단위 테스트 체크리스트
+
+> `libs/shared` 인프라 4종 + `PostCreatedHandler`에 단위 테스트를 추가하기 위한 단계별 체크리스트.
+> 각 Phase는 의존성이 없어 순서 조정이 가능하지만, 난이도 오름차순(순수 함수 → RxJS 인터셉터)으로 정렬했다.
+>
+> 케이스별 상세 설계, mock 도구 선택 근거, 발견 사항은 [shared-infra-unit-tests-prd.md](./shared-infra-unit-tests-prd.md)를 참고한다.
+
+---
+
+## 진행 현황 (요약)
+
+| Phase | 상태 | 비고 |
+|---|---|---|
+| 1. postgres-error.util | ✅ 완료 | 순수 함수, plain jest |
+| 2. PostCreatedHandler | ✅ 완료 | Suites `TestBed.solitary` |
+| 3. CacheService | ✅ 완료 | 수동 인스턴스화 + ioredis mock |
+| 4. SlackService | ✅ 완료 | `jest.mock('@slack/web-api')` + ConfigService stub |
+| 5. IdempotencyInterceptor | ✅ 완료 | 수동 인스턴스화, RxJS `firstValueFrom` |
+| 6. 최종 검증 | ✅ 완료 | format → lint:check → build:all → test → test:e2e |
+
+---
+
+## Phase 1: `postgres-error.util.spec.ts`
+
+> **위치**: `libs/shared/src/database/postgres-error.util.spec.ts`
+
+- [x] `QueryFailedError` + `driverError.code='23505'` → `true`
+- [x] `QueryFailedError` + 다른 SQLSTATE(`23503`) → `false`
+- [x] `QueryFailedError` + `code` 없는 `driverError` → `false`
+- [x] 일반 `Error` → `false`
+- [x] `null` / `undefined` / 문자열 → `false`
+- [x] `npx jest libs/shared/src/database/postgres-error.util.spec.ts` 통과
+
+## Phase 2: `post-created.handler.spec.ts`
+
+> **위치**: `apps/service/src/posts/event/post-created.handler.spec.ts`
+> 기존 핸들러 spec(예: `create-post.handler.spec.ts`)의 Suites 패턴을 그대로 따른다.
+
+- [x] `TestBed.solitary(PostCreatedHandler)` 셋업, `unitRef.get(SlackService)` mock 회수
+- [x] `handle(event)` 시 `sendPostCreatedNotification(postId, title, userId)` 인자 검증
+- [x] `npx jest apps/service/src/posts/event/post-created.handler.spec.ts` 통과
+
+## Phase 3: `cache.service.spec.ts`
+
+> **위치**: `libs/shared/src/cache/cache.service.spec.ts`
+> ioredis mock 객체(`get`/`set`/`del`/`scan`)를 생성자에 직접 주입.
+
+- [x] `get` 히트 → JSON 파싱 값 반환
+- [x] `get` 미스(null) → `undefined`
+- [x] `get` Redis 예외 → `undefined` (Fail-Open, rethrow 없음)
+- [x] `get` 손상 JSON → `undefined` + 해당 키 `del` 호출 (self-healing)
+- [x] `get` 손상 JSON + `del` 실패 → 그래도 `undefined` (이중 swallow)
+- [x] `set` 정상 → `JSON.stringify` + `'EX', ttl` 인자 검증
+- [x] `set`/`del` Redis 예외 → rethrow 없음
+- [x] `delByPattern` 커서 2회 순회 → 전체 키 `del(...keys)`
+- [x] `delByPattern` 매칭 없음 → `del` 미호출
+- [x] `delByPattern` Redis 예외 → rethrow 없음
+- [x] `npx jest libs/shared/src/cache/cache.service.spec.ts` 통과
+
+## Phase 4: `slack.service.spec.ts`
+
+> **위치**: `libs/shared/src/slack/slack.service.spec.ts`
+> `jest.mock('@slack/web-api')` + 케이스별 `ConfigService` stub 재인스턴스화.
+
+- [x] 토큰 미설정 → `WebClient` 미생성, `postMessage` 미호출, 예외 없음
+- [x] `sendPostCreatedNotification` → `&`/`<`/`>` escape + `POST_CREATED` 채널 검증
+- [x] `sendSlowQueryAlert` 1000자 초과 → truncation + `... (truncated)` 접미
+- [x] `sendSlowQueryAlert` 트리플 백틱 → zero-width space 무력화
+- [x] `sendSlowQueryAlert` HTTP 컨텍스트/userId 존재 → 해당 라인 포함
+- [x] `sendSlowQueryAlert` 비-HTTP 컨텍스트 → 해당 라인 생략
+- [x] `postMessage` 예외 → 호출자로 전파 안 됨 (Fail-Open)
+- [x] `npx jest libs/shared/src/slack/slack.service.spec.ts` 통과
+
+## Phase 5: `idempotency.interceptor.spec.ts`
+
+> **위치**: `libs/shared/src/idempotency/idempotency.interceptor.spec.ts`
+> 수동 인스턴스화(mock redis + mock PinoLogger). `ExecutionContext`/`CallHandler` 최소 stub.
+> Observable 검증은 `firstValueFrom` 사용.
+
+- [x] 헤더 없음 → `BadRequestException`
+- [x] UUID v4 아님 → `BadRequestException`
+- [x] `request.user` 없음 → `UnauthorizedException`
+- [x] 헤더 string[] → 첫 요소 사용
+- [x] SET NX 성공 + handler 성공 → `idempotency:{userId}:{key}` 키, 응답 `PX` 24h 캐시
+- [x] SET NX 성공 + handler 에러 → `redis.del` + 원본 에러 rethrow
+- [x] SET NX 실패 + GET=`__PROCESSING__` → 409
+- [x] SET NX 실패 + GET=유효 JSON → handler 미실행, `response.status(cached.statusCode)` + body 반환
+- [x] SET NX 실패 + GET=손상 JSON → `del` 후 409 (PRD §7-1: 현재 동작 고정)
+- [x] SET NX 실패 + GET=null (만료 race) → 409
+- [x] `npx jest libs/shared/src/idempotency/idempotency.interceptor.spec.ts` 통과
+
+## Phase 6: 최종 검증
+
+- [x] `pnpm format`
+- [x] `pnpm lint:check`
+- [x] `pnpm build:all`
+- [x] `pnpm test` (신규 spec 5개 포함 전체 통과)
+- [x] `pnpm test:e2e` (회귀 없음 확인, Docker 필요)
+- [x] 프로덕션 코드 diff 0 확인 (`git diff --stat` 에 spec·docs 파일만 존재)
+- [x] PRD §7 발견 사항 최신화

--- a/libs/shared/src/cache/cache.service.spec.ts
+++ b/libs/shared/src/cache/cache.service.spec.ts
@@ -1,0 +1,153 @@
+import { Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+import { CacheService } from './cache.service';
+
+type MockRedis = {
+  get: jest.Mock;
+  set: jest.Mock;
+  del: jest.Mock;
+  scan: jest.Mock;
+};
+
+describe('CacheService', () => {
+  let redis: MockRedis;
+  let service: CacheService;
+
+  beforeAll(() => {
+    // Fail-Open 경로가 warn을 남기므로 테스트 출력 오염을 막는다.
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+  });
+
+  beforeEach(() => {
+    redis = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+      scan: jest.fn(),
+    };
+    service = new CacheService(redis as unknown as Redis);
+  });
+
+  describe('get', () => {
+    it('키가 존재하면 JSON 파싱된 값을 반환한다', async () => {
+      redis.get.mockResolvedValue(JSON.stringify({ id: 1, title: 'Post' }));
+
+      await expect(service.get('post:1:1')).resolves.toEqual({
+        id: 1,
+        title: 'Post',
+      });
+    });
+
+    it('키가 없으면 undefined를 반환한다', async () => {
+      redis.get.mockResolvedValue(null);
+
+      await expect(service.get('post:1:1')).resolves.toBeUndefined();
+    });
+
+    it('Redis GET이 실패해도 예외를 전파하지 않고 undefined를 반환한다 (Fail-Open)', async () => {
+      redis.get.mockRejectedValue(new Error('connection refused'));
+
+      await expect(service.get('post:1:1')).resolves.toBeUndefined();
+    });
+
+    it('손상된 JSON이면 undefined를 반환하고 해당 키를 삭제한다 (self-healing)', async () => {
+      redis.get.mockResolvedValue('{not-json');
+      redis.del.mockResolvedValue(1);
+
+      await expect(service.get('post:1:1')).resolves.toBeUndefined();
+      expect(redis.del).toHaveBeenCalledWith('post:1:1');
+    });
+
+    it('손상된 JSON 삭제까지 실패해도 undefined를 반환한다 (이중 swallow)', async () => {
+      redis.get.mockResolvedValue('{not-json');
+      redis.del.mockRejectedValue(new Error('connection refused'));
+
+      await expect(service.get('post:1:1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('set', () => {
+    it('값을 JSON 직렬화하여 EX TTL과 함께 저장한다', async () => {
+      redis.set.mockResolvedValue('OK');
+
+      await service.set('post:1:1', { id: 1 }, 300);
+
+      expect(redis.set).toHaveBeenCalledWith(
+        'post:1:1',
+        JSON.stringify({ id: 1 }),
+        'EX',
+        300,
+      );
+    });
+
+    it('Redis SET이 실패해도 예외를 전파하지 않는다 (Fail-Open)', async () => {
+      redis.set.mockRejectedValue(new Error('connection refused'));
+
+      await expect(
+        service.set('post:1:1', { id: 1 }, 300),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('del', () => {
+    it('키를 삭제한다', async () => {
+      redis.del.mockResolvedValue(1);
+
+      await service.del('post:1:1');
+
+      expect(redis.del).toHaveBeenCalledWith('post:1:1');
+    });
+
+    it('Redis DEL이 실패해도 예외를 전파하지 않는다 (Fail-Open)', async () => {
+      redis.del.mockRejectedValue(new Error('connection refused'));
+
+      await expect(service.del('post:1:1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('delByPattern', () => {
+    it('SCAN 커서를 0이 될 때까지 순회하며 발견한 키를 모두 삭제한다', async () => {
+      redis.scan
+        .mockResolvedValueOnce(['42', ['posts:1:a', 'posts:1:b']])
+        .mockResolvedValueOnce(['0', ['posts:1:c']]);
+      redis.del.mockResolvedValue(1);
+
+      await service.delByPattern('posts:1:*');
+
+      expect(redis.scan).toHaveBeenCalledTimes(2);
+      expect(redis.scan).toHaveBeenNthCalledWith(
+        1,
+        '0',
+        'MATCH',
+        'posts:1:*',
+        'COUNT',
+        100,
+      );
+      expect(redis.scan).toHaveBeenNthCalledWith(
+        2,
+        '42',
+        'MATCH',
+        'posts:1:*',
+        'COUNT',
+        100,
+      );
+      expect(redis.del).toHaveBeenNthCalledWith(1, 'posts:1:a', 'posts:1:b');
+      expect(redis.del).toHaveBeenNthCalledWith(2, 'posts:1:c');
+    });
+
+    it('매칭되는 키가 없으면 DEL을 호출하지 않는다', async () => {
+      redis.scan.mockResolvedValue(['0', []]);
+
+      await service.delByPattern('posts:1:*');
+
+      expect(redis.del).not.toHaveBeenCalled();
+    });
+
+    it('Redis SCAN이 실패해도 예외를 전파하지 않는다 (Fail-Open)', async () => {
+      redis.scan.mockRejectedValue(new Error('connection refused'));
+
+      await expect(service.delByPattern('posts:1:*')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/libs/shared/src/database/postgres-error.util.spec.ts
+++ b/libs/shared/src/database/postgres-error.util.spec.ts
@@ -1,0 +1,42 @@
+import { QueryFailedError } from 'typeorm';
+import { isUniqueViolation } from './postgres-error.util';
+
+function createQueryFailedError(driverError: Error): QueryFailedError {
+  return new QueryFailedError('INSERT INTO posts ...', [], driverError);
+}
+
+describe('isUniqueViolation', () => {
+  it('driverError.code가 23505인 QueryFailedError이면 true를 반환한다', () => {
+    const driverError = Object.assign(new Error('duplicate key'), {
+      code: '23505',
+    });
+
+    expect(isUniqueViolation(createQueryFailedError(driverError))).toBe(true);
+  });
+
+  it('driverError.code가 다른 SQLSTATE(23503)이면 false를 반환한다', () => {
+    const driverError = Object.assign(new Error('fk violation'), {
+      code: '23503',
+    });
+
+    expect(isUniqueViolation(createQueryFailedError(driverError))).toBe(false);
+  });
+
+  it('driverError에 code가 없으면 false를 반환한다', () => {
+    expect(
+      isUniqueViolation(createQueryFailedError(new Error('no code'))),
+    ).toBe(false);
+  });
+
+  it('QueryFailedError가 아닌 일반 Error이면 false를 반환한다', () => {
+    const error = Object.assign(new Error('plain'), { code: '23505' });
+
+    expect(isUniqueViolation(error)).toBe(false);
+  });
+
+  it('null, undefined, 문자열 입력이면 false를 반환한다', () => {
+    expect(isUniqueViolation(null)).toBe(false);
+    expect(isUniqueViolation(undefined)).toBe(false);
+    expect(isUniqueViolation('23505')).toBe(false);
+  });
+});

--- a/libs/shared/src/idempotency/idempotency.interceptor.spec.ts
+++ b/libs/shared/src/idempotency/idempotency.interceptor.spec.ts
@@ -1,0 +1,206 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { firstValueFrom, of, throwError } from 'rxjs';
+import type Redis from 'ioredis';
+import { PinoLogger } from 'nestjs-pino';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+
+const VALID_UUID = '8d8b30e3-de52-4f62-90b3-4c8f1c1c1a1e';
+const PROCESSING_MARKER = '__PROCESSING__';
+
+type MockRedis = {
+  set: jest.Mock;
+  get: jest.Mock;
+  del: jest.Mock;
+};
+
+type MockResponse = {
+  statusCode: number;
+  status: jest.Mock;
+};
+
+function createExecutionContext(
+  request: Record<string, unknown>,
+  response: MockResponse,
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function createRequest(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    headers: { 'idempotency-key': VALID_UUID },
+    user: { id: 1 },
+    ...overrides,
+  };
+}
+
+describe('IdempotencyInterceptor', () => {
+  let redis: MockRedis;
+  let response: MockResponse;
+  let interceptor: IdempotencyInterceptor;
+  let next: CallHandler;
+
+  beforeEach(() => {
+    redis = { set: jest.fn(), get: jest.fn(), del: jest.fn() };
+    response = { statusCode: 201, status: jest.fn() };
+    const logger = {
+      setContext: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as PinoLogger;
+    interceptor = new IdempotencyInterceptor(redis as unknown as Redis, logger);
+    next = { handle: jest.fn().mockReturnValue(of({ id: 1 })) };
+  });
+
+  it('Idempotency-Key 헤더가 없으면 BadRequestException을 발생시킨다', async () => {
+    const ctx = createExecutionContext(
+      createRequest({ headers: {} }),
+      response,
+    );
+
+    await expect(interceptor.intercept(ctx, next)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('헤더가 UUID v4 형식이 아니면 BadRequestException을 발생시킨다', async () => {
+    const ctx = createExecutionContext(
+      createRequest({ headers: { 'idempotency-key': 'not-a-uuid' } }),
+      response,
+    );
+
+    await expect(interceptor.intercept(ctx, next)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('인증된 사용자가 없으면 UnauthorizedException을 발생시킨다', async () => {
+    const ctx = createExecutionContext(
+      createRequest({ user: undefined }),
+      response,
+    );
+
+    await expect(interceptor.intercept(ctx, next)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('헤더가 배열로 전달되면 첫 요소를 멱등성 키로 사용한다', async () => {
+    redis.set.mockResolvedValue('OK');
+    const ctx = createExecutionContext(
+      createRequest({ headers: { 'idempotency-key': [VALID_UUID, 'other'] } }),
+      response,
+    );
+
+    await firstValueFrom(await interceptor.intercept(ctx, next));
+
+    expect(redis.set).toHaveBeenCalledWith(
+      `idempotency:1:${VALID_UUID}`,
+      PROCESSING_MARKER,
+      'EX',
+      60,
+      'NX',
+    );
+  });
+
+  it('선점에 성공하면 handler를 실행하고 응답을 24시간 TTL로 캐시한다', async () => {
+    redis.set.mockResolvedValue('OK');
+    const ctx = createExecutionContext(createRequest(), response);
+
+    const result = await firstValueFrom(await interceptor.intercept(ctx, next));
+
+    expect(result).toEqual({ id: 1 });
+    expect(redis.set).toHaveBeenNthCalledWith(
+      1,
+      `idempotency:1:${VALID_UUID}`,
+      PROCESSING_MARKER,
+      'EX',
+      60,
+      'NX',
+    );
+    expect(redis.set).toHaveBeenNthCalledWith(
+      2,
+      `idempotency:1:${VALID_UUID}`,
+      JSON.stringify({ statusCode: 201, body: { id: 1 } }),
+      'PX',
+      1000 * 60 * 60 * 24,
+    );
+  });
+
+  it('handler가 실패하면 선점 키를 해제하고 원본 에러를 다시 던진다', async () => {
+    redis.set.mockResolvedValue('OK');
+    redis.del.mockResolvedValue(1);
+    next = {
+      handle: jest.fn().mockReturnValue(throwError(() => new Error('boom'))),
+    };
+    const ctx = createExecutionContext(createRequest(), response);
+
+    await expect(
+      firstValueFrom(await interceptor.intercept(ctx, next)),
+    ).rejects.toThrow('boom');
+    expect(redis.del).toHaveBeenCalledWith(`idempotency:1:${VALID_UUID}`);
+  });
+
+  it('다른 요청이 처리 중(PROCESSING 마커)이면 ConflictException을 발생시킨다', async () => {
+    redis.set.mockResolvedValue(null);
+    redis.get.mockResolvedValue(PROCESSING_MARKER);
+    const ctx = createExecutionContext(createRequest(), response);
+
+    await expect(interceptor.intercept(ctx, next)).rejects.toThrow(
+      ConflictException,
+    );
+    expect(next.handle).not.toHaveBeenCalled();
+  });
+
+  it('캐시된 응답이 있으면 handler를 실행하지 않고 저장된 상태 코드와 본문을 재생한다', async () => {
+    redis.set.mockResolvedValue(null);
+    redis.get.mockResolvedValue(
+      JSON.stringify({ statusCode: 201, body: { id: 5 } }),
+    );
+    const ctx = createExecutionContext(createRequest(), response);
+
+    const result = await firstValueFrom(await interceptor.intercept(ctx, next));
+
+    expect(result).toEqual({ id: 5 });
+    expect(response.status).toHaveBeenCalledWith(201);
+    expect(next.handle).not.toHaveBeenCalled();
+  });
+
+  it('캐시 엔트리가 손상되었으면 키를 삭제하고 ConflictException을 발생시킨다 (PRD §7-1: 현재 동작 고정)', async () => {
+    redis.set.mockResolvedValue(null);
+    redis.get.mockResolvedValue('{corrupted');
+    redis.del.mockResolvedValue(1);
+    const ctx = createExecutionContext(createRequest(), response);
+
+    await expect(interceptor.intercept(ctx, next)).rejects.toThrow(
+      ConflictException,
+    );
+    expect(redis.del).toHaveBeenCalledWith(`idempotency:1:${VALID_UUID}`);
+    expect(next.handle).not.toHaveBeenCalled();
+  });
+
+  it('선점 실패 후 키가 만료되어 GET이 null이면 ConflictException으로 안전하게 차단한다', async () => {
+    redis.set.mockResolvedValue(null);
+    redis.get.mockResolvedValue(null);
+    const ctx = createExecutionContext(createRequest(), response);
+
+    await expect(interceptor.intercept(ctx, next)).rejects.toThrow(
+      ConflictException,
+    );
+    expect(next.handle).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/src/slack/slack.service.spec.ts
+++ b/libs/shared/src/slack/slack.service.spec.ts
@@ -1,0 +1,138 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { WebClient } from '@slack/web-api';
+import { SlackService } from './slack.service';
+import { SLACK_CHANNELS } from './slack.channels';
+import type { SlowQueryInfo } from '../otel/slow-query-span-processor';
+
+jest.mock('@slack/web-api', () => ({
+  WebClient: jest.fn(),
+}));
+
+const WebClientMock = WebClient as unknown as jest.Mock;
+
+function createService(token: string | undefined): SlackService {
+  const configService = {
+    get: jest.fn().mockReturnValue(token),
+  } as unknown as ConfigService;
+  return new SlackService(configService);
+}
+
+function createSlowQueryInfo(
+  overrides: Partial<SlowQueryInfo> = {},
+): SlowQueryInfo {
+  return {
+    durationMs: 6500,
+    dbSystem: 'postgresql',
+    dbName: 'nest_repository',
+    operation: 'SELECT',
+    statement: 'SELECT * FROM posts WHERE user_id = $1',
+    traceId: 'trace-1',
+    spanId: 'span-1',
+    serviceName: 'service',
+    occurredAt: new Date('2026-06-11T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('SlackService', () => {
+  let postMessage: jest.Mock;
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  beforeEach(() => {
+    postMessage = jest.fn().mockResolvedValue({ ok: true });
+    WebClientMock.mockReset();
+    WebClientMock.mockImplementation(() => ({ chat: { postMessage } }));
+  });
+
+  it('SLACK_BOT_TOKEN이 없으면 WebClient를 생성하지 않고 전송을 건너뛴다 (silent skip)', async () => {
+    const service = createService(undefined);
+
+    await service.sendPostCreatedNotification(1, 'Title', 1);
+
+    expect(WebClientMock).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it('게시글 생성 알림은 제목의 & < > 를 escape하여 POST_CREATED 채널로 전송한다', async () => {
+    const service = createService('xoxb-token');
+
+    await service.sendPostCreatedNotification(10, 'A & B <script>', 1);
+
+    expect(postMessage).toHaveBeenCalledWith({
+      channel: SLACK_CHANNELS.POST_CREATED,
+      text: expect.stringContaining('A &amp; B &lt;script&gt;') as string,
+    });
+    const { text } = postMessage.mock.calls[0][0] as { text: string };
+    expect(text).toContain('*Post ID:* 10');
+    expect(text).toContain('*User ID:* 1');
+  });
+
+  it('슬로우 쿼리 SQL이 1000자를 넘으면 잘라내고 truncated 표시를 붙인다', async () => {
+    const service = createService('xoxb-token');
+    const longStatement = 'S'.repeat(1500);
+
+    await service.sendSlowQueryAlert(
+      createSlowQueryInfo({ statement: longStatement }),
+    );
+
+    const { channel, text } = postMessage.mock.calls[0][0] as {
+      channel: string;
+      text: string;
+    };
+    expect(channel).toBe(SLACK_CHANNELS.SLOW_QUERY);
+    expect(text).toContain(`${'S'.repeat(1000)}... (truncated)`);
+    expect(text).not.toContain('S'.repeat(1001));
+  });
+
+  it('SQL에 트리플 백틱이 있으면 zero-width space로 무력화하여 코드 블록 깨짐을 막는다', async () => {
+    const service = createService('xoxb-token');
+
+    await service.sendSlowQueryAlert(
+      createSlowQueryInfo({ statement: 'SELECT ``` FROM x' }),
+    );
+
+    const { text } = postMessage.mock.calls[0][0] as { text: string };
+    expect(text).toContain('`​`​`');
+    expect(text).not.toContain('SELECT ``` FROM x');
+  });
+
+  it('HTTP 컨텍스트와 userId가 있으면 해당 라인을 포함한다', async () => {
+    const service = createService('xoxb-token');
+
+    await service.sendSlowQueryAlert(
+      createSlowQueryInfo({
+        httpMethod: 'GET',
+        httpRoute: '/v1/posts/:id',
+        userId: 7,
+      }),
+    );
+
+    const { text } = postMessage.mock.calls[0][0] as { text: string };
+    expect(text).toContain('HTTP     : GET /v1/posts/:id');
+    expect(text).toContain('UserId   : 7');
+  });
+
+  it('비-HTTP 컨텍스트면 HTTP/UserId 라인을 생략한다', async () => {
+    const service = createService('xoxb-token');
+
+    await service.sendSlowQueryAlert(createSlowQueryInfo());
+
+    const { text } = postMessage.mock.calls[0][0] as { text: string };
+    expect(text).not.toContain('HTTP     :');
+    expect(text).not.toContain('UserId   :');
+  });
+
+  it('postMessage가 실패해도 호출자에게 예외를 전파하지 않는다 (Fail-Open)', async () => {
+    const service = createService('xoxb-token');
+    postMessage.mockRejectedValue(new Error('slack api error'));
+
+    await expect(
+      service.sendPostCreatedNotification(1, 'Title', 1),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
> **Merge Strategy**: Create a merge commit을 사용해주세요.

## Summary

핸들러 25개 중 24개가 단위 spec을 갖춘 것과 달리 공유 인프라 레이어는 단위 테스트가 전무했다. 이 PR은 분기 로직을 보유한 인프라 4종과 spec이 없던 유일한 핸들러의 현재 동작을 단위 테스트로 고정한다. 프로덕션 코드 변경은 없는 테스트 전용 작업이다.

| Spec | 케이스 | 핵심 검증 |
| --- | --- | --- |
| `postgres-error.util.spec.ts` | 5 | 23505 unique 위반 타입가드 판별 |
| `cache.service.spec.ts` | 12 | Fail-Open(장애 시에도 호출자에 예외를 던지지 않고 통과) 동작, 손상 JSON 자가 복구 삭제, SCAN 커서 순회 |
| `slack.service.spec.ts` | 7 | 토큰 미설정 시 전송 생략, 특수문자 escape, 1000자 잘라내기, 트리플 백틱 무력화 |
| `idempotency.interceptor.spec.ts` | 10 | 헤더 검증, SET NX 선점, 409 분기, 캐시 응답 재생, handler 실패 시 키 해제 |
| `post-created.handler.spec.ts` | 1 | 이벤트가 Slack 알림으로 전달되는 파라미터 매핑 |

설계 문서 2종(`docs/shared-infra-unit-tests-{prd,todo}.md`)을 함께 추가한다. 케이스별 설계, mock 도구 선택 근거, 진행 체크리스트를 담는다.

## Notes

- mock 도구는 프로젝트 컨벤션에 따라 분리했다. 핸들러는 Suites `TestBed.solitary`, 인프라 3종은 수동 인스턴스화를 사용한다. `REDIS_CLIENT` string token과 `SlackService`의 생성자 분기(토큰 유무) 때문에 자동 mock의 이점이 없는 구조다.
- 테스트 작성 중 `IdempotencyInterceptor`의 로그-동작 불일치를 발견했다. 손상된 캐시를 만나면 "reprocessing"이라 로깅하지만 실제로는 409를 반환한다. 이 PR은 현재 동작을 테스트로 고정하고, 수정은 PRD §7에 기록해 별도 작업으로 남겼다.

## Test plan

- [x] `pnpm format` / `pnpm lint:check` 통과
- [x] `pnpm build:all` 양쪽 앱 빌드 성공
- [x] `pnpm test` 183케이스 전체 통과 (신규 35케이스 포함, suite 42 → 47)
- [x] `pnpm test:e2e` service + back-office 통합 테스트 전체 통과
- [x] 프로덕션 코드 diff 0 확인 (신규 spec 5개 + docs 2개만 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 핵심 인프라 서비스 및 이벤트 핸들러에 대한 포괄적인 단위 테스트 추가.
  * 캐시 작업, 데이터베이스 오류 처리, 멱등성 검증, 알림 전달에 대한 테스트 케이스 포함.

* **Documentation**
  * 단위 테스트 구현 계획 및 실행 체크리스트 문서 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->