### PR TITLE
refactor: 예외 필터 방어 로깅, bcrypt rounds 상수화, idempotency 로그 문구 정정

### DIFF
--- a/apps/back-office/src/auth/admin-token-issuer.service.ts
+++ b/apps/back-office/src/auth/admin-token-issuer.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
-import { Admin, AuthTokens } from '@app/shared';
+import { Admin, AuthTokens, BCRYPT_SALT_ROUNDS } from '@app/shared';
 import { IAdminWriteRepository } from '@back-office/auth/interface/admin-write-repository.interface';
 
 @Injectable()
@@ -54,7 +54,10 @@ export class AdminTokenIssuer {
     refreshToken: string,
   ): Promise<void> {
     const tokenDigest = createHash('sha256').update(refreshToken).digest('hex');
-    const hashedRefreshToken = await bcrypt.hash(tokenDigest, 10);
+    const hashedRefreshToken = await bcrypt.hash(
+      tokenDigest,
+      BCRYPT_SALT_ROUNDS,
+    );
     await this.adminWriteRepository.update(adminId, { hashedRefreshToken });
   }
 }

--- a/apps/back-office/src/auth/command/admin-register.handler.ts
+++ b/apps/back-office/src/auth/command/admin-register.handler.ts
@@ -1,6 +1,6 @@
 import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { isUniqueViolation } from '@app/shared';
+import { BCRYPT_SALT_ROUNDS, isUniqueViolation } from '@app/shared';
 import * as bcrypt from 'bcrypt';
 import { AdminRegisterCommand } from './admin-register.command';
 import { IAdminReadRepository } from '@back-office/auth/interface/admin-read-repository.interface';
@@ -21,7 +21,10 @@ export class AdminRegisterHandler implements ICommandHandler<AdminRegisterComman
       );
     }
 
-    const hashedPassword = await bcrypt.hash(command.password, 10);
+    const hashedPassword = await bcrypt.hash(
+      command.password,
+      BCRYPT_SALT_ROUNDS,
+    );
 
     try {
       const admin = await this.adminWriteRepository.create({

--- a/apps/service/src/auth/auth-token-issuer.service.ts
+++ b/apps/service/src/auth/auth-token-issuer.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
-import { AuthTokens, User } from '@app/shared';
+import { AuthTokens, BCRYPT_SALT_ROUNDS, User } from '@app/shared';
 import { IUserWriteRepository } from '@service/auth/interface/user-write-repository.interface';
 
 @Injectable()
@@ -49,7 +49,10 @@ export class AuthTokenIssuer {
     refreshToken: string,
   ): Promise<void> {
     const tokenDigest = createHash('sha256').update(refreshToken).digest('hex');
-    const hashedRefreshToken = await bcrypt.hash(tokenDigest, 10);
+    const hashedRefreshToken = await bcrypt.hash(
+      tokenDigest,
+      BCRYPT_SALT_ROUNDS,
+    );
     await this.userWriteRepository.update(userId, { hashedRefreshToken });
   }
 }

--- a/apps/service/src/auth/command/google-login.handler.ts
+++ b/apps/service/src/auth/command/google-login.handler.ts
@@ -17,7 +17,13 @@ import {
 } from '@service/auth/interface/oauth-account-write-repository.interface';
 import { AuthTokenIssuer } from '@service/auth/auth-token-issuer.service';
 import type { GoogleProfilePayload } from '@service/auth/strategy/google-profile.type';
-import { AuthTokens, OAuthAccount, User, isUniqueViolation } from '@app/shared';
+import {
+  AuthTokens,
+  BCRYPT_SALT_ROUNDS,
+  OAuthAccount,
+  User,
+  isUniqueViolation,
+} from '@app/shared';
 
 @CommandHandler(GoogleLoginCommand)
 export class GoogleLoginHandler implements ICommandHandler<
@@ -93,7 +99,7 @@ export class GoogleLoginHandler implements ICommandHandler<
     profile: GoogleProfilePayload,
   ): Promise<User> {
     const randomSecret = randomBytes(32).toString('hex');
-    const hashedPassword = await bcrypt.hash(randomSecret, 10);
+    const hashedPassword = await bcrypt.hash(randomSecret, BCRYPT_SALT_ROUNDS);
     try {
       return await this.userWriteRepository.create({
         email: profile.email,

--- a/apps/service/src/auth/command/register.handler.ts
+++ b/apps/service/src/auth/command/register.handler.ts
@@ -1,6 +1,6 @@
 import { ConflictException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { isUniqueViolation } from '@app/shared';
+import { BCRYPT_SALT_ROUNDS, isUniqueViolation } from '@app/shared';
 import * as bcrypt from 'bcrypt';
 import { RegisterCommand } from './register.command';
 import { IUserReadRepository } from '@service/auth/interface/user-read-repository.interface';
@@ -18,7 +18,10 @@ export class RegisterHandler implements ICommandHandler<RegisterCommand> {
 
   async execute(command: RegisterCommand): Promise<number> {
     await this.validateEmailNotTaken(command.email);
-    const hashedPassword = await bcrypt.hash(command.password, 10);
+    const hashedPassword = await bcrypt.hash(
+      command.password,
+      BCRYPT_SALT_ROUNDS,
+    );
     return this.createUserOrConflict({
       email: command.email,
       password: hashedPassword,

--- a/docs/infra-hardening-prd.md
+++ b/docs/infra-hardening-prd.md
@@ -1,0 +1,44 @@
+# 인프라 소소한 정리 3건 PRD
+
+프로젝트 전수 점검(2026-06)에서 남은 마지막 권장 묶음. 관측성 보강 1건, 중복 제거 1건, 로그 문구 정정 1건을 한 PR로 처리한다. API 동작·응답에는 변화가 없다.
+
+## 1. 변경 항목
+
+### 1.1 `HttpExceptionFilter`에 비-HttpException 방어 로깅 추가
+
+- **현상**: `libs/shared/src/logging/http-exception.filter.ts`는 `@Catch()`로 모든 예외를 잡아 비-HttpException을 500으로 변환하지만 로깅이 없다. 핸들러 단계 예외는 `LoggingInterceptor`의 error 경로가 stack까지 로깅하지만, **가드/미들웨어 단계(인터셉터 진입 전)에서 터진 비-HttpException은 어디에도 stack이 남지 않는다.**
+- **변경**: `PinoLogger`(nestjs-pino, `LoggingInterceptor`와 동일 선례)를 주입하고, **비-HttpException일 때만** error 레벨로 메시지+stack을 로깅한다. HttpException(4xx 의도된 예외)은 기존처럼 로깅하지 않는다 — 핸들러 단계 예외는 인터셉터가 이미 로깅하므로 중복을 최소화하되, 500 변환 직전의 미기록 예외만 잡는 안전망이다.
+- **참고**: 핸들러 단계의 비-HttpException은 인터셉터와 필터 양쪽에서 로깅되어 중복 1회가 발생할 수 있다. 가드 단계 예외의 완전 유실(현재)보다 중복이 낫다고 판단 — 중복 제거를 위한 상태 공유는 복잡도 대비 이득이 없어 도입하지 않는다.
+- **단위 테스트**: 분기가 생기므로 Classical School 원칙에 따라 spec 추가 — (1) HttpException은 로깅하지 않고 해당 status로 응답, (2) 비-HttpException은 error 로깅 + 500 응답.
+
+### 1.2 bcrypt rounds 하드코딩 5곳 상수화
+
+- **현상**: `bcrypt.hash(…, 10)`이 5곳에 하드코딩되어 있다 — 강도 조정 시 5곳을 찾아 고쳐야 하고 누락 위험이 있다.
+  - `apps/service/src/auth/auth-token-issuer.service.ts:52`
+  - `apps/service/src/auth/command/register.handler.ts:21`
+  - `apps/service/src/auth/command/google-login.handler.ts:96`
+  - `apps/back-office/src/auth/admin-token-issuer.service.ts:57`
+  - `apps/back-office/src/auth/command/admin-register.handler.ts:24`
+- **변경**: `libs/shared/src/common/security.constant.ts`에 `BCRYPT_SALT_ROUNDS = 10`을 신설하고 `@app/shared`로 export, 5곳을 모두 상수 참조로 교체한다. 값은 10 그대로 — 동작 변화 없음.
+- **env 설정화는 하지 않는다**: 잘못된 env 값(예: 4)으로 보안 강도가 조용히 낮아지는 위험이 상수의 이점보다 크다. 강도 변경은 코드 리뷰를 거치는 상수 수정으로 충분하다.
+
+### 1.3 Idempotency 인터셉터 로그 문구 정정
+
+- **현상**: `idempotency.interceptor.ts:89`가 손상된 캐시 엔트리에서 `'Corrupted cache entry, reprocessing'`을 로깅하지만, 실제로는 키 삭제 후 **409를 반환**한다(클라이언트가 재시도해야 재처리됨). 1번 작업(`docs/shared-infra-unit-tests-prd.md` §7-1)에서 발견·기록한 항목의 후속 조치다.
+- **변경**: 로그 문구만 실제 동작에 맞게 수정 — `'Corrupted cache entry deleted, responding 409 so the client retry can reprocess'`. 동작(del + 409)은 변경하지 않으며, 기존 단위 테스트(`del` 호출 + `ConflictException` 검증)는 그대로 통과한다.
+- 발견 기록 문서(`shared-infra-unit-tests-prd.md` §7-1)에 처리 완료를 표기한다.
+
+## 2. 수용 기준 (Acceptance Criteria)
+
+- [x] `HttpExceptionFilter`가 비-HttpException을 error 레벨(stack 포함)로 로깅하고, HttpException은 로깅하지 않는다. 응답 변환 동작은 기존과 동일하다.
+- [x] `http-exception.filter.spec.ts`가 두 분기를 검증한다.
+- [x] `BCRYPT_SALT_ROUNDS` 상수가 신설되고, `bcrypt.hash(…, 10)` 직접 호출이 0곳이 된다 (값은 10 유지).
+- [x] idempotency 로그 문구가 실제 동작(삭제 후 409)을 서술하고, 기존 인터셉터 spec이 수정 없이 통과한다.
+- [x] `shared-infra-unit-tests-prd.md` §7-1에 처리 완료가 표기된다.
+- [x] `pnpm format` → `pnpm lint:check` → `pnpm build:all` → `pnpm test` → `pnpm test:e2e` 전부 통과한다 (auth 파일 변경이므로 test:e2e 필수).
+
+## 3. 범위 외 (Out of scope)
+
+- bcrypt rounds 값 변경 (10 → 12 등) — 보안 정책 결정 사항.
+- 인터셉터/필터 로깅의 중복 제거 메커니즘 — §1.1 참고대로 복잡도 대비 이득 없음.
+- idempotency 동작 변경 (손상 캐시 시 즉시 재처리 등) — 현재 409 + 클라이언트 재시도가 안전한 설계.

--- a/docs/infra-hardening-todo.md
+++ b/docs/infra-hardening-todo.md
@@ -1,0 +1,42 @@
+# 인프라 소소한 정리 3건 체크리스트
+
+> 변경 근거, 설계 결정(중복 로깅 허용, env 설정화 안 함 등)은 [infra-hardening-prd.md](./infra-hardening-prd.md)를 참고한다.
+
+## 진행 현황 (요약)
+
+| Phase | 상태 | 비고 |
+|---|---|---|
+| 1. HttpExceptionFilter 방어 로깅 | ✅ 완료 | PinoLogger 주입 + 비-HttpException만 error 로깅 + spec |
+| 2. bcrypt rounds 상수화 | ✅ 완료 | BCRYPT_SALT_ROUNDS 신설 + 5곳 교체 |
+| 3. idempotency 로그 문구 정정 | ✅ 완료 | 문구만 수정, 동작 무변경 |
+| 4. 최종 검증 | ✅ 완료 | format → lint:check → build:all → test → test:e2e |
+
+## Phase 1: `HttpExceptionFilter` 방어 로깅
+
+- [x] `PinoLogger` 주입 + `setContext` (LoggingInterceptor 선례)
+- [x] 비-HttpException이면 error 레벨로 메시지+stack 로깅
+- [x] HttpException은 로깅하지 않음 (기존 동작 유지)
+- [x] `http-exception.filter.spec.ts` 추가 — 두 분기 검증
+- [x] `npx jest libs/shared/src/logging/http-exception.filter.spec.ts` 통과
+
+## Phase 2: bcrypt rounds 상수화
+
+- [x] `libs/shared/src/common/security.constant.ts` 신설 (`BCRYPT_SALT_ROUNDS = 10`)
+- [x] `libs/shared/src/index.ts` export 추가
+- [x] 5곳 교체: auth-token-issuer.service / register.handler / google-login.handler / admin-token-issuer.service / admin-register.handler
+- [x] `grep "bcrypt.hash" 결과에 숫자 리터럴 0곳` 확인
+
+## Phase 3: idempotency 로그 문구 정정
+
+- [x] `idempotency.interceptor.ts:89` 문구를 실제 동작(삭제 후 409) 서술로 수정
+- [x] 기존 `idempotency.interceptor.spec.ts` 수정 없이 통과 확인
+- [x] `shared-infra-unit-tests-prd.md` §7-1에 처리 완료 표기
+
+## Phase 4: 최종 검증
+
+- [x] `pnpm format`
+- [x] `pnpm lint:check`
+- [x] `pnpm build:all`
+- [x] `pnpm test`
+- [x] `pnpm test:e2e` (auth 파일 변경 — 필수)
+- [x] 변경 범위 확인 (코드 8개 파일 + spec 1개 + docs 3개)

--- a/docs/shared-infra-unit-tests-prd.md
+++ b/docs/shared-infra-unit-tests-prd.md
@@ -115,4 +115,4 @@ DI가 string token(`REDIS_CLIENT`) + `PinoLogger`(nestjs-pino)라 **수동 인�
 
 ## 7. 작업 중 발견 사항 (코드 수정 없이 기록만)
 
-1. **IdempotencyInterceptor 로그-동작 불일치** (`idempotency.interceptor.ts:88-96`): 손상된 캐시 엔트리를 만나면 `'Corrupted cache entry, reprocessing'`을 로깅하고 키를 삭제한 뒤 — 재처리(reprocess)가 아니라 **`ConflictException`(409)을 던진다**. 클라이언트가 재시도하면 그때 재처리되므로 동작 자체는 안전하지만, 로그 문구가 오해를 유발한다. 테스트는 현재 동작(409)을 고정한다. 후속 작업에서 로그 문구 수정 권장.
+1. **IdempotencyInterceptor 로그-동작 불일치** (`idempotency.interceptor.ts:88-96`): 손상된 캐시 엔트리를 만나면 `'Corrupted cache entry, reprocessing'`을 로깅하고 키를 삭제한 뒤 — 재처리(reprocess)가 아니라 **`ConflictException`(409)을 던진다**. 클라이언트가 재시도하면 그때 재처리되므로 동작 자체는 안전하지만, 로그 문구가 오해를 유발한다. 테스트는 현재 동작(409)을 고정한다. ~~후속 작업에서 로그 문구 수정 권장.~~ **처리 완료** — `docs/infra-hardening-prd.md` §1.3에서 로그 문구를 실제 동작 서술로 수정함 (동작 무변경).

--- a/libs/shared/src/common/security.constant.ts
+++ b/libs/shared/src/common/security.constant.ts
@@ -1,0 +1,6 @@
+/**
+ * bcrypt 해시 강도(cost factor). 비밀번호와 refresh token digest 해싱에
+ * 공통 적용한다. 값 변경은 env가 아닌 코드 리뷰를 거친 상수 수정으로만 한다 —
+ * 잘못된 env 값으로 보안 강도가 조용히 낮아지는 사고를 막기 위함.
+ */
+export const BCRYPT_SALT_ROUNDS = 10;

--- a/libs/shared/src/idempotency/idempotency.interceptor.ts
+++ b/libs/shared/src/idempotency/idempotency.interceptor.ts
@@ -86,7 +86,10 @@ export class IdempotencyInterceptor implements NestInterceptor {
           response.status(existing.statusCode);
           return of(existing.body);
         } catch {
-          this.logger.warn({ cacheKey }, 'Corrupted cache entry, reprocessing');
+          this.logger.warn(
+            { cacheKey },
+            'Corrupted cache entry deleted — responding 409 so the client retry can reprocess',
+          );
           await this.redis.del(cacheKey);
         }
       }

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -16,6 +16,9 @@ export { isUniqueViolation } from './database/postgres-error.util';
 // Common - Base Repository
 export { BaseRepository } from './common/base.repository';
 
+// Common - Security Constants
+export { BCRYPT_SALT_ROUNDS } from './common/security.constant';
+
 // Common - DTOs
 export {
   PaginatedResponseDto,

--- a/libs/shared/src/logging/http-exception.filter.spec.ts
+++ b/libs/shared/src/logging/http-exception.filter.spec.ts
@@ -1,0 +1,57 @@
+import { ArgumentsHost, NotFoundException } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { PinoLogger } from 'nestjs-pino';
+import { HttpExceptionFilter } from './http-exception.filter';
+
+describe('HttpExceptionFilter', () => {
+  let reply: jest.Mock;
+  let loggerError: jest.Mock;
+  let filter: HttpExceptionFilter;
+  const response = {};
+
+  function createHost(): ArgumentsHost {
+    return {
+      switchToHttp: () => ({
+        getResponse: () => response,
+      }),
+    } as unknown as ArgumentsHost;
+  }
+
+  beforeEach(() => {
+    reply = jest.fn();
+    loggerError = jest.fn();
+    const adapterHost = {
+      httpAdapter: { reply },
+    } as unknown as HttpAdapterHost;
+    const logger = {
+      setContext: jest.fn(),
+      error: loggerError,
+    } as unknown as PinoLogger;
+    filter = new HttpExceptionFilter(adapterHost, logger);
+  });
+
+  it('HttpException은 로깅하지 않고 해당 상태 코드와 본문으로 응답한다', () => {
+    const exception = new NotFoundException('Post with ID 1 not found');
+
+    filter.catch(exception, createHost());
+
+    expect(loggerError).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith(response, exception.getResponse(), 404);
+  });
+
+  it('비-HttpException은 error 레벨로 로깅하고 500으로 변환해 응답한다', () => {
+    const exception = new Error('unexpected failure');
+
+    filter.catch(exception, createHost());
+
+    expect(loggerError).toHaveBeenCalledWith(
+      { err: exception },
+      'Unhandled exception converted to 500',
+    );
+    expect(reply).toHaveBeenCalledWith(
+      response,
+      { statusCode: 500, message: 'Internal server error' },
+      500,
+    );
+  });
+});

--- a/libs/shared/src/logging/http-exception.filter.ts
+++ b/libs/shared/src/logging/http-exception.filter.ts
@@ -6,16 +6,32 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
+import { PinoLogger } from 'nestjs-pino';
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
-  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+  constructor(
+    private readonly httpAdapterHost: HttpAdapterHost,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(HttpExceptionFilter.name);
+  }
 
   catch(exception: unknown, host: ArgumentsHost): void {
     const { httpAdapter } = this.httpAdapterHost;
     const ctx = host.switchToHttp();
 
     const isHttpException = exception instanceof HttpException;
+
+    // 가드/미들웨어 단계의 비-HttpException은 LoggingInterceptor가 잡지 못하므로
+    // 500으로 변환하기 전에 여기서 stack을 남긴다 (마지막 안전망).
+    if (!isHttpException) {
+      this.logger.error(
+        { err: exception },
+        'Unhandled exception converted to 500',
+      );
+    }
+
     const status = isHttpException
       ? exception.getStatus()
       : HttpStatus.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
> **Merge Strategy**: Create a merge commit을 사용해주세요.

## Summary

프로젝트 전수 점검에서 남은 마지막 정리 묶음 3건. API 동작·응답에는 변화가 없다.

| 항목 | 파일 | 내용 |
| --- | --- | --- |
| 예외 필터 방어 로깅 | `http-exception.filter.ts` (+spec) | 비-HttpException을 error 레벨(stack 포함)로 로깅 후 500 변환. 가드/미들웨어 단계 예외의 stack이 어디에도 남지 않던 빈틈을 막는 마지막 안전망 |
| bcrypt rounds 상수화 | `security.constant.ts`(신설) + 5곳 | `BCRYPT_SALT_ROUNDS = 10`을 `@app/shared`로 신설, 양쪽 앱의 하드코딩 5곳 교체. 값 그대로 — 동작 무변경 |
| idempotency 로그 문구 정정 | `idempotency.interceptor.ts` | "reprocessing" 문구를 실제 동작(삭제 후 409, 클라이언트 재시도 시 재처리) 서술로 수정. PR #75에서 발견·기록한 항목의 후속 조치 |

## Notes

- **필터 로깅은 비-HttpException만** — 의도된 4xx는 로깅하지 않는다. 핸들러 단계의 비-HttpException은 LoggingInterceptor와 중복 1회가 발생할 수 있는데, 가드 단계 예외의 완전 유실보다 중복이 낫다고 판단했다 (중복 제거용 상태 공유는 복잡도 대비 이득 없음).
- **bcrypt는 env 설정화하지 않는다** — 잘못된 env 값(예: 4)으로 보안 강도가 조용히 낮아지는 위험이 이점보다 크다. 강도 변경은 코드 리뷰를 거치는 상수 수정으로만 한다.
- idempotency는 **로그 문구만** 수정 — 동작(del + 409)은 안전한 설계라 유지하며, 기존 spec 10케이스가 수정 없이 통과한다. 발견 기록(`shared-infra-unit-tests-prd.md` §7-1)에 처리 완료를 표기했다.
- 상세 배경·설계 결정은 `docs/infra-hardening-prd.md` 참고.

## Test plan

- [x] `http-exception.filter.spec.ts` 신규 2케이스 — HttpException 미로깅 / 비-HttpException 로깅 + 500
- [x] 기존 `idempotency.interceptor.spec.ts` 10케이스 수정 없이 통과 (동작 무변경 입증)
- [x] `bcrypt.hash(…, 10)` 숫자 리터럴 잔존 0곳 확인
- [x] `pnpm format` / `pnpm lint:check` / `npx tsc --noEmit` 통과
- [x] `pnpm build:all` 양쪽 앱 빌드 성공
- [x] `pnpm test` 185케이스 전체 통과
- [x] `pnpm test:e2e` service 160 + back-office 34 전체 통과 (auth 파일 변경 — 필수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)