### PR TITLE
test: 영어 it 문장 125건을 한국어로 통일

### DIFF
--- a/apps/service/src/auth/dto/response/auth-tokens.response.dto.spec.ts
+++ b/apps/service/src/auth/dto/response/auth-tokens.response.dto.spec.ts
@@ -2,7 +2,7 @@ import { AuthTokensResponseDto } from './auth-tokens.response.dto';
 
 describe('AuthTokensResponseDto', () => {
   describe('of', () => {
-    it('should map accessToken and refreshToken to DTO', () => {
+    it('accessToken과 refreshToken을 DTO로 매핑한다', () => {
       const dto = AuthTokensResponseDto.of({
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
@@ -12,7 +12,7 @@ describe('AuthTokensResponseDto', () => {
       expect(dto.refreshToken).toBe('refresh-token');
     });
 
-    it('should return an instance of AuthTokensResponseDto', () => {
+    it('AuthTokensResponseDto 인스턴스를 반환한다', () => {
       const dto = AuthTokensResponseDto.of({
         accessToken: 'a',
         refreshToken: 'r',

--- a/apps/service/src/auth/dto/response/register.response.dto.spec.ts
+++ b/apps/service/src/auth/dto/response/register.response.dto.spec.ts
@@ -2,13 +2,13 @@ import { RegisterResponseDto } from './register.response.dto';
 
 describe('RegisterResponseDto', () => {
   describe('of', () => {
-    it('should map id to DTO', () => {
+    it('id를 DTO로 매핑한다', () => {
       const dto = RegisterResponseDto.of(42, true);
 
       expect(dto.id).toBe(42);
     });
 
-    it('should return an instance of RegisterResponseDto', () => {
+    it('RegisterResponseDto 인스턴스를 반환한다', () => {
       const dto = RegisterResponseDto.of(1, true);
 
       expect(dto).toBeInstanceOf(RegisterResponseDto);

--- a/apps/service/src/posts/dto/response/create-post.response.dto.spec.ts
+++ b/apps/service/src/posts/dto/response/create-post.response.dto.spec.ts
@@ -2,13 +2,13 @@ import { CreatePostResponseDto } from './create-post.response.dto';
 
 describe('CreatePostResponseDto', () => {
   describe('of', () => {
-    it('should map id to DTO', () => {
+    it('id를 DTO로 매핑한다', () => {
       const dto = CreatePostResponseDto.of(42);
 
       expect(dto.id).toBe(42);
     });
 
-    it('should return an instance of CreatePostResponseDto', () => {
+    it('CreatePostResponseDto 인스턴스를 반환한다', () => {
       const dto = CreatePostResponseDto.of(1);
 
       expect(dto).toBeInstanceOf(CreatePostResponseDto);

--- a/apps/service/src/posts/dto/response/post.response.dto.spec.ts
+++ b/apps/service/src/posts/dto/response/post.response.dto.spec.ts
@@ -18,7 +18,7 @@ describe('PostResponseDto', () => {
   };
 
   describe('of', () => {
-    it('should map all Post entity fields to DTO', () => {
+    it('Post 엔티티의 모든 필드를 DTO로 매핑한다', () => {
       const post = createPost();
 
       const dto = PostResponseDto.of(post);
@@ -32,7 +32,7 @@ describe('PostResponseDto', () => {
       expect(dto.updatedAt).toBe(post.updatedAt);
     });
 
-    it('should return an instance of PostResponseDto', () => {
+    it('PostResponseDto 인스턴스를 반환한다', () => {
       const post = createPost();
 
       const dto = PostResponseDto.of(post);
@@ -40,7 +40,7 @@ describe('PostResponseDto', () => {
       expect(dto).toBeInstanceOf(PostResponseDto);
     });
 
-    it('should correctly map isPublished: true', () => {
+    it('isPublished: true 값을 그대로 매핑한다', () => {
       const post = createPost({ isPublished: true });
 
       const dto = PostResponseDto.of(post);
@@ -48,7 +48,7 @@ describe('PostResponseDto', () => {
       expect(dto.isPublished).toBe(true);
     });
 
-    it('should correctly map userId', () => {
+    it('userId 값을 그대로 매핑한다', () => {
       const post = createPost({ userId: 42 });
 
       const dto = PostResponseDto.of(post);

--- a/docs/spec-it-korean-prd.md
+++ b/docs/spec-it-korean-prd.md
@@ -1,0 +1,42 @@
+# 테스트 it 문장 한국어 통일 PRD
+
+루트 CLAUDE.md의 전체 spec 일관 규칙 — "`describe`는 영문 클래스명, `it` 문장은 한국어로 행위와 결과를 진술한다" — 을 위반하는 영어 `it` 문장을 전부 한국어로 통일한다. **테스트 로직·assertion은 일절 변경하지 않는 문자열 전용 작업**이다.
+
+## 1. 배경 및 측정
+
+1차 점검(2026-06)에서는 back-office 통합 테스트만 영어로 보고됐으나, 정밀 측정 결과 service 쪽에도 영어 문장이 광범위하게 남아 있다.
+
+> 측정 방법: `it(...)` 라인 중 **한글이 전혀 없는** 라인을 영어로 집계. ("한글로 시작" 기준은 `it('HttpException은 …')`처럼 식별자로 시작하는 한국어 문장을 오탐하므로 부적합 — 1차 점검의 back-office 단위 spec 위반 보고는 이 오탐이었고, 실제로는 모두 한국어였다.)
+
+| 파일 | 영어 it | 비고 |
+| --- | --- | --- |
+| `test/back-office/admin.integration-spec.ts` | 27 / 27 | 파일 전체가 영어 |
+| `test/service/posts.integration-spec.ts` | 53 | 한국어와 혼재 |
+| `test/service/auth.integration-spec.ts` | 28 | 한국어와 혼재 |
+| `test/service/google-oauth.integration-spec.ts` | ~~1~~ 0 | 측정 오탐 — assertion의 `split('.')`이 `it(` 패턴에 걸림. 실제 영어 it 없음 |
+| `libs/shared/src/common/dto/response/paginated.response.dto.spec.ts` | 7 | |
+| `apps/service/src/posts/dto/response/post.response.dto.spec.ts` | 4 | |
+| `apps/service/src/posts/dto/response/create-post.response.dto.spec.ts` | 2 | |
+| `apps/service/src/auth/dto/response/auth-tokens.response.dto.spec.ts` | 2 | |
+| `apps/service/src/auth/dto/response/register.response.dto.spec.ts` | 2 | |
+| **합계** | **125건 / 8개 파일** | |
+
+## 2. 변경 원칙
+
+- `it('should return 401 for GET /posts without token')` → `it('토큰 없이 GET /posts 호출 시 401을 반환한다')` 형식 — **행위(조건) + 결과**를 한국어로 진술하고, HTTP 메서드·라우트·상태 코드·식별자는 원문 그대로 유지한다.
+- 같은 파일의 기존 한국어 문장 스타일(예: `posts.integration-spec.ts`의 한국어 케이스)을 어휘·어순 기준으로 삼는다.
+- `describe` 블록은 변경하지 않는다 (영문 클래스/엔드포인트명 유지가 규칙).
+- **테스트 본문(setup·실행·assertion)은 한 글자도 변경하지 않는다.** diff가 `it('…')` 문자열 라인에만 존재해야 한다.
+
+## 3. 수용 기준 (Acceptance Criteria)
+
+- [x] 한글 미포함 `it` 문장이 9개 파일 모두에서 0건이 된다 (측정 스크립트 재실행으로 확인).
+- [x] diff가 `it(...)` 설명 문자열 라인(및 prettier 줄바꿈)에만 존재한다 — 테스트 로직 무변경.
+- [x] 테스트 수가 변하지 않는다: 단위 185개, 통합 service 160 + back-office 34.
+- [x] `pnpm format` → `pnpm lint:check` → `pnpm build:all` → `pnpm test` → `pnpm test:e2e` 전부 통과한다.
+
+## 4. 범위 외 (Out of scope)
+
+- 테스트 내용·구조 개선 — 1차 점검에서 지적된 DTO spec의 중복 `instanceof` 단언 제거 등은 별도 결정 사항. 이번 작업에서 문장 번역과 섞으면 diff 리뷰가 어려워진다.
+- `describe` 문구 변경 — 규칙상 영문 유지.
+- 주석·변수명 등 코드 본문의 영어 — 규칙 대상 아님.

--- a/docs/spec-it-korean-todo.md
+++ b/docs/spec-it-korean-todo.md
@@ -1,0 +1,43 @@
+# 테스트 it 문장 한국어 통일 체크리스트
+
+> 측정 방법(오탐 교정 포함), 변경 원칙, 범위 외 결정은 [spec-it-korean-prd.md](./spec-it-korean-prd.md)를 참고한다.
+
+## 진행 현황 (요약)
+
+| Phase | 상태 | 비고 |
+|---|---|---|
+| 1. back-office 통합 spec | ✅ 완료 | admin.integration-spec.ts 27건 |
+| 2. service 통합 spec | ✅ 완료 | posts 53 + auth 28 = 81건 (google-oauth는 측정 오탐으로 0건) |
+| 3. DTO 단위 spec | ✅ 완료 | 5개 파일 17건 |
+| 4. 최종 검증 | ✅ 완료 | 잔존 0건 측정 + format → lint:check → build:all → test → test:e2e |
+
+## Phase 1: `test/back-office/admin.integration-spec.ts` (27건)
+
+- [x] 27건 전부 한국어(행위+결과)로 교체, 라우트·상태 코드 원문 유지
+- [x] `pnpm test:e2e:back-office` 34개 통과 (테스트 수 불변)
+
+## Phase 2: service 통합 spec (82건)
+
+- [x] `test/service/posts.integration-spec.ts` 53건 교체 (기존 한국어 케이스 스타일 준수)
+- [x] `test/service/auth.integration-spec.ts` 28건 교체
+- [x] `test/service/google-oauth.integration-spec.ts` — 측정 오탐 확인(영어 it 없음), 변경 없음 (PRD §1 참고)
+- [x] `pnpm test:e2e:service` 160개 통과 (테스트 수 불변)
+
+## Phase 3: DTO 단위 spec (17건)
+
+- [x] `libs/shared/src/common/dto/response/paginated.response.dto.spec.ts` 7건
+- [x] `apps/service/src/posts/dto/response/post.response.dto.spec.ts` 4건
+- [x] `apps/service/src/posts/dto/response/create-post.response.dto.spec.ts` 2건
+- [x] `apps/service/src/auth/dto/response/auth-tokens.response.dto.spec.ts` 2건
+- [x] `apps/service/src/auth/dto/response/register.response.dto.spec.ts` 2건
+- [x] `pnpm test` 185개 통과 (테스트 수 불변)
+
+## Phase 4: 최종 검증
+
+- [x] 측정 스크립트 재실행 — 한글 미포함 it 문장 전체 0건
+- [x] `git diff` 검토 — it 문자열 라인 외 변경 없음
+- [x] `pnpm format`
+- [x] `pnpm lint:check`
+- [x] `pnpm build:all`
+- [x] `pnpm test` (185개)
+- [x] `pnpm test:e2e` (160 + 34, Docker 필요)

--- a/libs/shared/src/common/dto/response/paginated.response.dto.spec.ts
+++ b/libs/shared/src/common/dto/response/paginated.response.dto.spec.ts
@@ -2,34 +2,34 @@ import { PaginatedResponseDto } from './paginated.response.dto';
 
 describe('PaginatedResponseDto', () => {
   describe('of', () => {
-    it('should calculate totalPages correctly', () => {
+    it('totalPages를 올바르게 계산한다', () => {
       const result = PaginatedResponseDto.of(['a', 'b', 'c'], 10, 1, 3);
 
       expect(result.meta.totalPages).toBe(4); // ceil(10/3) = 4
     });
 
-    it('should mark first page as isFirst=true, isLast=false', () => {
+    it('첫 페이지를 isFirst=true, isLast=false로 표시한다', () => {
       const result = PaginatedResponseDto.of(['a', 'b'], 5, 1, 2);
 
       expect(result.meta.isFirst).toBe(true);
       expect(result.meta.isLast).toBe(false);
     });
 
-    it('should mark last page as isFirst=false, isLast=true', () => {
+    it('마지막 페이지를 isFirst=false, isLast=true로 표시한다', () => {
       const result = PaginatedResponseDto.of(['a'], 5, 3, 2);
 
       expect(result.meta.isFirst).toBe(false);
       expect(result.meta.isLast).toBe(true);
     });
 
-    it('should mark single page as both isFirst and isLast', () => {
+    it('단일 페이지를 isFirst와 isLast 모두 true로 표시한다', () => {
       const result = PaginatedResponseDto.of(['a'], 1, 1, 10);
 
       expect(result.meta.isFirst).toBe(true);
       expect(result.meta.isLast).toBe(true);
     });
 
-    it('should handle empty result', () => {
+    it('빈 결과를 처리한다', () => {
       const result = PaginatedResponseDto.of([], 0, 1, 10);
 
       expect(result.items).toEqual([]);
@@ -39,7 +39,7 @@ describe('PaginatedResponseDto', () => {
       expect(result.meta.isLast).toBe(true);
     });
 
-    it('should set items and meta correctly', () => {
+    it('items와 meta를 올바르게 설정한다', () => {
       const items = [{ id: 1 }, { id: 2 }];
       const result = PaginatedResponseDto.of(items, 7, 2, 3);
 
@@ -50,7 +50,7 @@ describe('PaginatedResponseDto', () => {
       expect(result.meta.totalPages).toBe(3); // ceil(7/3) = 3
     });
 
-    it('should handle exact page boundary', () => {
+    it('페이지 경계가 정확히 나누어떨어지는 경우를 처리한다', () => {
       const result = PaginatedResponseDto.of(['a', 'b'], 6, 3, 2);
 
       expect(result.meta.totalPages).toBe(3);

--- a/test/back-office/admin.integration-spec.ts
+++ b/test/back-office/admin.integration-spec.ts
@@ -75,7 +75,7 @@ describe('Admin (integration)', () => {
   // POST /admin/auth/register
   // ============================================================
   describe('POST /admin/auth/register', () => {
-    it('should register and return { id } with 201', async () => {
+    it('회원가입 성공 시 201과 { id }를 반환한다', async () => {
       const res = await registerAdmin().expect(201);
 
       expect(res.body.id).toBeDefined();
@@ -83,7 +83,7 @@ describe('Admin (integration)', () => {
       expect(Object.keys(res.body)).toEqual(['id']);
     });
 
-    it('should persist admin (verified via login)', async () => {
+    it('관리자를 저장한다 (로그인으로 검증)', async () => {
       await registerAdmin().expect(201);
 
       await request(app.getHttpServer())
@@ -92,7 +92,7 @@ describe('Admin (integration)', () => {
         .expect(200);
     });
 
-    it('should always register with MANAGER role', async () => {
+    it('항상 MANAGER 역할로 등록한다', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -103,7 +103,7 @@ describe('Admin (integration)', () => {
       expect(res.body.role).toBe('MANAGER');
     });
 
-    it('should return 409 for duplicate email', async () => {
+    it('중복된 이메일이면 409를 반환한다', async () => {
       await registerAdmin().expect(201);
 
       const res = await registerAdmin().expect(409);
@@ -111,28 +111,28 @@ describe('Admin (integration)', () => {
       expect(res.body.message).toContain(defaultAdmin.email);
     });
 
-    it('should return 400 when email is missing', () => {
+    it('email이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/register')
         .send({ password: 'password123', name: '테스트' })
         .expect(400);
     });
 
-    it('should return 400 when password is shorter than 8 characters', () => {
+    it('password가 8자 미만이면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/register')
         .send({ email: 'a@b.com', password: 'short', name: '테스트' })
         .expect(400);
     });
 
-    it('should return 400 when name is missing', () => {
+    it('name이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/register')
         .send({ email: 'a@b.com', password: 'password123' })
         .expect(400);
     });
 
-    it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
+    it('알 수 없는 속성이 포함되면 400을 반환한다 (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/register')
         .send({ ...defaultAdmin, role: 'SUPER' })
@@ -144,7 +144,7 @@ describe('Admin (integration)', () => {
   // POST /admin/auth/login
   // ============================================================
   describe('POST /admin/auth/login', () => {
-    it('should login and return { accessToken, refreshToken } with 200', async () => {
+    it('로그인 성공 시 200과 { accessToken, refreshToken }을 반환한다', async () => {
       await registerAdmin().expect(201);
 
       const res = await request(app.getHttpServer())
@@ -162,14 +162,14 @@ describe('Admin (integration)', () => {
       ]);
     });
 
-    it('should return 401 for non-existent email', () => {
+    it('존재하지 않는 이메일이면 401을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/login')
         .send({ email: 'nobody@example.com', password: 'password123' })
         .expect(401);
     });
 
-    it('should return 401 for wrong password', async () => {
+    it('비밀번호가 틀리면 401을 반환한다', async () => {
       await registerAdmin().expect(201);
 
       return request(app.getHttpServer())
@@ -178,14 +178,14 @@ describe('Admin (integration)', () => {
         .expect(401);
     });
 
-    it('should return 400 when email is missing', () => {
+    it('email이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/login')
         .send({ password: 'password123' })
         .expect(400);
     });
 
-    it('should return 400 when password is missing', () => {
+    it('password가 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/login')
         .send({ email: 'a@b.com' })
@@ -197,7 +197,7 @@ describe('Admin (integration)', () => {
   // POST /admin/auth/refresh
   // ============================================================
   describe('POST /admin/auth/refresh', () => {
-    it('should return new { accessToken, refreshToken } with 200', async () => {
+    it('새로운 { accessToken, refreshToken }과 200을 반환한다', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -210,7 +210,7 @@ describe('Admin (integration)', () => {
       expect(res.body.refreshToken).not.toBe(tokens.refreshToken);
     });
 
-    it('should invalidate old refresh token after rotation', async () => {
+    it('rotation 후 기존 refresh token을 무효화한다', async () => {
       const tokens = await registerAndLogin();
 
       await request(app.getHttpServer())
@@ -224,14 +224,14 @@ describe('Admin (integration)', () => {
         .expect(401);
     });
 
-    it('should return 401 for invalid token', () => {
+    it('유효하지 않은 토큰이면 401을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/refresh')
         .send({ refreshToken: 'invalid-token' })
         .expect(401);
     });
 
-    it('should return 400 when refreshToken is missing', () => {
+    it('refreshToken이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/refresh')
         .send({})
@@ -243,7 +243,7 @@ describe('Admin (integration)', () => {
   // GET /admin/auth/profile
   // ============================================================
   describe('GET /admin/auth/profile', () => {
-    it('should return profile with { id, email, name, role, createdAt, updatedAt } and 200', async () => {
+    it('200과 함께 { id, email, name, role, createdAt, updatedAt } 프로필을 반환한다', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -268,7 +268,7 @@ describe('Admin (integration)', () => {
       ]);
     });
 
-    it('should not include password or hashedRefreshToken in response', async () => {
+    it('응답에 password와 hashedRefreshToken을 포함하지 않는다', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -280,13 +280,13 @@ describe('Admin (integration)', () => {
       expect(res.body).not.toHaveProperty('hashedRefreshToken');
     });
 
-    it('should return 401 without token', () => {
+    it('토큰 없이 호출 시 401을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/back-office/auth/profile')
         .expect(401);
     });
 
-    it('should return 401 with invalid token', () => {
+    it('유효하지 않은 토큰으로 호출 시 401을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/back-office/auth/profile')
         .set('Authorization', 'Bearer invalid-token')
@@ -298,7 +298,7 @@ describe('Admin (integration)', () => {
   // POST /admin/auth/logout
   // ============================================================
   describe('POST /admin/auth/logout', () => {
-    it('should return 204 on successful logout', async () => {
+    it('로그아웃 성공 시 204를 반환한다', async () => {
       const { accessToken } = await registerAndLogin();
 
       await request(app.getHttpServer())
@@ -307,7 +307,7 @@ describe('Admin (integration)', () => {
         .expect(204);
     });
 
-    it('should invalidate refresh token after logout', async () => {
+    it('로그아웃 후 refresh token을 무효화한다', async () => {
       const { accessToken, refreshToken } = await registerAndLogin();
 
       await request(app.getHttpServer())
@@ -321,13 +321,13 @@ describe('Admin (integration)', () => {
         .expect(401);
     });
 
-    it('should return 401 when no Authorization header is provided', () => {
+    it('Authorization 헤더가 없으면 401을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/logout')
         .expect(401);
     });
 
-    it('should return 401 when an invalid token is provided', () => {
+    it('유효하지 않은 토큰이 제공되면 401을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/back-office/auth/logout')
         .set('Authorization', 'Bearer invalid-token')
@@ -339,7 +339,7 @@ describe('Admin (integration)', () => {
   // 토큰 격리: User ↔ Admin 토큰 교차 사용 불가
   // ============================================================
   describe('Token isolation', () => {
-    it('should reject User token on Admin endpoints (401)', async () => {
+    it('Admin 엔드포인트에서 User 토큰 사용 시 401로 거부한다', async () => {
       const userTokens = await registerAndLoginUser();
 
       await request(app.getHttpServer())
@@ -348,7 +348,7 @@ describe('Admin (integration)', () => {
         .expect(401);
     });
 
-    it('should reject Admin token on User endpoints (401)', async () => {
+    it('User 엔드포인트에서 Admin 토큰 사용 시 401로 거부한다', async () => {
       const adminTokens = await registerAndLogin();
 
       await request(app.getHttpServer())

--- a/test/service/auth.integration-spec.ts
+++ b/test/service/auth.integration-spec.ts
@@ -55,7 +55,7 @@ describe('Auth (integration)', () => {
   // POST /auth/register
   // ============================================================
   describe('POST /auth/register', () => {
-    it('should register and return { id, marketingConsent } with 201', async () => {
+    it('가입에 성공하면 201과 함께 { id, marketingConsent }를 반환한다', async () => {
       const res = await registerUser().expect(201);
 
       expect(res.body.id).toBeDefined();
@@ -85,7 +85,7 @@ describe('Auth (integration)', () => {
         .expect(400);
     });
 
-    it('should persist user (verified via login)', async () => {
+    it('가입한 사용자가 영속화된다 (로그인으로 검증)', async () => {
       await registerUser().expect(201);
 
       await request(app.getHttpServer())
@@ -94,7 +94,7 @@ describe('Auth (integration)', () => {
         .expect(200);
     });
 
-    it('should return 409 for duplicate email', async () => {
+    it('중복된 email로 가입하면 409를 반환한다', async () => {
       await registerUser().expect(201);
 
       const res = await registerUser().expect(409);
@@ -102,7 +102,7 @@ describe('Auth (integration)', () => {
       expect(res.body.message).toContain(defaultUser.email);
     });
 
-    it('should return 400 when email is missing', () => {
+    it('email이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
         .send({
@@ -113,7 +113,7 @@ describe('Auth (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when email format is invalid', () => {
+    it('email 형식이 올바르지 않으면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
         .send({
@@ -125,14 +125,14 @@ describe('Auth (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when password is missing', () => {
+    it('password가 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
         .send({ email: 'a@b.com', name: '테스트', marketingConsent: true })
         .expect(400);
     });
 
-    it('should return 400 when password is shorter than 8 characters', () => {
+    it('password가 8자 미만이면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
         .send({
@@ -144,7 +144,7 @@ describe('Auth (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when name is missing', () => {
+    it('name이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
         .send({
@@ -155,7 +155,7 @@ describe('Auth (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
+    it('정의되지 않은 속성을 보내면 400을 반환한다 (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/register')
         .send({ ...defaultUser, hacked: true })
@@ -167,7 +167,7 @@ describe('Auth (integration)', () => {
   // POST /auth/login
   // ============================================================
   describe('POST /auth/login', () => {
-    it('should login and return { accessToken, refreshToken } with 200', async () => {
+    it('로그인에 성공하면 200과 함께 { accessToken, refreshToken }을 반환한다', async () => {
       await registerUser().expect(201);
 
       const res = await request(app.getHttpServer())
@@ -185,14 +185,14 @@ describe('Auth (integration)', () => {
       ]);
     });
 
-    it('should return 401 for non-existent email', () => {
+    it('존재하지 않는 email로 로그인하면 401을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/login')
         .send({ email: 'nobody@example.com', password: 'password123' })
         .expect(401);
     });
 
-    it('should return 401 for wrong password', async () => {
+    it('잘못된 password로 로그인하면 401을 반환한다', async () => {
       await registerUser().expect(201);
 
       return request(app.getHttpServer())
@@ -201,21 +201,21 @@ describe('Auth (integration)', () => {
         .expect(401);
     });
 
-    it('should return 400 when email is missing', () => {
+    it('email이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/login')
         .send({ password: 'password123' })
         .expect(400);
     });
 
-    it('should return 400 when password is missing', () => {
+    it('password가 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/login')
         .send({ email: 'a@b.com' })
         .expect(400);
     });
 
-    it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
+    it('정의되지 않은 속성을 보내면 400을 반환한다 (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/login')
         .send({ email: 'a@b.com', password: 'password123', hacked: true })
@@ -227,7 +227,7 @@ describe('Auth (integration)', () => {
   // POST /auth/refresh
   // ============================================================
   describe('POST /auth/refresh', () => {
-    it('should return new { accessToken, refreshToken } with 200', async () => {
+    it('refresh에 성공하면 200과 함께 새로운 { accessToken, refreshToken }을 반환한다', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -240,7 +240,7 @@ describe('Auth (integration)', () => {
       expect(res.body.refreshToken).not.toBe(tokens.refreshToken);
     });
 
-    it('should invalidate old refresh token after rotation', async () => {
+    it('rotation 후 이전 refreshToken으로 다시 시도하면 401을 반환한다', async () => {
       const tokens = await registerAndLogin();
 
       // 첫 번째 refresh — 성공
@@ -256,21 +256,21 @@ describe('Auth (integration)', () => {
         .expect(401);
     });
 
-    it('should return 401 for invalid token', () => {
+    it('유효하지 않은 토큰이면 401을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/refresh')
         .send({ refreshToken: 'invalid-token' })
         .expect(401);
     });
 
-    it('should return 400 when refreshToken is missing', () => {
+    it('refreshToken이 누락되면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/refresh')
         .send({})
         .expect(400);
     });
 
-    it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
+    it('정의되지 않은 속성을 보내면 400을 반환한다 (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
         .post('/v1/auth/refresh')
         .send({ refreshToken: 'some-token', hacked: true })
@@ -282,7 +282,7 @@ describe('Auth (integration)', () => {
   // GET /auth/profile
   // ============================================================
   describe('GET /auth/profile', () => {
-    it('should return profile with { id, email, name, marketingConsent, createdAt, updatedAt } and 200', async () => {
+    it('프로필 조회에 성공하면 200과 함께 { id, email, name, marketingConsent, createdAt, updatedAt }를 반환한다', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -334,7 +334,7 @@ describe('Auth (integration)', () => {
       expect(res.body.marketingConsent).toBe(false);
     });
 
-    it('should not include password or hashedRefreshToken in response', async () => {
+    it('응답에 password와 hashedRefreshToken을 포함하지 않는다', async () => {
       const tokens = await registerAndLogin();
 
       const res = await request(app.getHttpServer())
@@ -346,11 +346,11 @@ describe('Auth (integration)', () => {
       expect(res.body).not.toHaveProperty('hashedRefreshToken');
     });
 
-    it('should return 401 without token', () => {
+    it('토큰 없이 조회하면 401을 반환한다', () => {
       return request(app.getHttpServer()).get('/v1/auth/profile').expect(401);
     });
 
-    it('should return 401 with invalid token', () => {
+    it('유효하지 않은 토큰으로 조회하면 401을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/auth/profile')
         .set('Authorization', 'Bearer invalid-token')
@@ -428,7 +428,7 @@ describe('Auth (integration)', () => {
   // POST /auth/logout
   // ============================================================
   describe('POST /auth/logout', () => {
-    it('should return 204 on successful logout', async () => {
+    it('로그아웃에 성공하면 204를 반환한다', async () => {
       const { accessToken } = await registerAndLogin();
 
       await request(app.getHttpServer())
@@ -437,7 +437,7 @@ describe('Auth (integration)', () => {
         .expect(204);
     });
 
-    it('should invalidate refresh token after logout', async () => {
+    it('로그아웃 후 refreshToken으로 refresh를 시도하면 401을 반환한다', async () => {
       const { accessToken, refreshToken } = await registerAndLogin();
 
       await request(app.getHttpServer())
@@ -451,11 +451,11 @@ describe('Auth (integration)', () => {
         .expect(401);
     });
 
-    it('should return 401 when no Authorization header is provided', async () => {
+    it('Authorization 헤더 없이 호출하면 401을 반환한다', async () => {
       await request(app.getHttpServer()).post('/v1/auth/logout').expect(401);
     });
 
-    it('should return 401 when an invalid token is provided', async () => {
+    it('유효하지 않은 토큰으로 호출하면 401을 반환한다', async () => {
       await request(app.getHttpServer())
         .post('/v1/auth/logout')
         .set('Authorization', 'Bearer invalid-token')

--- a/test/service/posts.integration-spec.ts
+++ b/test/service/posts.integration-spec.ts
@@ -71,29 +71,29 @@ describe('Posts (integration)', () => {
   // 인증 없이 요청 시 401
   // ============================================================
   describe('Authentication required', () => {
-    it('should return 401 for GET /posts without token', () => {
+    it('토큰 없이 GET /posts 호출 시 401을 반환한다', () => {
       return request(app.getHttpServer()).get('/v1/posts').expect(401);
     });
 
-    it('should return 401 for GET /posts/:id without token', () => {
+    it('토큰 없이 GET /posts/:id 호출 시 401을 반환한다', () => {
       return request(app.getHttpServer()).get('/v1/posts/1').expect(401);
     });
 
-    it('should return 401 for POST /posts without token', () => {
+    it('토큰 없이 POST /posts 호출 시 401을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/posts')
         .send({ title: 'Test', content: 'Content' })
         .expect(401);
     });
 
-    it('should return 401 for PATCH /posts/:id without token', () => {
+    it('토큰 없이 PATCH /posts/:id 호출 시 401을 반환한다', () => {
       return request(app.getHttpServer())
         .patch('/v1/posts/1')
         .send({ title: 'Test', content: 'Content', isPublished: false })
         .expect(401);
     });
 
-    it('should return 401 for DELETE /posts/:id without token', () => {
+    it('토큰 없이 DELETE /posts/:id 호출 시 401을 반환한다', () => {
       return request(app.getHttpServer()).delete('/v1/posts/1').expect(401);
     });
   });
@@ -109,7 +109,7 @@ describe('Posts (integration)', () => {
       token = tokens.accessToken;
     });
 
-    it('should create a post and return { id }', async () => {
+    it('게시글을 생성하고 { id }를 반환한다', async () => {
       const res = await createPost(token, {
         title: 'Integration Test',
         content: 'Real DB',
@@ -120,7 +120,7 @@ describe('Posts (integration)', () => {
       expect(Object.keys(res.body)).toEqual(['id']);
     });
 
-    it('should persist the post to DB (verified via GET)', async () => {
+    it('생성한 게시글이 DB에 저장된다 (GET으로 검증)', async () => {
       const getRes = await createAndGet(token, {
         title: 'Integration Test',
         content: 'Real DB',
@@ -131,7 +131,7 @@ describe('Posts (integration)', () => {
       expect(getRes.body.isPublished).toBe(false);
     });
 
-    it('should store userId of the authenticated user', async () => {
+    it('인증된 사용자의 userId가 저장된다', async () => {
       const getRes = await createAndGet(token, {
         title: 'With Author',
         content: 'Content',
@@ -141,7 +141,7 @@ describe('Posts (integration)', () => {
       expect(typeof getRes.body.userId).toBe('number');
     });
 
-    it('should auto-generate id, createdAt, and updatedAt', async () => {
+    it('id, createdAt, updatedAt이 자동 생성된다', async () => {
       const getRes = await createAndGet(token);
 
       expect(typeof getRes.body.id).toBe('number');
@@ -152,7 +152,7 @@ describe('Posts (integration)', () => {
       expect(new Date(getRes.body.updatedAt as string).getTime()).not.toBeNaN();
     });
 
-    it('should default isPublished to false when not provided', async () => {
+    it('isPublished를 보내지 않으면 기본값 false로 저장된다', async () => {
       const getRes = await createAndGet(token, {
         title: 'No publish flag',
         content: 'Content',
@@ -161,27 +161,27 @@ describe('Posts (integration)', () => {
       expect(getRes.body.isPublished).toBe(false);
     });
 
-    it('should create a post with isPublished: true', async () => {
+    it('isPublished: true로 게시글을 생성한다', async () => {
       const getRes = await createAndGet(token, { isPublished: true });
 
       expect(getRes.body.isPublished).toBe(true);
     });
 
-    it('should accept title at maximum column length (200 chars)', async () => {
+    it('컬럼 최대 길이(200자)의 title을 허용한다', async () => {
       const maxTitle = 'A'.repeat(200);
       const getRes = await createAndGet(token, { title: maxTitle });
 
       expect(getRes.body.title).toBe(maxTitle);
     });
 
-    it('should assign sequential ids for multiple creates', async () => {
+    it('여러 번 생성하면 id가 순차적으로 증가한다', async () => {
       const res1 = await createPost(token, { title: 'First' }).expect(201);
       const res2 = await createPost(token, { title: 'Second' }).expect(201);
 
       expect(res2.body.id).toBeGreaterThan(res1.body.id as number);
     });
 
-    it('should return 400 when title is missing', () => {
+    it('title이 없으면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
@@ -189,7 +189,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when content is missing', () => {
+    it('content가 없으면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
@@ -197,7 +197,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when body is empty', () => {
+    it('body가 비어 있으면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
@@ -205,7 +205,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 for unknown properties (forbidNonWhitelisted)', () => {
+    it('정의되지 않은 속성이 있으면 400을 반환한다 (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
         .post('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
@@ -213,7 +213,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 409 when same user creates a post with duplicate title', async () => {
+    it('같은 사용자가 중복 title로 게시글을 생성하면 409를 반환한다', async () => {
       await createPost(token, {
         title: 'Unique Title',
         content: 'First',
@@ -227,7 +227,7 @@ describe('Posts (integration)', () => {
       expect(res.body.message).toContain('Unique Title');
     });
 
-    it('should allow different users to create posts with the same title', async () => {
+    it('서로 다른 사용자는 같은 title로 게시글을 생성할 수 있다', async () => {
       await createPost(token, {
         title: 'Shared Title',
         content: 'User 1',
@@ -256,7 +256,7 @@ describe('Posts (integration)', () => {
       token = tokens.accessToken;
     });
 
-    it('should return paginated response with default page=1, limit=10', async () => {
+    it('기본값 page=1, limit=10으로 페이지네이션 응답을 반환한다', async () => {
       await createPost(token, { title: 'Post A' }).expect(201);
 
       const res = await request(app.getHttpServer())
@@ -275,7 +275,7 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.isLast).toBe(true);
     });
 
-    it('should return empty items when no posts exist', async () => {
+    it('게시글이 없으면 빈 items를 반환한다', async () => {
       const res = await request(app.getHttpServer())
         .get('/v1/posts')
         .set('Authorization', `Bearer ${token}`)
@@ -286,7 +286,7 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.totalPages).toBe(0);
     });
 
-    it('should paginate with custom page and limit', async () => {
+    it('지정한 page와 limit으로 페이지네이션한다', async () => {
       for (let i = 0; i < 5; i++) {
         await createPost(token, { title: `Post ${i + 1}` }).expect(201);
       }
@@ -305,7 +305,7 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.isLast).toBe(false);
     });
 
-    it('should return items in id DESC order (newest first)', async () => {
+    it('items를 id DESC 순서로 반환한다 (최신순)', async () => {
       await createPost(token, { title: 'First' }).expect(201);
       await createPost(token, { title: 'Second' }).expect(201);
       await createPost(token, { title: 'Third' }).expect(201);
@@ -320,7 +320,7 @@ describe('Posts (integration)', () => {
       expect(res.body.items[2].title).toBe('First');
     });
 
-    it('should mark last page correctly', async () => {
+    it('마지막 페이지를 올바르게 표시한다', async () => {
       for (let i = 0; i < 3; i++) {
         await createPost(token, { title: `Post ${i + 1}` }).expect(201);
       }
@@ -335,7 +335,7 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.isFirst).toBe(false);
     });
 
-    it('should return correct response shape for items', async () => {
+    it('items가 올바른 응답 형태를 가진다', async () => {
       await createPost(token).expect(201);
 
       const res = await request(app.getHttpServer())
@@ -353,28 +353,28 @@ describe('Posts (integration)', () => {
       expect(post).toHaveProperty('updatedAt');
     });
 
-    it('should return 400 when page is 0', () => {
+    it('page가 0이면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/posts?page=0')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
 
-    it('should return 400 when limit exceeds 100', () => {
+    it('limit이 100을 초과하면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/posts?limit=101')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
 
-    it('should return 400 when page is not a number', () => {
+    it('page가 숫자가 아니면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/posts?page=abc')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
 
-    it('should filter by isPublished=true', async () => {
+    it('isPublished=true로 필터링한다', async () => {
       await createPost(token, {
         title: 'Published',
         isPublished: true,
@@ -394,7 +394,7 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.totalElements).toBe(1);
     });
 
-    it('should filter by isPublished=false', async () => {
+    it('isPublished=false로 필터링한다', async () => {
       await createPost(token, {
         title: 'Published',
         isPublished: true,
@@ -411,7 +411,7 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.totalElements).toBe(1);
     });
 
-    it('should combine isPublished filter with pagination', async () => {
+    it('isPublished 필터와 페이지네이션을 함께 적용한다', async () => {
       for (let i = 0; i < 5; i++) {
         await createPost(token, {
           title: `Published ${i}`,
@@ -430,14 +430,14 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.totalPages).toBe(3);
     });
 
-    it('should return 400 for invalid isPublished value', () => {
+    it('isPublished 값이 유효하지 않으면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/posts?isPublished=notabool')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
 
-    it('should only return posts created by the authenticated user', async () => {
+    it('인증된 사용자가 생성한 게시글만 반환한다', async () => {
       await createPost(token, { title: 'My Post' }).expect(201);
 
       const tokens2 = await registerAndLogin({
@@ -458,7 +458,7 @@ describe('Posts (integration)', () => {
       expect(res.body.meta.totalElements).toBe(1);
     });
 
-    it('should return empty when user has no posts even if other users do', async () => {
+    it('다른 사용자의 게시글이 있어도 본인 게시글이 없으면 빈 결과를 반환한다', async () => {
       await createPost(token, { title: 'User 1 Post' }).expect(201);
 
       const tokens2 = await registerAndLogin({
@@ -487,7 +487,7 @@ describe('Posts (integration)', () => {
       token = tokens.accessToken;
     });
 
-    it('should return a post by id', async () => {
+    it('id로 게시글을 조회한다', async () => {
       const createRes = await createPost(token, {
         title: 'Find Me',
         content: 'By ID',
@@ -504,7 +504,7 @@ describe('Posts (integration)', () => {
       expect(res.body.content).toBe('By ID');
     });
 
-    it('should return all entity fields correctly', async () => {
+    it('모든 엔티티 필드를 올바르게 반환한다', async () => {
       const createRes = await createPost(token, {
         title: 'Full Fields',
         content: 'Check all',
@@ -525,7 +525,7 @@ describe('Posts (integration)', () => {
       expect(res.body.updatedAt).toBeDefined();
     });
 
-    it('should return 404 when post not found', () => {
+    it('게시글이 존재하지 않으면 404를 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/posts/99999')
         .set('Authorization', `Bearer ${token}`)
@@ -535,7 +535,7 @@ describe('Posts (integration)', () => {
         });
     });
 
-    it("should return 404 when accessing another user's post", async () => {
+    it('다른 사용자의 게시글을 조회하면 404를 반환한다', async () => {
       const createRes = await createPost(token, {
         title: 'Private Post',
         content: 'Owner Only',
@@ -553,7 +553,7 @@ describe('Posts (integration)', () => {
         .expect(404);
     });
 
-    it('should return 400 for non-numeric id', () => {
+    it('id가 숫자가 아니면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .get('/v1/posts/abc')
         .set('Authorization', `Bearer ${token}`)
@@ -578,7 +578,7 @@ describe('Posts (integration)', () => {
       token = tokens.accessToken;
     });
 
-    it('should update all fields and return 204', async () => {
+    it('모든 필드를 수정하고 204를 반환한다', async () => {
       const createRes = await createPost(token).expect(201);
       const id = createRes.body.id as number;
 
@@ -598,7 +598,7 @@ describe('Posts (integration)', () => {
       expect(getRes.body.isPublished).toBe(true);
     });
 
-    it('should return 404 when post not found', () => {
+    it('게시글이 존재하지 않으면 404를 반환한다', () => {
       return request(app.getHttpServer())
         .patch('/v1/posts/99999')
         .set('Authorization', `Bearer ${token}`)
@@ -609,7 +609,7 @@ describe('Posts (integration)', () => {
         });
     });
 
-    it("should return 404 when updating another user's post", async () => {
+    it('다른 사용자의 게시글을 수정하면 404를 반환한다', async () => {
       const createRes = await createPost(token).expect(201);
       const id = createRes.body.id as number;
 
@@ -625,7 +625,7 @@ describe('Posts (integration)', () => {
         .expect(404);
     });
 
-    it('should return 400 for non-numeric id', () => {
+    it('id가 숫자가 아니면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .patch('/v1/posts/abc')
         .set('Authorization', `Bearer ${token}`)
@@ -633,7 +633,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 for invalid body (forbidNonWhitelisted)', () => {
+    it('body에 정의되지 않은 속성이 있으면 400을 반환한다 (forbidNonWhitelisted)', () => {
       return request(app.getHttpServer())
         .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
@@ -641,7 +641,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when required field is missing', () => {
+    it('필수 필드가 없으면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
@@ -649,7 +649,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when title is empty string', () => {
+    it('title이 빈 문자열이면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
@@ -657,7 +657,7 @@ describe('Posts (integration)', () => {
         .expect(400);
     });
 
-    it('should return 400 when content is empty string', () => {
+    it('content가 빈 문자열이면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .patch('/v1/posts/1')
         .set('Authorization', `Bearer ${token}`)
@@ -677,7 +677,7 @@ describe('Posts (integration)', () => {
       token = tokens.accessToken;
     });
 
-    it('should delete a post and return 204', async () => {
+    it('게시글을 삭제하고 204를 반환한다', async () => {
       const createRes = await createPost(token).expect(201);
       const id = createRes.body.id as number;
 
@@ -692,7 +692,7 @@ describe('Posts (integration)', () => {
         .expect(404);
     });
 
-    it('should return 404 when post not found', () => {
+    it('게시글이 존재하지 않으면 404를 반환한다', () => {
       return request(app.getHttpServer())
         .delete('/v1/posts/99999')
         .set('Authorization', `Bearer ${token}`)
@@ -702,7 +702,7 @@ describe('Posts (integration)', () => {
         });
     });
 
-    it("should return 404 when deleting another user's post", async () => {
+    it('다른 사용자의 게시글을 삭제하면 404를 반환한다', async () => {
       const createRes = await createPost(token).expect(201);
       const id = createRes.body.id as number;
 
@@ -717,14 +717,14 @@ describe('Posts (integration)', () => {
         .expect(404);
     });
 
-    it('should return 400 for non-numeric id', () => {
+    it('id가 숫자가 아니면 400을 반환한다', () => {
       return request(app.getHttpServer())
         .delete('/v1/posts/abc')
         .set('Authorization', `Bearer ${token}`)
         .expect(400);
     });
 
-    it('should allow creating a post with same title after soft-delete', async () => {
+    it('soft-delete 후 같은 title로 게시글을 생성할 수 있다', async () => {
       const createRes = await createPost(token, {
         title: 'Reusable Title',
         content: 'Original',
@@ -752,7 +752,7 @@ describe('Posts (integration)', () => {
       expect(getRes.body.content).toBe('Recreated');
     });
 
-    it('should not affect other posts', async () => {
+    it('삭제 시 다른 게시글에 영향을 주지 않는다', async () => {
       const res1 = await createPost(token, { title: 'Keep' }).expect(201);
       const res2 = await createPost(token, { title: 'Delete Me' }).expect(201);
 


### PR DESCRIPTION
> **Merge Strategy**: Create a merge commit을 사용해주세요.

## Summary

루트 CLAUDE.md의 전체 spec 일관 규칙 — "describe는 영문 클래스명, it 문장은 한국어로 행위와 결과를 진술한다" — 을 위반하는 영어 `it` 문장 125건을 한국어로 통일한다. **테스트 본문·assertion은 한 글자도 변경하지 않은 문자열 전용 작업**이다.

| 파일 | 건수 |
| --- | --- |
| `test/back-office/admin.integration-spec.ts` | 27건 (파일 전체) |
| `test/service/posts.integration-spec.ts` | 53건 (한국어와 혼재) |
| `test/service/auth.integration-spec.ts` | 28건 (한국어와 혼재) |
| DTO 단위 spec 5개 파일 | 17건 |

## Notes

- **측정 교정**: 1차 점검의 "back-office만 위반" 보고는 "한글로 시작" 휴리스틱의 오탐이었다 (`it('HttpException은 …')`처럼 식별자로 시작하는 한국어 문장을 영어로 집계). "한글 미포함" 기준으로 재측정한 결과 service 통합 spec이 더 큰 위반 영역이었다.
- google-oauth 스펙에 1건으로 집계됐던 것은 assertion의 `split('.')`이 `it(` 패턴에 걸린 측정 오탐 — 실제 변경 없음.
- 번역 원칙: 행위(조건) + 결과를 "~한다"로 진술, HTTP 메서드·라우트·상태 코드·식별자는 원문 유지, 같은 파일의 기존 한국어 문장 어휘를 기준으로 통일.
- `git diff -U0` 기계 검증으로 **변경 라인 전부가 `it(` 선언 라인**임을 확인 — describe·본문·assertion 무변경.
- 상세 측정·원칙은 `docs/spec-it-korean-prd.md` 참고.

## Test plan

- [x] 코드베이스 전체에서 한글 미포함 it 문장 0건 (측정 스크립트 재실행)
- [x] 테스트 수 불변 — 단위 185 / 통합 service 160 + back-office 34 (번역 전과 동일)
- [x] `pnpm format` / `pnpm lint:check` / `pnpm build:all` 통과
- [x] `pnpm test` / `pnpm test:e2e` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test descriptions to Korean across authentication, registration, and post management test suites to improve consistency and readability.

* **Chores**
  * Added development documentation outlining Korean language standardization guidelines for test descriptions and tracking progress across multiple testing phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->