### PR TITLE
refactor: TypeScript full strict 전환 — 필드 ! 단언 100건, advisory CI 정리

### DIFF
--- a/.github/workflows/typescript-strict.yml
+++ b/.github/workflows/typescript-strict.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Type check (current config)
+      # tsconfig.json이 "strict": true이므로 이 체크가 곧 strict 체크다.
+      # 과거의 advisory(continue-on-error) 단계는 full strict 달성으로 중복이 되어 제거함.
+      - name: Type check (strict)
         run: npx tsc --noEmit
-
-      - name: Strict type check (advisory)
-        continue-on-error: true
-        run: npx tsc --noEmit --strict

--- a/apps/back-office/src/auth/admin-token-issuer.service.spec.ts
+++ b/apps/back-office/src/auth/admin-token-issuer.service.spec.ts
@@ -45,7 +45,7 @@ describe('AdminTokenIssuer', () => {
       .mockReturnValueOnce('refresh-token');
     (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-refresh-token');
     adminWriteRepository.update.mockResolvedValue(1);
-    configService.get.mockImplementation(
+    (configService.get as jest.Mock).mockImplementation(
       (key: string, defaultValue?: string) => {
         if (key === 'JWT_ADMIN_ACCESS_EXPIRATION') return defaultValue ?? '15m';
         if (key === 'JWT_ADMIN_REFRESH_EXPIRATION') return defaultValue ?? '7d';

--- a/apps/back-office/src/auth/decorator/auth-admin.type.ts
+++ b/apps/back-office/src/auth/decorator/auth-admin.type.ts
@@ -1,7 +1,7 @@
 import { AdminRole } from '@app/shared';
 
 export class AuthAdmin {
-  id: number;
-  email: string;
-  role: AdminRole;
+  id!: number;
+  email!: string;
+  role!: AdminRole;
 }

--- a/apps/back-office/src/auth/dto/request/admin-login.request.dto.ts
+++ b/apps/back-office/src/auth/dto/request/admin-login.request.dto.ts
@@ -5,10 +5,10 @@ export class AdminLoginRequestDto {
   @ApiProperty({ description: '이메일', example: 'admin@example.com' })
   @IsEmail()
   @IsNotEmpty()
-  email: string;
+  email!: string;
 
   @ApiProperty({ description: '비밀번호', example: 'password123' })
   @IsString()
   @IsNotEmpty()
-  password: string;
+  password!: string;
 }

--- a/apps/back-office/src/auth/dto/request/admin-refresh-token.request.dto.ts
+++ b/apps/back-office/src/auth/dto/request/admin-refresh-token.request.dto.ts
@@ -5,5 +5,5 @@ export class AdminRefreshTokenRequestDto {
   @ApiProperty({ description: '리프레시 토큰' })
   @IsString()
   @IsNotEmpty()
-  refreshToken: string;
+  refreshToken!: string;
 }

--- a/apps/back-office/src/auth/dto/request/admin-register.request.dto.ts
+++ b/apps/back-office/src/auth/dto/request/admin-register.request.dto.ts
@@ -5,16 +5,16 @@ export class AdminRegisterRequestDto {
   @ApiProperty({ description: '이메일', example: 'admin@example.com' })
   @IsEmail()
   @IsNotEmpty()
-  email: string;
+  email!: string;
 
   @ApiProperty({ description: '비밀번호 (최소 8자)', example: 'password123' })
   @IsString()
   @IsNotEmpty()
   @MinLength(8)
-  password: string;
+  password!: string;
 
   @ApiProperty({ description: '이름', example: '관리자' })
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name!: string;
 }

--- a/apps/back-office/src/auth/dto/response/admin-auth-tokens.response.dto.ts
+++ b/apps/back-office/src/auth/dto/response/admin-auth-tokens.response.dto.ts
@@ -3,10 +3,10 @@ import { AuthTokens } from '@app/shared';
 
 export class AdminAuthTokensResponseDto {
   @ApiProperty({ description: '액세스 토큰' })
-  accessToken: string;
+  accessToken!: string;
 
   @ApiProperty({ description: '리프레시 토큰' })
-  refreshToken: string;
+  refreshToken!: string;
 
   static of(tokens: AuthTokens): AdminAuthTokensResponseDto {
     const dto = new AdminAuthTokensResponseDto();

--- a/apps/back-office/src/auth/dto/response/admin-profile.response.dto.ts
+++ b/apps/back-office/src/auth/dto/response/admin-profile.response.dto.ts
@@ -3,26 +3,26 @@ import { Admin, AdminRole } from '@app/shared';
 
 export class AdminProfileResponseDto {
   @ApiProperty({ description: '관리자 ID', example: 1 })
-  id: number;
+  id!: number;
 
   @ApiProperty({ description: '이메일', example: 'admin@example.com' })
-  email: string;
+  email!: string;
 
   @ApiProperty({ description: '이름', example: '관리자' })
-  name: string;
+  name!: string;
 
   @ApiProperty({
     description: '등급',
     enum: AdminRole,
     example: AdminRole.MANAGER,
   })
-  role: AdminRole;
+  role!: AdminRole;
 
   @ApiProperty({ description: '생성일시' })
-  createdAt: Date;
+  createdAt!: Date;
 
   @ApiProperty({ description: '수정일시' })
-  updatedAt: Date;
+  updatedAt!: Date;
 
   static of(admin: Admin): AdminProfileResponseDto {
     const dto = new AdminProfileResponseDto();

--- a/apps/back-office/src/auth/dto/response/admin-register.response.dto.ts
+++ b/apps/back-office/src/auth/dto/response/admin-register.response.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class AdminRegisterResponseDto {
   @ApiProperty({ description: '생성된 관리자 ID', example: 1 })
-  id: number;
+  id!: number;
 
   static of(id: number): AdminRegisterResponseDto {
     const dto = new AdminRegisterResponseDto();

--- a/apps/service/src/auth/auth-token-issuer.service.spec.ts
+++ b/apps/service/src/auth/auth-token-issuer.service.spec.ts
@@ -43,7 +43,7 @@ describe('AuthTokenIssuer', () => {
       .mockReturnValueOnce('refresh-token');
     (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-refresh-token');
     userWriteRepository.update.mockResolvedValue(1);
-    configService.get.mockImplementation(
+    (configService.get as jest.Mock).mockImplementation(
       (key: string, defaultValue?: string) => {
         if (key === 'JWT_ACCESS_EXPIRATION') return defaultValue ?? '15m';
         if (key === 'JWT_REFRESH_EXPIRATION') return defaultValue ?? '7d';

--- a/apps/service/src/auth/decorator/auth-user.type.ts
+++ b/apps/service/src/auth/decorator/auth-user.type.ts
@@ -1,4 +1,4 @@
 export class AuthUser {
-  id: number;
-  email: string;
+  id!: number;
+  email!: string;
 }

--- a/apps/service/src/auth/dto/request/login.request.dto.ts
+++ b/apps/service/src/auth/dto/request/login.request.dto.ts
@@ -5,10 +5,10 @@ export class LoginRequestDto {
   @ApiProperty({ description: '이메일', example: 'user@example.com' })
   @IsEmail()
   @IsNotEmpty()
-  email: string;
+  email!: string;
 
   @ApiProperty({ description: '비밀번호', example: 'password123' })
   @IsString()
   @IsNotEmpty()
-  password: string;
+  password!: string;
 }

--- a/apps/service/src/auth/dto/request/refresh-token.request.dto.ts
+++ b/apps/service/src/auth/dto/request/refresh-token.request.dto.ts
@@ -5,5 +5,5 @@ export class RefreshTokenRequestDto {
   @ApiProperty({ description: '리프레시 토큰' })
   @IsString()
   @IsNotEmpty()
-  refreshToken: string;
+  refreshToken!: string;
 }

--- a/apps/service/src/auth/dto/request/register.request.dto.ts
+++ b/apps/service/src/auth/dto/request/register.request.dto.ts
@@ -11,20 +11,20 @@ export class RegisterRequestDto {
   @ApiProperty({ description: '이메일', example: 'user@example.com' })
   @IsEmail()
   @IsNotEmpty()
-  email: string;
+  email!: string;
 
   @ApiProperty({ description: '비밀번호 (최소 8자)', example: 'password123' })
   @IsString()
   @IsNotEmpty()
   @MinLength(8)
-  password: string;
+  password!: string;
 
   @ApiProperty({ description: '이름', example: '홍길동' })
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name!: string;
 
   @ApiProperty({ description: '마케팅 수신 동의', example: true })
   @IsBoolean()
-  marketingConsent: boolean;
+  marketingConsent!: boolean;
 }

--- a/apps/service/src/auth/dto/request/update-profile.request.dto.ts
+++ b/apps/service/src/auth/dto/request/update-profile.request.dto.ts
@@ -11,5 +11,5 @@ export class UpdateProfileRequestDto {
   @IsString()
   @IsNotEmpty()
   @Length(1, 30)
-  name: string;
+  name!: string;
 }

--- a/apps/service/src/auth/dto/response/auth-tokens.response.dto.ts
+++ b/apps/service/src/auth/dto/response/auth-tokens.response.dto.ts
@@ -3,10 +3,10 @@ import { AuthTokens } from '@app/shared';
 
 export class AuthTokensResponseDto {
   @ApiProperty({ description: '액세스 토큰' })
-  accessToken: string;
+  accessToken!: string;
 
   @ApiProperty({ description: '리프레시 토큰' })
-  refreshToken: string;
+  refreshToken!: string;
 
   static of(tokens: AuthTokens): AuthTokensResponseDto {
     const dto = new AuthTokensResponseDto();

--- a/apps/service/src/auth/dto/response/link-initiate.response.dto.ts
+++ b/apps/service/src/auth/dto/response/link-initiate.response.dto.ts
@@ -7,7 +7,7 @@ export class LinkInitiateResponseDto {
     example:
       'https://accounts.google.com/o/oauth2/v2/auth?client_id=...&state=...',
   })
-  authorizationUrl: string;
+  authorizationUrl!: string;
 
   static of(authorizationUrl: string): LinkInitiateResponseDto {
     const dto = new LinkInitiateResponseDto();

--- a/apps/service/src/auth/dto/response/profile.response.dto.ts
+++ b/apps/service/src/auth/dto/response/profile.response.dto.ts
@@ -3,22 +3,22 @@ import { User } from '@app/shared';
 
 export class ProfileResponseDto {
   @ApiProperty({ description: '사용자 ID', example: 1 })
-  id: number;
+  id!: number;
 
   @ApiProperty({ description: '이메일', example: 'user@example.com' })
-  email: string;
+  email!: string;
 
   @ApiProperty({ description: '이름', example: '홍길동' })
-  name: string;
+  name!: string;
 
   @ApiProperty({ description: '생성일시' })
-  createdAt: Date;
+  createdAt!: Date;
 
   @ApiProperty({ description: '수정일시' })
-  updatedAt: Date;
+  updatedAt!: Date;
 
   @ApiProperty({ description: '마케팅 수신 동의', example: true })
-  marketingConsent: boolean;
+  marketingConsent!: boolean;
 
   static of(user: User): ProfileResponseDto {
     const dto = new ProfileResponseDto();

--- a/apps/service/src/auth/dto/response/register.response.dto.ts
+++ b/apps/service/src/auth/dto/response/register.response.dto.ts
@@ -2,10 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class RegisterResponseDto {
   @ApiProperty({ description: '생성된 사용자 ID', example: 1 })
-  id: number;
+  id!: number;
 
   @ApiProperty({ description: '마케팅 수신 동의', example: true })
-  marketingConsent: boolean;
+  marketingConsent!: boolean;
 
   static of(id: number, marketingConsent: boolean): RegisterResponseDto {
     const dto = new RegisterResponseDto();

--- a/apps/service/src/posts/dto/request/create-post.request.dto.ts
+++ b/apps/service/src/posts/dto/request/create-post.request.dto.ts
@@ -12,12 +12,12 @@ export class CreatePostRequestDto {
   @ApiProperty({ description: '게시글 제목', example: 'First Post' })
   @IsString()
   @IsNotEmpty()
-  title: string;
+  title!: string;
 
   @ApiProperty({ description: '게시글 내용', example: 'Hello World' })
   @IsString()
   @IsNotEmpty()
-  content: string;
+  content!: string;
 
   @ApiPropertyOptional({ description: '공개 여부', default: false })
   @IsBoolean()

--- a/apps/service/src/posts/dto/request/update-post.request.dto.ts
+++ b/apps/service/src/posts/dto/request/update-post.request.dto.ts
@@ -12,7 +12,7 @@ export class UpdatePostRequestDto {
   @ApiProperty({ description: '게시글 제목', example: 'Updated Title' })
   @IsString()
   @IsNotEmpty()
-  title: string;
+  title!: string;
 
   @ApiProperty({
     description: '게시글 내용',
@@ -20,11 +20,11 @@ export class UpdatePostRequestDto {
   })
   @IsString()
   @IsNotEmpty()
-  content: string;
+  content!: string;
 
   @ApiProperty({ description: '공개 여부' })
   @IsBoolean()
-  isPublished: boolean;
+  isPublished!: boolean;
 
   @ApiPropertyOptional({
     description: '연결할 태그 ID 목록 (제공 시 기존 태그를 이 목록으로 대체)',

--- a/apps/service/src/posts/dto/response/create-post.response.dto.ts
+++ b/apps/service/src/posts/dto/response/create-post.response.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class CreatePostResponseDto {
   @ApiProperty({ description: '생성된 게시글 ID', example: 1 })
-  id: number;
+  id!: number;
 
   static of(id: number): CreatePostResponseDto {
     const dto = new CreatePostResponseDto();

--- a/apps/service/src/posts/dto/response/post.response.dto.ts
+++ b/apps/service/src/posts/dto/response/post.response.dto.ts
@@ -4,28 +4,28 @@ import { TagResponseDto } from '@service/tags/dto/response/tag.response.dto';
 
 export class PostResponseDto {
   @ApiProperty({ description: '게시글 ID', example: 1 })
-  id: number;
+  id!: number;
 
   @ApiProperty({ description: '작성자 ID', example: 1 })
-  userId: number;
+  userId!: number;
 
   @ApiProperty({ description: '게시글 제목', example: 'First Post' })
-  title: string;
+  title!: string;
 
   @ApiProperty({ description: '게시글 내용', example: 'Hello World' })
-  content: string;
+  content!: string;
 
   @ApiProperty({ description: '공개 여부', example: false })
-  isPublished: boolean;
+  isPublished!: boolean;
 
   @ApiProperty({ description: '생성일시' })
-  createdAt: Date;
+  createdAt!: Date;
 
   @ApiProperty({ description: '수정일시' })
-  updatedAt: Date;
+  updatedAt!: Date;
 
   @ApiProperty({ description: '연결된 태그 목록', type: [TagResponseDto] })
-  tags: TagResponseDto[];
+  tags!: TagResponseDto[];
 
   static of(post: Post): PostResponseDto {
     const dto = new PostResponseDto();

--- a/apps/service/src/tags/dto/request/create-tag.request.dto.ts
+++ b/apps/service/src/tags/dto/request/create-tag.request.dto.ts
@@ -6,5 +6,5 @@ export class CreateTagRequestDto {
   @IsString()
   @IsNotEmpty()
   @MaxLength(50)
-  name: string;
+  name!: string;
 }

--- a/apps/service/src/tags/dto/request/update-tag.request.dto.ts
+++ b/apps/service/src/tags/dto/request/update-tag.request.dto.ts
@@ -10,5 +10,5 @@ export class UpdateTagRequestDto {
   @IsString()
   @IsNotEmpty()
   @MaxLength(50)
-  name: string;
+  name!: string;
 }

--- a/apps/service/src/tags/dto/response/create-tag.response.dto.ts
+++ b/apps/service/src/tags/dto/response/create-tag.response.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateTagResponseDto {
   @ApiProperty({ description: '생성된 태그 ID', example: 1 })
-  id: number;
+  id!: number;
 
   static of(id: number): CreateTagResponseDto {
     const dto = new CreateTagResponseDto();

--- a/apps/service/src/tags/dto/response/tag.response.dto.ts
+++ b/apps/service/src/tags/dto/response/tag.response.dto.ts
@@ -3,19 +3,19 @@ import { Tag } from '@app/shared';
 
 export class TagResponseDto {
   @ApiProperty({ description: '태그 ID', example: 1 })
-  id: number;
+  id!: number;
 
   @ApiProperty({ description: '소유자 ID', example: 1 })
-  userId: number;
+  userId!: number;
 
   @ApiProperty({ description: '태그 이름', example: 'nestjs' })
-  name: string;
+  name!: string;
 
   @ApiProperty({ description: '생성일시' })
-  createdAt: Date;
+  createdAt!: Date;
 
   @ApiProperty({ description: '수정일시' })
-  updatedAt: Date;
+  updatedAt!: Date;
 
   static of(tag: Tag): TagResponseDto {
     const dto = new TagResponseDto();

--- a/docs/typescript-full-strict-prd.md
+++ b/docs/typescript-full-strict-prd.md
@@ -1,0 +1,52 @@
+# TypeScript full strict 활성화 PRD
+
+엄격성 강화 2단계(1단계: PR #78). `tsconfig.json`을 `"strict": true`로 전환하고 잔여 위반 102건을 해소한다. 완료 시 CI의 advisory strict 체크가 본 체크와 동일해지므로 중복 단계를 정리한다.
+
+## 1. 위반 분석 (main `24e68f7` 기준, 총 102건)
+
+| TS 코드 | 건수 | 의미 | 해소 방법 |
+| --- | --- | --- | --- |
+| TS2564 (`strictPropertyInitialization`) | **100건 / 26개 파일** | 필드가 생성자에서 확정 할당되지 않음 | `!`(definite assignment assertion) 추가 |
+| TS2345 (`strictFunctionTypes`) | **2건** | spec의 ConfigService mock 시그니처가 overload와 불일치 | mock 타이핑 수정 |
+
+TS2564의 분포: 엔티티 6개 파일(31건), Response DTO 9개(33건), Request DTO 8개(19건), 타입 클래스 2개(`auth-user.type`, `auth-admin.type`, 5건), 기타(12건). `noImplicitThis`·`alwaysStrict`·`useUnknownInCatchVariables` 위반은 0건 (catch 블록은 이미 `(error as Error)` 캐스팅 패턴 사용).
+
+## 2. 변경 내용
+
+### 2.1 필드 선언에 `!` 추가 (TS2564, 100건)
+
+- TypeORM 엔티티·class-transformer DTO·데코레이터 주입 타입은 **프레임워크가 런타임에 값을 채우는** 클래스라 생성자 초기화가 부자연스럽다. TypeORM/NestJS 생태계의 표준 해법인 `!` 단언을 일괄 적용한다: `title: string;` → `title!: string;`
+- `!`는 타입 선언 전용이라 **런타임 동작·SWC 빌드 산출물에 영향이 없다** (생성자 초기화 방식은 인스턴스 생성 시 실제 할당이 발생해 동작 변화 가능성이 있어 배제).
+- 기본값이 이미 있는 필드(`page: number = 1` 등)와 `?` 옵셔널 필드는 에러가 아니므로 손대지 않는다.
+
+### 2.2 spec의 ConfigService mock 타이핑 수정 (TS2345, 2건)
+
+- `apps/service/src/auth/auth-token-issuer.service.spec.ts:47`, `apps/back-office/src/auth/admin-token-issuer.service.spec.ts:49` — `strictFunctionTypes`에서 ConfigService.get overload 해석이 엄격해져 mock 구현 시그니처가 거부된다. 구현 시점에 실제 코드를 보고 최소 수정(시그니처 조정 또는 명시적 캐스팅)한다.
+
+### 2.3 `tsconfig.json` — `"strict": true`로 통합
+
+- 개별 플래그(`strictNullChecks`, `noImplicitAny`, `strictBindCallApply`)를 `"strict": true` 한 줄로 대체한다 (모두 strict 포함 항목). `noFallthroughCasesInSwitch`는 strict 미포함이므로 유지.
+
+### 2.4 (구현 중 발견) slack.service.ts 템플릿 리터럴 1건
+
+- `"strict": true` 적용으로 `useUnknownInCatchVariables`가 켜지면서 catch 변수가 `unknown`이 되었고, `slack.service.ts:108`의 템플릿 리터럴 else 분기(`: error`)가 eslint `restrict-template-expressions`에 걸렸다 (tsc가 아닌 type-aware lint에서 검출 — §1 사전 측정에 잡히지 않은 이유).
+- `String(error)`로 수정 — 문자열 보간 결과는 동일하므로 런타임 무변경.
+
+### 2.5 CI `typescript-strict.yml` — advisory 단계 정리
+
+- tsconfig가 strict면 기존 "Type check (current config)" 단계(`npx tsc --noEmit`)가 곧 strict 체크다. 동일 명령을 `--strict`로 한 번 더 돌리는 advisory 단계(`continue-on-error: true`)는 중복이므로 **제거**한다. 이제 strict 위반은 CI에서 차단된다 — PR #78에서 "full strict 달성 후"로 미뤄둔 항목의 완결.
+
+## 3. 수용 기준 (Acceptance Criteria)
+
+- [x] `tsconfig.json`이 `"strict": true`이고 중복 개별 플래그가 정리된다.
+- [x] `npx tsc --noEmit` 에러 0건.
+- [x] `typescript-strict.yml`에서 advisory 단계가 제거된다 (본 체크 1개만 남음).
+- [x] `!` 추가와 spec mock 수정 외 코드 변경이 없다 — 런타임 동작 무변경.
+- [x] 테스트 수 불변: 단위 185 / 통합 160 + 34.
+- [x] `pnpm format` → `pnpm lint:check` → `pnpm build:all` → `pnpm test` → `pnpm test:e2e` 전부 통과한다.
+
+## 4. 범위 외 (Out of scope)
+
+- `exactOptionalPropertyTypes`·`noUncheckedIndexedAccess` 등 strict 미포함 추가 플래그 — 별도 결정.
+- `!` 대신 생성자 초기화/`declare`로의 구조 변경 — 생태계 표준에서 벗어나고 런타임 영향 가능성.
+- 엔티티/DTO 필드의 타입 자체 변경.

--- a/docs/typescript-full-strict-todo.md
+++ b/docs/typescript-full-strict-todo.md
@@ -1,0 +1,41 @@
+# TypeScript full strict 활성화 체크리스트
+
+> 위반 분석(102건 분해), `!` 선택 근거, 범위 외 결정은 [typescript-full-strict-prd.md](./typescript-full-strict-prd.md)를 참고한다.
+
+## 진행 현황 (요약)
+
+| Phase | 상태 | 비고 |
+|---|---|---|
+| 1. 필드 `!` 추가 | ✅ 완료 | TS2564 100건 / 26개 파일 (엔티티·DTO·타입 클래스) |
+| 2. spec mock 타이핑 수정 | ✅ 완료 | TS2345 2건 (ConfigService.get mock) |
+| 3. tsconfig strict 통합 + CI 정리 | ✅ 완료 | "strict": true + advisory 단계 제거 |
+| 4. 최종 검증 | ✅ 완료 | tsc 0건 + format → lint:check → build:all → test → test:e2e |
+
+## Phase 1: 필드 `!` 추가 (100건)
+
+- [x] 엔티티 6개 파일 (base/post/user/admin/tag/oauth-account)
+- [x] Response DTO 9개 파일
+- [x] Request DTO 8개 파일 (기본값 있는 필드는 제외)
+- [x] 타입 클래스 2개 (`auth-user.type.ts`, `auth-admin.type.ts`)
+- [x] 기타 잔여 파일 — `/tmp/strict-errors.txt` 목록 기준 전부 소진
+
+## Phase 2: spec mock 타이핑 수정 (2건)
+
+- [x] `apps/service/src/auth/auth-token-issuer.service.spec.ts:47`
+- [x] `apps/back-office/src/auth/admin-token-issuer.service.spec.ts:49`
+- [x] 해당 spec 2개 단독 실행 통과
+
+## Phase 3: tsconfig + CI
+
+- [x] `tsconfig.json` — `"strict": true`, 중복 개별 플래그 제거, `noFallthroughCasesInSwitch` 유지
+- [x] `npx tsc --noEmit` 0건 확인
+- [x] `.github/workflows/typescript-strict.yml` — advisory 단계 제거
+
+## Phase 4: 최종 검증
+
+- [x] `pnpm format`
+- [x] `pnpm lint:check`
+- [x] `pnpm build:all`
+- [x] `pnpm test` (185개, 수 불변)
+- [x] `pnpm test:e2e` (160 + 34, Docker 필요)
+- [x] diff 검토 — `!` 추가·mock 수정·tsconfig·CI yml 외 변경 없음

--- a/libs/shared/src/common/dto/response/paginated.response.dto.ts
+++ b/libs/shared/src/common/dto/response/paginated.response.dto.ts
@@ -2,30 +2,30 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class PaginationMeta {
   @ApiProperty({ description: '현재 페이지 번호', example: 1 })
-  page: number;
+  page!: number;
 
   @ApiProperty({ description: '페이지당 항목 수', example: 10 })
-  limit: number;
+  limit!: number;
 
   @ApiProperty({ description: '전체 항목 수', example: 100 })
-  totalElements: number;
+  totalElements!: number;
 
   @ApiProperty({ description: '전체 페이지 수', example: 10 })
-  totalPages: number;
+  totalPages!: number;
 
   @ApiProperty({ description: '첫 페이지 여부', example: true })
-  isFirst: boolean;
+  isFirst!: boolean;
 
   @ApiProperty({ description: '마지막 페이지 여부', example: false })
-  isLast: boolean;
+  isLast!: boolean;
 }
 
 export class PaginatedResponseDto<T> {
   @ApiProperty({ description: '항목 목록', isArray: true })
-  items: T[];
+  items!: T[];
 
   @ApiProperty({ description: '페이지네이션 메타 정보', type: PaginationMeta })
-  meta: PaginationMeta;
+  meta!: PaginationMeta;
 
   static of<T>(
     items: T[],

--- a/libs/shared/src/entities/admin.entity.ts
+++ b/libs/shared/src/entities/admin.entity.ts
@@ -5,17 +5,17 @@ import { AdminRole } from '../enum/admin-role.enum';
 @Entity('admins')
 export class Admin extends BaseTimeEntity {
   @Column({ length: 255, unique: true })
-  email: string;
+  email!: string;
 
   @Column({ length: 255 })
-  password: string;
+  password!: string;
 
   @Column({ length: 100 })
-  name: string;
+  name!: string;
 
   @Column({ type: 'varchar', length: 20, default: AdminRole.MANAGER })
-  role: AdminRole;
+  role!: AdminRole;
 
   @Column({ type: 'varchar', length: 255, nullable: true })
-  hashedRefreshToken: string | null;
+  hashedRefreshToken!: string | null;
 }

--- a/libs/shared/src/entities/base.entity.ts
+++ b/libs/shared/src/entities/base.entity.ts
@@ -6,11 +6,11 @@ import {
 
 export abstract class BaseTimeEntity {
   @PrimaryGeneratedColumn()
-  id: number;
+  id!: number;
 
   @CreateDateColumn()
-  createdAt: Date;
+  createdAt!: Date;
 
   @UpdateDateColumn()
-  updatedAt: Date;
+  updatedAt!: Date;
 }

--- a/libs/shared/src/entities/oauth-account.entity.ts
+++ b/libs/shared/src/entities/oauth-account.entity.ts
@@ -10,21 +10,21 @@ import { BaseTimeEntity } from './base.entity';
 @Index('UQ_oauth_user_provider', ['userId', 'provider'], { unique: true })
 export class OAuthAccount extends BaseTimeEntity {
   @Column()
-  userId: number;
+  userId!: number;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn()
-  user: Relation<User>;
+  user!: Relation<User>;
 
   @Column({ length: 20 })
-  provider: string;
+  provider!: string;
 
   @Column({ length: 255 })
-  providerId: string;
+  providerId!: string;
 
   @Column({ length: 255 })
-  providerEmail: string;
+  providerEmail!: string;
 
   @Column({ type: 'boolean', default: false })
-  emailVerified: boolean;
+  emailVerified!: boolean;
 }

--- a/libs/shared/src/entities/post.entity.ts
+++ b/libs/shared/src/entities/post.entity.ts
@@ -20,25 +20,25 @@ import { BaseTimeEntity } from './base.entity';
 })
 export class Post extends BaseTimeEntity {
   @Column()
-  userId: number;
+  userId!: number;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn()
-  user: Relation<User>;
+  user!: Relation<User>;
 
   @Column({ length: 200 })
-  title: string;
+  title!: string;
 
   @Column({ type: 'text' })
-  content: string;
+  content!: string;
 
   @Column({ default: false })
-  isPublished: boolean;
+  isPublished!: boolean;
 
   @ManyToMany(() => Tag, (tag) => tag.posts)
   @JoinTable({ name: 'post_tags', synchronize: false })
-  tags: Relation<Tag[]>;
+  tags!: Relation<Tag[]>;
 
   @DeleteDateColumn()
-  deletedAt: Date | null;
+  deletedAt!: Date | null;
 }

--- a/libs/shared/src/entities/tag.entity.ts
+++ b/libs/shared/src/entities/tag.entity.ts
@@ -15,15 +15,15 @@ import { BaseTimeEntity } from './base.entity';
 @Index('UQ_tags_user_id_name', ['userId', 'name'], { unique: true })
 export class Tag extends BaseTimeEntity {
   @Column()
-  userId: number;
+  userId!: number;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn()
-  user: Relation<User>;
+  user!: Relation<User>;
 
   @Column({ length: 50 })
-  name: string;
+  name!: string;
 
   @ManyToMany(() => Post, (post) => post.tags)
-  posts: Relation<Post[]>;
+  posts!: Relation<Post[]>;
 }

--- a/libs/shared/src/entities/user.entity.ts
+++ b/libs/shared/src/entities/user.entity.ts
@@ -6,20 +6,20 @@ import { Post } from './post.entity';
 @Entity('users')
 export class User extends BaseTimeEntity {
   @Column({ length: 255, unique: true })
-  email: string;
+  email!: string;
 
   @Column({ length: 255 })
-  password: string;
+  password!: string;
 
   @Column({ length: 100 })
-  name: string;
+  name!: string;
 
   @Column({ type: 'varchar', length: 255, nullable: true })
-  hashedRefreshToken: string | null;
+  hashedRefreshToken!: string | null;
 
   @Column({ type: 'boolean', default: false })
-  marketingConsent: boolean;
+  marketingConsent!: boolean;
 
   @OneToMany(() => Post, (post) => post.user)
-  posts: Relation<Post[]>;
+  posts!: Relation<Post[]>;
 }

--- a/libs/shared/src/slack/slack.service.ts
+++ b/libs/shared/src/slack/slack.service.ts
@@ -105,7 +105,7 @@ export class SlackService {
       await this.client.chat.postMessage({ channel, text });
     } catch (error) {
       this.logger.error(
-        `Failed to send Slack notification to ${channel}: ${error instanceof Error ? error.message : error}`,
+        `Failed to send Slack notification to ${channel}: ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error.stack : undefined,
       );
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,10 +30,8 @@
         "apps/back-office/src/*"
       ]
     },
-    "strictNullChecks": true,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": true,
-    "strictBindCallApply": true,
     "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
> **Merge Strategy**: Create a merge commit을 사용해주세요.

## Summary

엄격성 강화 2단계 (1단계: #78). `tsconfig.json`을 `"strict": true`로 전환하고 잔여 위반 102건을 전부 해소한다. **이제 strict 위반은 advisory 경고가 아니라 CI에서 차단된다.**

위반 102건의 구성과 해소:

| 유형 | 건수 | 해소 |
| --- | --- | --- |
| TS2564 `strictPropertyInitialization` | 100건 / 26개 파일 | 필드에 `!` 단언 추가 (엔티티 6 + Response DTO 9 + Request DTO 8 + 타입 클래스 2 등) |
| TS2345 `strictFunctionTypes` | 2건 | spec의 ConfigService.get mock에 `as jest.Mock` 캐스팅 (기존 `bcrypt.hash` 캐스팅 선례와 동일) |
| (구현 중 발견) lint 1건 | 1건 | `useUnknownInCatchVariables`로 catch 변수가 `unknown`이 되며 `slack.service.ts` 템플릿 리터럴이 걸려 `String(error)`로 수정 |

## Notes

- **`!` 단언 선택 근거**: TypeORM 엔티티·class-transformer DTO는 프레임워크가 런타임에 값을 채우는 클래스라 생성자 초기화가 부자연스럽고, `!`는 생태계 표준이며 **타입 전용이라 런타임·빌드 산출물 무영향**이다. 기본값 있는 필드(`page = 1` 등)와 `?` 옵셔널은 손대지 않았다.
- **tsconfig 정리**: 개별 플래그 3개(`strictNullChecks`·`noImplicitAny`·`strictBindCallApply`)를 `"strict": true` 한 줄로 통합. strict 미포함인 `noFallthroughCasesInSwitch`는 유지.
- **CI 정리**: tsconfig가 strict면 본 체크(`tsc --noEmit`)가 곧 strict 체크라, 중복인 advisory(`continue-on-error`) 단계를 제거했다 — #78에서 "full strict 달성 후"로 미뤄둔 항목의 완결.
- 위반 분석·설계 결정은 `docs/typescript-full-strict-prd.md` 참고.

## Test plan

- [x] `npx tsc --noEmit` — strict 상태에서 에러 0건
- [x] `pnpm lint:check` / `pnpm format` 통과
- [x] `pnpm build:all` 양쪽 앱 빌드 성공 (SWC 산출물에 `!` 영향 없음)
- [x] `pnpm test` 185케이스 전체 통과 (수 불변)
- [x] `pnpm test:e2e` service 160 + back-office 34 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * TypeScript 타입 안정성 개선을 위한 코드베이스 전반적 업데이트
  * 타입 선언 방식을 표준화하여 컴파일 시 안정성 강화

* **Chores**
  * TypeScript 컴파일러 설정을 엄격 모드로 통일
  * CI/CD 워크플로우 최적화 및 정리
  * 테스트 코드의 타입 호환성 개선

* **Documentation**
  * TypeScript 엄격 모드 마이그레이션 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->