### PR TITLE
chore: jest 커버리지 수집 범위를 apps/libs 소스로 한정

### DIFF
--- a/docs/jest-coverage-scope-prd.md
+++ b/docs/jest-coverage-scope-prd.md
@@ -1,0 +1,37 @@
+# Jest 커버리지 수집 범위 한정 PRD
+
+루트 `package.json`의 jest 설정에서 `collectCoverageFrom`을 소스 디렉터리(`apps/`, `libs/`)의 TypeScript 파일로 한정한다. 1줄 설정 변경이며 테스트 코드·프로덕션 코드 변경은 없다.
+
+## 1. 배경
+
+현재 설정은 `"collectCoverageFrom": ["**/*.(t|j)s"]`로, 커버리지 대상이 레포 루트 전체의 `.ts`/`.js` 파일이다. jest 기본 제외는 `node_modules`뿐이라 다음이 커버리지 분모에 섞인다.
+
+| 오염원 | 발생 환경 | 영향 |
+| --- | --- | --- |
+| `test/**/*.ts` (통합 spec 6개 + setup 헬퍼 등 15개 파일) | CI(coverage.yml) + 로컬 | 단위 테스트가 실행하지 않는 파일이 0%로 집계되어 수치 희석 |
+| `webpack.config.js` 등 루트 `.js` 설정 파일 | CI + 로컬 | 동일 |
+| `dist/**` 컴파일 산출물 | 로컬에서 빌드 후 `test:cov` 실행 시 | 소스와 산출물 이중 집계 (CI coverage job은 빌드 단계가 없어 미발생) |
+
+PR 커버리지 리포트(coverage.yml의 PR 코멘트)가 실제 소스 커버리지보다 낮게 표시되고, 로컬과 CI의 수치가 빌드 여부에 따라 달라진다.
+
+## 2. 목표
+
+- `collectCoverageFrom`을 `["apps/**/*.ts", "libs/**/*.ts"]`로 변경하여 커버리지 분모를 소스 코드로 한정한다.
+- 커버리지 수치가 "단위 테스트가 커버해야 할 코드" 기준으로 일관되게 산출된다 (로컬 빌드 여부·test/ 헬퍼와 무관).
+
+## 3. 수용 기준 (Acceptance Criteria)
+
+- [x] `package.json` jest 설정의 `collectCoverageFrom`이 `["apps/**/*.ts", "libs/**/*.ts"]`로 변경된다.
+- [x] `pnpm test -- --coverage` 리포트의 파일 목록에 `test/`, `webpack.config.js`, `dist/` 경로가 나타나지 않는다.
+- [x] CI coverage.yml이 사용하는 `coverage/coverage-summary.json`·`coverage-final.json`이 기존과 동일하게 생성된다 (reporter 설정은 변경하지 않으므로 영향 없음 확인).
+- [x] `pnpm format` → `pnpm lint:check` → `pnpm build:all` → `pnpm test` → `pnpm test:e2e` 전부 통과한다.
+
+## 4. 범위 외 (Out of scope)
+
+- **`coverageThreshold` 추가** — 기준선 수치 합의가 필요한 별도 결정 사항. 이번 변경으로 정확해진 수치를 보고 추후 판단한다.
+- **`main.ts`·`migrations/` 등 세부 제외 규칙** — 부팅·마이그레이션 코드를 분모에서 뺄지는 측정 정책 논의가 필요하므로 이번엔 손대지 않는다.
+- coverage.yml 워크플로 자체 변경 (reporter·액션 교체 등).
+
+## 5. 참고
+
+- spec 파일(`*.spec.ts`)은 glob에 매칭되더라도 jest가 테스트 파일을 instrumentation 대상에서 자동 제외하므로 별도 제외 패턴이 필요 없다 — 검증 단계에서 리포트에 spec 파일이 없는 것으로 확인한다.

--- a/docs/jest-coverage-scope-todo.md
+++ b/docs/jest-coverage-scope-todo.md
@@ -1,0 +1,31 @@
+# Jest 커버리지 수집 범위 한정 체크리스트
+
+> 배경과 수용 기준은 [jest-coverage-scope-prd.md](./jest-coverage-scope-prd.md)를 참고한다.
+
+## 진행 현황 (요약)
+
+| Phase | 상태 | 비고 |
+|---|---|---|
+| 1. 설정 변경 | ✅ 완료 | `collectCoverageFrom` 1줄 |
+| 2. 커버리지 산출 검증 | ✅ 완료 | 리포트 파일 목록 + CI용 json 생성 확인 |
+| 3. 최종 검증 | ✅ 완료 | format → lint:check → build:all → test → test:e2e |
+
+## Phase 1: 설정 변경
+
+- [x] `package.json` jest의 `collectCoverageFrom`을 `["apps/**/*.ts", "libs/**/*.ts"]`로 변경
+
+## Phase 2: 커버리지 산출 검증
+
+- [x] `pnpm test -- --coverage --coverageReporters=text --coverageReporters=json-summary --coverageReporters=json` 실행
+- [x] 리포트 파일 목록에 `test/`·`webpack.config.js`·`*.spec.ts` 없음 확인
+- [x] (로컬 빌드 후 재실행) `dist/` 경로 없음 확인
+- [x] `coverage/coverage-summary.json`·`coverage-final.json` 생성 확인 (CI 액션 입력 호환)
+
+## Phase 3: 최종 검증
+
+- [x] `pnpm format`
+- [x] `pnpm lint:check`
+- [x] `pnpm build:all`
+- [x] `pnpm test`
+- [x] `pnpm test:e2e` (Docker 필요)
+- [x] 변경 파일이 `package.json`·docs 2개뿐인지 확인

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
       "^.+\\.(t|j)s$": "@swc/jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "apps/**/*.ts",
+      "libs/**/*.ts"
     ],
     "coverageDirectory": "./coverage",
     "testEnvironment": "node",


### PR DESCRIPTION
> **Merge Strategy**: Create a merge commit을 사용해주세요.

## Summary

기존 `collectCoverageFrom`(`"**/*.(t|j)s"`)은 커버리지 분모에 소스가 아닌 파일들을 포함해 수치를 희석했다. 이 PR은 수집 범위를 `["apps/**/*.ts", "libs/**/*.ts"]`로 한정한다. 실질 변경은 `package.json` 1줄이며, 설계 문서 2개(`docs/jest-coverage-scope-{prd,todo}.md`)를 함께 추가한다.

기존 설정의 오염원 3종:

| 오염원 | 발생 환경 | 영향 |
| --- | --- | --- |
| `test/**/*.ts` (통합 spec + setup 헬퍼 15개) | CI + 로컬 | 단위 테스트가 실행하지 않는 파일이 0%로 집계 |
| `webpack.config.js` 등 루트 `.js` | CI + 로컬 | 동일 |
| `dist/**` 컴파일 산출물 | 로컬 빌드 후 실행 시 | 소스와 산출물 이중 집계로 CI와 수치 불일치 |

## Notes

- 머지 후 첫 PR부터 커버리지 코멘트 수치가 **올라가 보이는 변화**가 나타난다. 분모에서 0% 파일들이 빠지기 때문이며, 실제 테스트가 줄어든 것이 아니다.
- `coverageThreshold` 도입은 범위 외로 남겼다. 정확해진 수치를 확보한 뒤 기준선을 별도로 결정한다.
- spec 파일은 glob에 매칭되어도 jest가 테스트 파일을 instrumentation에서 자동 제외하므로 별도 제외 패턴이 필요 없다 (검증으로 확인).

## Test plan

- [x] 커버리지 대상 166개 파일이 전부 apps/libs 소스임을 확인 (`test/`·`webpack.config.js`·`*.spec.ts` 0건)
- [x] `pnpm build:all`로 `dist/`가 존재하는 상태에서 재실행해도 산출물 미포함 확인
- [x] CI coverage.yml이 소비하는 `coverage-summary.json`·`coverage-final.json` 정상 생성 확인 (reporter 미변경)
- [x] `pnpm format` / `pnpm lint:check` / `pnpm build:all` / `pnpm test`(183개) / `pnpm test:e2e`(service 160 + back-office 34) 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)