### PR TITLE
chore: 실현 불가능한 Swagger 403 문서 제거, env 템플릿·engines 보완

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,12 @@ OTEL_SERVICE_NAME=nest-repository-pattern
 # 단일 PostgreSQL 쿼리가 이 값(ms)을 넘으면 Slack #*-slow-query 채널로 알림. 0 또는 음수/잘못된 값이면 5000ms 폴백.
 SLOW_QUERY_THRESHOLD_MS=5000
 
+# 앱 포트 (미설정 시 service 3000, back-office 3001 기본값)
+PORT=3000
 ADMIN_PORT=3001
+
+# Rate Limiting 비활성화 (테스트 전용 — true면 ThrottlerGuard를 건너뜀, 운영에서는 false 유지)
+THROTTLE_SKIP=false
 
 # CORS (쉼표 구분 origin 목록, production 환경에서는 필수)
 SERVICE_CORS_ORIGINS=https://app.example.com

--- a/apps/service/src/posts/posts.controller.ts
+++ b/apps/service/src/posts/posts.controller.ts
@@ -18,7 +18,6 @@ import {
   ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
-  ApiForbiddenResponse,
   ApiHeader,
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -114,8 +113,9 @@ export class PostsController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: '게시글 수정 (전체 업데이트)' })
   @ApiNoContentResponse({ description: '수정 성공' })
-  @ApiNotFoundResponse({ description: '게시글을 찾을 수 없음' })
-  @ApiForbiddenResponse({ description: '본인의 게시글만 수정 가능' })
+  @ApiNotFoundResponse({
+    description: '게시글을 찾을 수 없음 (본인의 게시글이 아닌 경우 포함)',
+  })
   @ApiBadRequestResponse({ description: '잘못된 요청' })
   async updatePost(
     @CurrentUser() user: AuthUser,
@@ -138,8 +138,9 @@ export class PostsController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: '게시글 삭제' })
   @ApiNoContentResponse({ description: '삭제 성공' })
-  @ApiNotFoundResponse({ description: '게시글을 찾을 수 없음' })
-  @ApiForbiddenResponse({ description: '본인의 게시글만 삭제 가능' })
+  @ApiNotFoundResponse({
+    description: '게시글을 찾을 수 없음 (본인의 게시글이 아닌 경우 포함)',
+  })
   async deletePost(
     @CurrentUser() user: AuthUser,
     @Param('id', ParseIntPipe) id: number,

--- a/docs/swagger-env-engines-prd.md
+++ b/docs/swagger-env-engines-prd.md
@@ -1,0 +1,41 @@
+# Swagger 죽은 403 제거 + 환경 문서·engines 보완 PRD
+
+프로젝트 전수 점검(2026-06)에서 확인된 빠른 정리 항목 3건을 한 PR로 묶는다. 모두 런타임 동작 변경이 없는 문서·메타데이터 정합성 작업이다.
+
+## 1. 변경 항목
+
+### 1.1 PostsController의 실현 불가능한 403 Swagger 문서 제거
+
+- **현상**: `apps/service/src/posts/posts.controller.ts`의 PATCH(`:118`)·DELETE(`:142`)에 `@ApiForbiddenResponse('본인의 게시글만 수정/삭제 가능')`가 선언되어 있지만, 코드베이스 전체에 `ForbiddenException`을 던지는 곳이 없다. 소유권 불일치는 핸들러에서 `NotFoundException`(404)으로 처리된다 (affected=0 분기).
+- **참고**: 404 처리 자체는 의도된 설계다 — 타인 리소스의 존재 여부를 숨기는 IDOR 내성 패턴이며, TagsController는 이미 403 문서 없이 동일하게 동작한다 (이쪽이 기준).
+- **변경**: `@ApiForbiddenResponse` 2개를 제거하고, `@ApiNotFoundResponse` description을 "게시글을 찾을 수 없음 (본인의 게시글이 아닌 경우 포함)"으로 보강한다. 미사용이 되는 import도 정리한다.
+- **API 동작 변경 없음** — Swagger 문서만 실제 동작과 일치시킨다.
+
+### 1.2 `.env.example` 누락 변수 보완
+
+- **현상**: 코드에서 사용 중인데 템플릿에 없는 변수 2개.
+  - `PORT` — `apps/service/src/main.ts:56` `process.env.PORT ?? 3000` (`ADMIN_PORT`는 이미 템플릿에 있음)
+  - `THROTTLE_SKIP` — 양쪽 `app.module.ts`의 `skipIf: () => process.env.THROTTLE_SKIP === 'true'`
+- **변경**: 두 변수를 기본값·용도 주석과 함께 추가한다. `PORT=3000`은 `ADMIN_PORT=3001` 옆에, `THROTTLE_SKIP=false`는 테스트 전용임을 주석으로 명시한다.
+
+### 1.3 `package.json` engines 필드 추가
+
+- **현상**: CI는 Node 22·pnpm 9로 고정되어 있지만 로컬 도구 버전을 선언하는 `engines`가 없어, 버전이 다른 환경에서 조용히 설치·실행될 수 있다.
+- **변경**: `"engines": { "node": ">=22", "pnpm": ">=9" }` 추가. CI(Node 22)와 현재 로컬(Node 24)을 모두 포함하는 하한 선언이다.
+- **동작 특성**: pnpm은 기본 설정에서 engines 불일치 시 경고만 출력한다 (`engine-strict=true`일 때만 차단). 강제 차단 도입은 범위 외 — 선언만으로도 의도가 문서화되고 CI/도구가 참조할 수 있다.
+
+## 2. 수용 기준 (Acceptance Criteria)
+
+- [x] `posts.controller.ts`에서 `@ApiForbiddenResponse` 2건이 제거되고 import에 잔존하지 않는다.
+- [x] PATCH·DELETE의 `@ApiNotFoundResponse` description이 소유권 불일치 케이스를 포함하도록 보강된다.
+- [x] `.env.example`에 `PORT`, `THROTTLE_SKIP`이 용도 주석과 함께 추가된다.
+- [x] `package.json`에 `engines` 필드가 추가된다.
+- [x] `verify-api-compat` 관점에서 하위 호환성 영향 없음을 확인한다 (라우트·DTO·응답 스키마 무변경).
+- [x] `pnpm format` → `pnpm lint:check` → `pnpm build:all` → `pnpm test` → `pnpm test:e2e` 전부 통과한다.
+
+## 3. 범위 외 (Out of scope)
+
+- `.npmrc`의 `engine-strict=true` 도입 (버전 불일치 강제 차단) — 팀 합의 필요.
+- 소유권 불일치를 403으로 바꾸는 동작 변경 — 404 유지가 의도된 설계.
+- back-office 컨트롤러 Swagger 점검 — 1차 점검에서 동일 문제 미발견.
+- 나머지 점검 항목(tsconfig strict, eslint any 범위, HttpExceptionFilter 로깅 등) — 별도 작업.

--- a/docs/swagger-env-engines-todo.md
+++ b/docs/swagger-env-engines-todo.md
@@ -1,0 +1,38 @@
+# Swagger 403 제거 + env·engines 보완 체크리스트
+
+> 배경, 변경 근거, 범위 외 결정은 [swagger-env-engines-prd.md](./swagger-env-engines-prd.md)를 참고한다.
+
+## 진행 현황 (요약)
+
+| Phase | 상태 | 비고 |
+|---|---|---|
+| 1. Swagger 403 제거 | ✅ 완료 | posts.controller.ts PATCH/DELETE |
+| 2. .env.example 보완 | ✅ 완료 | PORT, THROTTLE_SKIP |
+| 3. engines 추가 | ✅ 완료 | node >=22, pnpm >=9 |
+| 4. 최종 검증 | ✅ 완료 | api-compat 확인 + format → lint:check → build:all → test → test:e2e |
+
+## Phase 1: Swagger 403 제거 (`posts.controller.ts`)
+
+- [x] PATCH `:id`의 `@ApiForbiddenResponse` 제거
+- [x] DELETE `:id`의 `@ApiForbiddenResponse` 제거
+- [x] PATCH·DELETE `@ApiNotFoundResponse` description에 "본인의 게시글이 아닌 경우 포함" 보강
+- [x] `ApiForbiddenResponse` import 제거 (미사용)
+
+## Phase 2: `.env.example` 보완
+
+- [x] `PORT=3000` 추가 (`ADMIN_PORT` 옆, service 앱 포트 주석)
+- [x] `THROTTLE_SKIP=false` 추가 (테스트 전용 — true면 rate limiting 비활성화 주석)
+
+## Phase 3: `package.json` engines 추가
+
+- [x] `"engines": { "node": ">=22", "pnpm": ">=9" }` 추가
+
+## Phase 4: 최종 검증
+
+- [x] 하위 호환성 영향 없음 확인 (라우트·DTO·응답 스키마 무변경 — Swagger 데코레이터와 메타데이터만 변경)
+- [x] `pnpm format`
+- [x] `pnpm lint:check`
+- [x] `pnpm build:all`
+- [x] `pnpm test`
+- [x] `pnpm test:e2e` (Docker 필요)
+- [x] 변경 파일이 `posts.controller.ts`·`.env.example`·`package.json`·docs 2개뿐인지 확인

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=9"
+  },
   "scripts": {
     "build:service": "nest build service",
     "build:back-office": "nest build back-office",


### PR DESCRIPTION
> **Merge Strategy**: Create a merge commit을 사용해주세요.

## Summary

프로젝트 전수 점검에서 확인된 문서·메타데이터 정합성 항목 3건을 한 PR로 정리한다. 모두 런타임 동작 변경이 없다.

| 항목 | 파일 | 내용 |
| --- | --- | --- |
| Swagger 죽은 403 제거 | `posts.controller.ts` | PATCH/DELETE의 `@ApiForbiddenResponse` 제거 — 코드베이스 어디에서도 `ForbiddenException`을 던지지 않아 실제로 발생할 수 없는 응답 문서였다 |
| env 템플릿 보완 | `.env.example` | 코드에서 사용 중인데 누락됐던 `PORT`, `THROTTLE_SKIP`을 용도 주석과 함께 추가 |
| engines 선언 | `package.json` | `node >=22, pnpm >=9` — CI가 고정한 도구 버전의 하한을 선언 |

## Notes

- **404 동작은 그대로 유지한다.** 소유권 불일치를 404로 처리하는 것은 타인 리소스의 존재 여부를 숨기는 의도된 설계이며, TagsController가 이미 같은 방식이다. 이 PR은 문서를 실제 동작에 일치시키고 `@ApiNotFoundResponse` 설명에 "본인의 게시글이 아닌 경우 포함"을 명시한다.
- engines는 pnpm 기본 설정에서 불일치 시 경고만 출력한다. 강제 차단(`engine-strict=true`)은 팀 합의가 필요해 범위 외로 남겼다.
- 상세 배경과 범위 외 결정은 `docs/swagger-env-engines-prd.md` 참고.

## Test plan

- [x] verify-api-compat 검증 — 변경된 DTO 없음(C1~C4 해당 없음), 라우트 데코레이터 무변경(C5 PASS), `@Idempotent()` 유지(C6 PASS). 하위 호환성 영향 없음
- [x] `pnpm format` / `pnpm lint:check` 통과
- [x] `pnpm build:all` 양쪽 앱 빌드 성공
- [x] `pnpm test` 183케이스 전체 통과
- [x] `pnpm test:e2e` service 160 + back-office 34 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)